### PR TITLE
Security hardening: pin CI actions and add continuous scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
       - name: Run deterministic Hook, grader, and repository-policy tests

--- a/.github/workflows/plugin-security.yml
+++ b/.github/workflows/plugin-security.yml
@@ -13,6 +13,8 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Scan plugin
         uses: hashgraph-online/ai-plugin-scanner-action@6c4a64c217ac7884f2678b080b73eb80decf889e # v1
         with:

--- a/.github/workflows/plugin-security.yml
+++ b/.github/workflows/plugin-security.yml
@@ -1,0 +1,24 @@
+name: Plugin Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scan plugin
+        uses: hashgraph-online/ai-plugin-scanner-action@6c4a64c217ac7884f2678b080b73eb80decf889e # v1
+        with:
+          plugin_dir: "."
+          mode: "scan"
+          min_score: "80"
+          fail_on_severity: "high"
+          upload_sarif: "false"
+          pr_comment: "off"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do not disclose exploitable vulnerabilities, secrets, or proof-of-concept attack details in a public issue.
+
+If GitHub's private vulnerability reporting is available for this repository, use **Security → Report a vulnerability**. Otherwise, contact the maintainer through the repository owner's GitHub profile and ask for a private reporting channel without including sensitive details publicly.
+
+When reporting, include only what is needed to reproduce and assess the issue:
+
+- affected Click version or commit;
+- affected platform and Codex version;
+- the smallest reproducible sequence of actions;
+- expected versus observed security boundary;
+- whether the issue can execute commands, bypass approval, escape the approved boundary, expose secrets, or modify files unexpectedly.
+
+Please remove real credentials, personal data, and unrelated repository contents from reports.
+
+## Security-sensitive behavior
+
+Click intentionally uses lifecycle hooks and local command runners to enforce workflow boundaries. Security reports are especially useful for issues involving:
+
+- approval or contract bypass;
+- shell or command injection;
+- unsafe path traversal or writes outside the intended repository boundary;
+- secret exposure or unsafe environment handling;
+- verification commands that unexpectedly mutate protected source content;
+- GitHub Actions or dependency supply-chain risks.
+
+## Supported versions
+
+Security fixes are applied to the current release line. Users should upgrade to the latest published version before reporting an issue that may already have been fixed.


### PR DESCRIPTION
## Summary

This keeps the existing Codex marketplace format unchanged and applies only security improvements that materially reduce risk:

- pin existing GitHub Actions to immutable commit SHAs;
- add Dependabot updates for the GitHub Actions supply-chain surface;
- add a read-only, SHA-pinned plugin security scan on pull requests and main;
- add a responsible vulnerability reporting policy in `SECURITY.md`.

## Deliberately not changed

- `.agents/plugins/marketplace.json` remains on the current Codex `source: "url"` format rather than being rewritten solely to satisfy HOL's older local-source scanner rule.
- no cosmetic interface assets or score-only metadata were added.

## Security posture

The scanner workflow has only `contents: read`, does not upload SARIF, does not post PR comments, and fails on high-severity findings or a score below 80.
