### PR TITLE
Support safe read-only SSH inspection

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -169,12 +169,15 @@ Click은 코드를 건드리기 전에 다음과 같은 축약 계약을 제시�
 
 ### 구조화 capability
 
-각 capability는 프로토콜 버전 `1`을 사용하고 실행 파일과 모든 인자를 분리합니다. 승인된 argv 배열은 `shell=False`로 실행되므로 요청 안에 pipeline, redirection, command substitution, shell wrapper를 숨길 수 없습니다.
+각 capability는 프로토콜 버전 `1`을 사용하고 실행 파일과 모든 인자를 분리합니다. 승인된 로컬 argv 배열은 `shell=False`로 실행되므로 요청 안에 pipeline, redirection, command substitution, shell wrapper를 숨길 수 없습니다. 정형 SSH 요청에서도 로컬 `ssh` 프로세스는 `shell=False`로 시작합니다. 다만 OpenSSH가 원격 명령을 단일 문자열로 받기 때문에 Click은 검증된 원격 argv를 안전하게 인용해 그 문자열을 만듭니다. 원격 POSIX shell이 이 인용된 argv 표현을 파싱하므로 SSH 자체를 shell-free 원격 전송이라고 설명하지는 않습니다.
 
 ```text
 click-gate inspect '{"version":1,"commands":[["git","status","--short"],["sed","-n","1,160p","src/app.py"]]}'
+click-gate inspect '{"version":1,"commands":[["ssh","gx10-01","docker","ps","--format","{{.Names}}|{{.Image}}"]]}'
 click-gate mutate '{"version":1,"argv":["python3","scripts/generate.py","--target","src"]}'
 ```
+
+SSH 읽기 경로는 SSH 클라이언트 옵션이 없는 `ssh <대상> <원격 실행 파일> <인자...>` 형식만 의도적으로 허용합니다. 기존의 제한된 읽기 전용 명령에 더해 hostname 표시, `docker ps`, 승인된 `nvidia-smi` 조회 옵션, 읽기 전용 `systemctl` 하위 명령만 인식합니다. 불투명한 원격 명령 문자열, 중첩 SSH, shell 또는 `sudo` wrapper, 원격 변경 명령은 fail-closed로 거부합니다. 승인된 mutation과 verification runner도 원격 argv 리터럴을 보존하는 같은 준비 과정을 사용하지만, 인용 처리가 mutation을 읽기 전용으로 바꾸거나 계약·검증 예산을 우회하게 하지는 않습니다.
 
 `inspect`는 Hook이 허용한 제한된 읽기 전용 작업만 받습니다. `mutate`는 정확한 계약 승인이 있어야 하고 이전 근거를 오래된 것으로 표시합니다. `apply_patch`, `Edit`, `Write` 같은 명확한 편집 도구는 shell envelope 없이 그대로 지원합니다. 잘못된 요청과 shell interpreter는 fail-closed로 거부합니다. 정확한 schema와 적용 경계는 [capability protocol](skills/click/references/capability-protocol.md)에 있습니다.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -173,11 +173,11 @@ Click은 코드를 건드리기 전에 다음과 같은 축약 계약을 제시�
 
 ```text
 click-gate inspect '{"version":1,"commands":[["git","status","--short"],["sed","-n","1,160p","src/app.py"]]}'
-click-gate inspect '{"version":1,"commands":[["ssh","gx10-01","docker","ps","--format","{{.Names}}|{{.Image}}"]]}'
+click-gate inspect '{"version":1,"commands":[["ssh","example-host","docker","ps","--format","{{.Names}}|{{.Image}}"]]}'
 click-gate mutate '{"version":1,"argv":["python3","scripts/generate.py","--target","src"]}'
 ```
 
-SSH 읽기 경로는 SSH 클라이언트 옵션이 없는 `ssh <대상> <원격 실행 파일> <인자...>` 형식만 의도적으로 허용합니다. 기존의 제한된 읽기 전용 명령에 더해 hostname 표시, `docker ps`, 승인된 `nvidia-smi` 조회 옵션, 읽기 전용 `systemctl` 하위 명령만 인식합니다. 불투명한 원격 명령 문자열, 중첩 SSH, shell 또는 `sudo` wrapper, 원격 변경 명령은 fail-closed로 거부합니다. 승인된 mutation과 verification runner도 원격 argv 리터럴을 보존하는 같은 준비 과정을 사용하지만, 인용 처리가 mutation을 읽기 전용으로 바꾸거나 계약·검증 예산을 우회하게 하지는 않습니다.
+SSH 읽기 경로는 SSH 클라이언트 옵션이 없는 `ssh <대상> <원격 실행 파일> <인자...>` 형식만 의도적으로 허용합니다. 기존의 제한된 읽기 전용 명령에 더해 Git `merge-base`, 엄격하게 검증한 `git remote` 목록·`get-url` 형식, hostname 표시, `docker ps`, 승인된 `nvidia-smi` 조회 옵션, 읽기 전용 `systemctl` 하위 명령만 인식합니다. Git 원격 쓰기와 네트워크 작업, 불투명한 원격 명령 문자열, 중첩 SSH, shell 또는 `sudo` wrapper, 그 밖의 원격 변경 명령은 fail-closed로 거부합니다. 승인된 mutation과 verification runner도 원격 argv 리터럴을 보존하는 같은 준비 과정을 사용하지만, 인용 처리가 mutation을 읽기 전용으로 바꾸거나 계약·검증 예산을 우회하게 하지는 않습니다.
 
 `inspect`는 Hook이 허용한 제한된 읽기 전용 작업만 받습니다. `mutate`는 정확한 계약 승인이 있어야 하고 이전 근거를 오래된 것으로 표시합니다. `apply_patch`, `Edit`, `Write` 같은 명확한 편집 도구는 shell envelope 없이 그대로 지원합니다. 잘못된 요청과 shell interpreter는 fail-closed로 거부합니다. 정확한 schema와 적용 경계는 [capability protocol](skills/click/references/capability-protocol.md)에 있습니다.
 

--- a/README.md
+++ b/README.md
@@ -169,12 +169,15 @@ These are tool-level guardrails, not a reasoning-token cap or operating-system s
 
 ### Structured capabilities
 
-Each capability uses protocol version `1` and separates the executable from every argument. Accepted argv arrays run with `shell=False`, so pipelines, redirections, command substitutions, and shell wrappers cannot be hidden in the request.
+Each capability uses protocol version `1` and separates the executable from every argument. Accepted local argv arrays run with `shell=False`, so pipelines, redirections, command substitutions, and shell wrappers cannot be hidden in the request. For canonical SSH requests, Click still starts the local `ssh` process with `shell=False`, then safely quotes the validated remote argv into the single command string OpenSSH requires. A remote POSIX shell parses that quoted argv representation, so SSH is not described as a shell-free remote transport.
 
 ```text
 click-gate inspect '{"version":1,"commands":[["git","status","--short"],["sed","-n","1,160p","src/app.py"]]}'
+click-gate inspect '{"version":1,"commands":[["ssh","gx10-01","docker","ps","--format","{{.Names}}|{{.Image}}"]]}'
 click-gate mutate '{"version":1,"argv":["python3","scripts/generate.py","--target","src"]}'
 ```
+
+The SSH read path intentionally accepts only `ssh <target> <remote executable> <args...>` with no SSH client options. It recognizes the existing bounded read-only commands plus hostname display, `docker ps`, approved `nvidia-smi` query flags, and read-only `systemctl` subcommands. Opaque remote command strings, nested SSH, shell or `sudo` wrappers, and mutating remote commands fail closed. The same literal-preserving SSH argv preparation applies to approved mutation and verification runners; quoting never makes a mutation read-only or bypasses the contract and verification budget.
 
 `inspect` accepts only the Hook's bounded read-only operations. `mutate` requires the exact approved contract and marks prior evidence stale. Ordinary canonical edit tools such as `apply_patch`, `Edit`, and `Write` remain supported mutations without a shell envelope. Malformed requests and shell interpreters fail closed. See [the capability protocol](skills/click/references/capability-protocol.md) for the exact schemas and enforcement boundary.
 

--- a/README.md
+++ b/README.md
@@ -173,11 +173,11 @@ Each capability uses protocol version `1` and separates the executable from ever
 
 ```text
 click-gate inspect '{"version":1,"commands":[["git","status","--short"],["sed","-n","1,160p","src/app.py"]]}'
-click-gate inspect '{"version":1,"commands":[["ssh","gx10-01","docker","ps","--format","{{.Names}}|{{.Image}}"]]}'
+click-gate inspect '{"version":1,"commands":[["ssh","example-host","docker","ps","--format","{{.Names}}|{{.Image}}"]]}'
 click-gate mutate '{"version":1,"argv":["python3","scripts/generate.py","--target","src"]}'
 ```
 
-The SSH read path intentionally accepts only `ssh <target> <remote executable> <args...>` with no SSH client options. It recognizes the existing bounded read-only commands plus hostname display, `docker ps`, approved `nvidia-smi` query flags, and read-only `systemctl` subcommands. Opaque remote command strings, nested SSH, shell or `sudo` wrappers, and mutating remote commands fail closed. The same literal-preserving SSH argv preparation applies to approved mutation and verification runners; quoting never makes a mutation read-only or bypasses the contract and verification budget.
+The SSH read path intentionally accepts only `ssh <target> <remote executable> <args...>` with no SSH client options. It recognizes the existing bounded read-only commands plus Git `merge-base`, narrowly validated `git remote` listing and `get-url` forms, hostname display, `docker ps`, approved `nvidia-smi` query flags, and read-only `systemctl` subcommands. Git remote writes and network operations, opaque remote command strings, nested SSH, shell or `sudo` wrappers, and other mutating remote commands fail closed. The same literal-preserving SSH argv preparation applies to approved mutation and verification runners; quoting never makes a mutation read-only or bypasses the contract and verification budget.
 
 `inspect` accepts only the Hook's bounded read-only operations. `mutate` requires the exact approved contract and marks prior evidence stale. Ordinary canonical edit tools such as `apply_patch`, `Edit`, and `Write` remain supported mutations without a shell envelope. Malformed requests and shell interpreters fail closed. See [the capability protocol](skills/click/references/capability-protocol.md) for the exact schemas and enforcement boundary.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -173,11 +173,11 @@ flowchart TB
 
 ```text
 click-gate inspect '{"version":1,"commands":[["git","status","--short"],["sed","-n","1,160p","src/app.py"]]}'
-click-gate inspect '{"version":1,"commands":[["ssh","gx10-01","docker","ps","--format","{{.Names}}|{{.Image}}"]]}'
+click-gate inspect '{"version":1,"commands":[["ssh","example-host","docker","ps","--format","{{.Names}}|{{.Image}}"]]}'
 click-gate mutate '{"version":1,"argv":["python3","scripts/generate.py","--target","src"]}'
 ```
 
-SSH 读取路径有意只接受不带 SSH 客户端选项的 `ssh <目标> <远程可执行程序> <参数...>` 形式。除了现有限定的只读命令，它只识别主机名显示、`docker ps`、获准的 `nvidia-smi` 查询参数以及只读 `systemctl` 子命令。不透明的远程命令字符串、嵌套 SSH、shell 或 `sudo` wrapper，以及会修改远程状态的命令都会 fail closed。获准的 mutation 和 verification runner 也使用同一套保留远程 argv 字面值的准备过程；引用处理不会把 mutation 变成只读操作，也不会绕过契约或验证预算。
+SSH 读取路径有意只接受不带 SSH 客户端选项的 `ssh <目标> <远程可执行程序> <参数...>` 形式。除了现有限定的只读命令，它只识别 Git `merge-base`、经过严格验证的 `git remote` 列表和 `get-url` 形式、主机名显示、`docker ps`、获准的 `nvidia-smi` 查询参数以及只读 `systemctl` 子命令。Git 远程写入和网络操作、不透明的远程命令字符串、嵌套 SSH、shell 或 `sudo` wrapper，以及其他会修改远程状态的命令都会 fail closed。获准的 mutation 和 verification runner 也使用同一套保留远程 argv 字面值的准备过程；引用处理不会把 mutation 变成只读操作，也不会绕过契约或验证预算。
 
 `inspect` 只接受 Hook 限定的只读操作。`mutate` 要求提供完全相同的已批准契约，并把先前证据标记为 stale。`apply_patch`、`Edit` 和 `Write` 等普通标准编辑工具仍可作为 mutation 使用，不需要 shell envelope。格式错误的请求和 shell interpreter 会 fail closed。精确 schema 和执行边界请参阅[能力协议](skills/click/references/capability-protocol.md)。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -169,12 +169,15 @@ flowchart TB
 
 ### 结构化能力
 
-每项 capability 都使用协议版本 `1`，并将可执行程序与每个参数分离。获准的 argv 数组会以 `shell=False` 运行，因此无法在请求中隐藏 pipeline、redirection、命令替换或 shell wrapper。
+每项 capability 都使用协议版本 `1`，并将可执行程序与每个参数分离。获准的本地 argv 数组会以 `shell=False` 运行，因此无法在请求中隐藏 pipeline、redirection、命令替换或 shell wrapper。对于规范化的 SSH 请求，Click 仍以 `shell=False` 启动本地 `ssh` 进程，然后把已验证的远程 argv 安全引用为 OpenSSH 所需的单个命令字符串。远程 POSIX shell 会解析这个经过引用的 argv 表达，因此 SSH 并不被描述为无 shell 的远程传输。
 
 ```text
 click-gate inspect '{"version":1,"commands":[["git","status","--short"],["sed","-n","1,160p","src/app.py"]]}'
+click-gate inspect '{"version":1,"commands":[["ssh","gx10-01","docker","ps","--format","{{.Names}}|{{.Image}}"]]}'
 click-gate mutate '{"version":1,"argv":["python3","scripts/generate.py","--target","src"]}'
 ```
+
+SSH 读取路径有意只接受不带 SSH 客户端选项的 `ssh <目标> <远程可执行程序> <参数...>` 形式。除了现有限定的只读命令，它只识别主机名显示、`docker ps`、获准的 `nvidia-smi` 查询参数以及只读 `systemctl` 子命令。不透明的远程命令字符串、嵌套 SSH、shell 或 `sudo` wrapper，以及会修改远程状态的命令都会 fail closed。获准的 mutation 和 verification runner 也使用同一套保留远程 argv 字面值的准备过程；引用处理不会把 mutation 变成只读操作，也不会绕过契约或验证预算。
 
 `inspect` 只接受 Hook 限定的只读操作。`mutate` 要求提供完全相同的已批准契约，并把先前证据标记为 stale。`apply_patch`、`Edit` 和 `Write` 等普通标准编辑工具仍可作为 mutation 使用，不需要 shell envelope。格式错误的请求和 shell interpreter 会 fail closed。精确 schema 和执行边界请参阅[能力协议](skills/click/references/capability-protocol.md)。
 

--- a/hooks/click_gate.py
+++ b/hooks/click_gate.py
@@ -218,7 +218,9 @@ READ_ONLY_GIT_SUBCOMMANDS = {
     "log",
     "ls-files",
     "ls-tree",
+    "merge-base",
     "name-rev",
+    "remote",
     "rev-parse",
     "show",
     "status",
@@ -1027,7 +1029,7 @@ def _control_request(command: str) -> tuple[str | None, str, str]:
     )
 
 
-def _git_subcommand(tokens: list[str]) -> str:
+def _git_subcommand_index(tokens: list[str]) -> int | None:
     index = 1
     while index < len(tokens):
         token = tokens[index]
@@ -1040,8 +1042,34 @@ def _git_subcommand(tokens: list[str]) -> str:
         if token.startswith("-"):
             index += 1
             continue
-        return token
-    return ""
+        return index
+    return None
+
+
+def _git_subcommand(tokens: list[str]) -> str:
+    index = _git_subcommand_index(tokens)
+    return tokens[index] if index is not None else ""
+
+
+def _is_read_only_git_remote(tokens: list[str]) -> bool:
+    index = _git_subcommand_index(tokens)
+    if index is None or tokens[index] != "remote":
+        return False
+
+    arguments = tokens[index + 1 :]
+    if not arguments or arguments in (["-v"], ["--verbose"]):
+        return True
+    if arguments[0] != "get-url" or len(arguments) < 2:
+        return False
+
+    options = arguments[1:-1]
+    remote_name = arguments[-1]
+    return (
+        bool(remote_name)
+        and not remote_name.startswith("-")
+        and len(options) == len(set(options))
+        and all(option in {"--all", "--push"} for option in options)
+    )
 
 
 def _shell_segments(command: str) -> list[list[str]] | None:
@@ -1361,15 +1389,16 @@ def _is_broad_exploration_tokens(tokens: list[str]) -> bool:
         targets = _positional_arguments(arguments)
         return _targets_repository_root(targets)
     if executable == "git":
-        subcommand = _git_subcommand(tokens)
+        index = _git_subcommand_index(tokens)
+        if index is None:
+            return False
+        subcommand = tokens[index]
         if subcommand == "ls-files":
-            index = tokens.index(subcommand)
             targets = _positional_arguments(
                 [item.lower() for item in tokens[index + 1 :]]
             )
             return _targets_repository_root(targets)
         if subcommand == "ls-tree":
-            index = tokens.index(subcommand)
             remainder = [item.lower() for item in tokens[index + 1 :]]
             if "--" not in remainder:
                 return True
@@ -1784,7 +1813,10 @@ def _is_local_read_only_tokens(tokens: list[str]) -> bool:
 
     executable = Path(tokens[0]).name.lower()
     if executable == "git":
-        if _git_subcommand(tokens) not in READ_ONLY_GIT_SUBCOMMANDS:
+        subcommand = _git_subcommand(tokens)
+        if subcommand not in READ_ONLY_GIT_SUBCOMMANDS:
+            return False
+        if subcommand == "remote" and not _is_read_only_git_remote(tokens):
             return False
         return not any(
             token in {"--ext-diff", "--textconv"}

--- a/hooks/click_gate.py
+++ b/hooks/click_gate.py
@@ -224,6 +224,39 @@ READ_ONLY_GIT_SUBCOMMANDS = {
     "status",
 }
 
+READ_ONLY_REMOTE_COMMANDS = {
+    "hostname",
+}
+READ_ONLY_SYSTEMCTL_SUBCOMMANDS = {
+    "is-active",
+    "is-enabled",
+    "list-unit-files",
+    "list-units",
+    "show",
+    "status",
+}
+READ_ONLY_HOSTNAME_OPTIONS = {
+    "-d",
+    "-f",
+    "-i",
+    "-I",
+    "-s",
+    "--all-ip-addresses",
+    "--domain",
+    "--fqdn",
+    "--help",
+    "--ip-address",
+    "--short",
+    "--version",
+}
+READ_ONLY_NVIDIA_SMI_OPTIONS = {
+    "-L",
+    "-q",
+    "--help",
+    "--list-gpus",
+    "--query",
+}
+
 SHELL_CONTROL_PUNCTUATION = set("();<>|&")
 SED_READ_SCRIPT = re.compile(
     r"^\s*(?:\d+|\$)(?:\s*,\s*(?:\d+|\$))?\s*[pq]\s*$"
@@ -244,6 +277,8 @@ RG_OPTIONS_WITH_VALUES = {
     "--type-not",
 }
 ENVIRONMENT_ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+SSH_TARGET = re.compile(r"^[A-Za-z0-9_.-]+(?:@[A-Za-z0-9_.-]+)?$")
+SSH_REMOTE_EXECUTABLE = re.compile(r"^[A-Za-z0-9_./+-]+$")
 
 
 def _emit(payload: dict[str, Any]) -> None:
@@ -1699,7 +1734,49 @@ def _get_content_paths(tokens: list[str]) -> list[str] | None:
     return paths or None
 
 
-def _is_read_only_tokens(tokens: list[str]) -> bool:
+def _structured_ssh_parts(tokens: list[str]) -> tuple[str, list[str]] | None:
+    if len(tokens) < 3 or Path(tokens[0]).name.lower() != "ssh":
+        return None
+    target = tokens[1]
+    remote_argv = tokens[2:]
+    if target.startswith("-") or not SSH_TARGET.fullmatch(target):
+        return None
+    remote_executable = remote_argv[0]
+    if remote_executable.startswith("-") or not SSH_REMOTE_EXECUTABLE.fullmatch(
+        remote_executable
+    ):
+        return None
+    return target, remote_argv
+
+
+def _is_read_only_nvidia_smi(tokens: list[str]) -> bool:
+    for token in tokens[1:]:
+        if token in READ_ONLY_NVIDIA_SMI_OPTIONS:
+            continue
+        if token.startswith(
+            ("--format=", "--query-compute-apps=", "--query-gpu=")
+        ):
+            continue
+        return False
+    return True
+
+
+def _is_read_only_remote_tokens(tokens: list[str]) -> bool:
+    executable = Path(tokens[0]).name.lower()
+    if executable in READ_ONLY_REMOTE_COMMANDS:
+        return len(tokens) == 1 or all(
+            token in READ_ONLY_HOSTNAME_OPTIONS for token in tokens[1:]
+        )
+    if executable == "docker":
+        return len(tokens) >= 2 and tokens[1] == "ps"
+    if executable == "nvidia-smi":
+        return _is_read_only_nvidia_smi(tokens)
+    if executable == "systemctl":
+        return len(tokens) >= 2 and tokens[1] in READ_ONLY_SYSTEMCTL_SUBCOMMANDS
+    return _is_local_read_only_tokens(tokens)
+
+
+def _is_local_read_only_tokens(tokens: list[str]) -> bool:
     if not tokens:
         return False
     if ENVIRONMENT_ASSIGNMENT.match(tokens[0]):
@@ -1755,6 +1832,15 @@ def _is_read_only_tokens(tokens: list[str]) -> bool:
     ):
         return False
     return True
+
+
+def _is_read_only_tokens(tokens: list[str]) -> bool:
+    if not tokens:
+        return False
+    if Path(tokens[0]).name.lower() == "ssh":
+        parts = _structured_ssh_parts(tokens)
+        return parts is not None and _is_read_only_remote_tokens(parts[1])
+    return _is_local_read_only_tokens(tokens)
 
 
 def _is_read_only_bash(command: str) -> bool:
@@ -2343,6 +2429,14 @@ def _decode_encoded_request(encoded: str, label: str) -> tuple[str, str]:
         return "", f"Click {label} runner received an invalid request."
 
 
+def _execution_argv(argv: list[str]) -> list[str]:
+    parts = _structured_ssh_parts(argv)
+    if parts is None:
+        return argv
+    target, remote_argv = parts
+    return [argv[0], target, shlex.join(remote_argv)]
+
+
 def _execute_argv_commands(
     commands: list[list[str]], stdout_file: Any | None = None, stderr_file: Any | None = None
 ) -> int:
@@ -2350,7 +2444,7 @@ def _execute_argv_commands(
     for argv in commands:
         try:
             result = subprocess.run(
-                argv,
+                _execution_argv(argv),
                 stdout=stdout_file,
                 stderr=stderr_file,
                 check=False,

--- a/skills/click/references/capability-protocol.md
+++ b/skills/click/references/capability-protocol.md
@@ -8,12 +8,12 @@ Use before approval for an ambiguous but read-only command, and during approved 
 
 ```text
 click-gate inspect '{"version":1,"commands":[["git","status","--short"],["sed","-n","1,160p","src/app.py"]]}'
-click-gate inspect '{"version":1,"commands":[["ssh","gx10-01","docker","ps","--format","{{.Names}}|{{.Image}}"]]}'
+click-gate inspect '{"version":1,"commands":[["ssh","example-host","docker","ps","--format","{{.Names}}|{{.Image}}"]]}'
 ```
 
 Every command must match the Hook's read-only argv policy. One request may contain up to eight commands, which run serially and stop on the first failure. The Hook rejects shell interpreters and write-capable options. In active review and implementation it stores only a request digest and result metadata, applies the existing output cap and retry policy, and detects repository-wide inventory from the validated argv.
 
-The SSH inspection form is deliberately narrow: `ssh <target> <remote executable> <args...>`, with no SSH client options. It reuses Click's bounded local read-only policy and adds hostname display, `docker ps`, approved `nvidia-smi` query flags, and read-only `systemctl` subcommands. Opaque remote command strings, nested SSH, shell or `sudo` wrappers, and mutating remote commands are rejected. Structured mutation and verification runners use the same literal-preserving preparation, but only the allowlisted remote reads qualify as inspection or read-only verification.
+The SSH inspection form is deliberately narrow: `ssh <target> <remote executable> <args...>`, with no SSH client options. It reuses Click's bounded local read-only policy and adds Git `merge-base`, only `git remote`, `git remote -v|--verbose`, and `git remote get-url [--all] [--push] <name>`, hostname display, `docker ps`, approved `nvidia-smi` query flags, and read-only `systemctl` subcommands. Git remote writes and network operations, opaque remote command strings, nested SSH, shell or `sudo` wrappers, and other mutating remote commands are rejected. Structured mutation and verification runners use the same literal-preserving preparation, but only the allowlisted remote reads qualify as inspection or read-only verification.
 
 Recognized simple Bash reads remain compatible: the Hook converts safe direct syntax into the same internal argv request. It accepts direct `&&` sequencing only when every segment is independently read-only; it rejects pipelines and other shell control because their behavior is not represented by the protocol. Use explicit `inspect` whenever a legitimate read is not recognized.
 

--- a/skills/click/references/capability-protocol.md
+++ b/skills/click/references/capability-protocol.md
@@ -1,6 +1,6 @@
 # Structured Capability Protocol
 
-Use protocol version `1` whenever Click routes inspection, implementation commands, or final verification through Bash. Every executable and argument is a separate JSON string. The Hook executes accepted argv arrays with `shell=False`; never hide a shell, pipeline, redirect, command substitution, or background job inside an entry.
+Use protocol version `1` whenever Click routes inspection, implementation commands, or final verification through Bash. Every executable and argument is a separate JSON string. The Hook executes accepted local argv arrays with `shell=False`; never hide a shell, pipeline, redirect, command substitution, or background job inside an entry. Canonical SSH requests still start the local `ssh` process with `shell=False`, but OpenSSH requires one remote command string. Click constructs it by POSIX-quoting each validated remote argv item, and the remote POSIX shell parses that quoted representation.
 
 ## Inspection
 
@@ -8,9 +8,12 @@ Use before approval for an ambiguous but read-only command, and during approved 
 
 ```text
 click-gate inspect '{"version":1,"commands":[["git","status","--short"],["sed","-n","1,160p","src/app.py"]]}'
+click-gate inspect '{"version":1,"commands":[["ssh","gx10-01","docker","ps","--format","{{.Names}}|{{.Image}}"]]}'
 ```
 
 Every command must match the Hook's read-only argv policy. One request may contain up to eight commands, which run serially and stop on the first failure. The Hook rejects shell interpreters and write-capable options. In active review and implementation it stores only a request digest and result metadata, applies the existing output cap and retry policy, and detects repository-wide inventory from the validated argv.
+
+The SSH inspection form is deliberately narrow: `ssh <target> <remote executable> <args...>`, with no SSH client options. It reuses Click's bounded local read-only policy and adds hostname display, `docker ps`, approved `nvidia-smi` query flags, and read-only `systemctl` subcommands. Opaque remote command strings, nested SSH, shell or `sudo` wrappers, and mutating remote commands are rejected. Structured mutation and verification runners use the same literal-preserving preparation, but only the allowlisted remote reads qualify as inspection or read-only verification.
 
 Recognized simple Bash reads remain compatible: the Hook converts safe direct syntax into the same internal argv request. It accepts direct `&&` sequencing only when every segment is independently read-only; it rejects pipelines and other shell control because their behavior is not represented by the protocol. Use explicit `inspect` whenever a legitimate read is not recognized.
 

--- a/tests/test_click_gate.py
+++ b/tests/test_click_gate.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 
 SCRIPT = Path(
@@ -407,6 +408,137 @@ class ClickGateTests(unittest.TestCase):
                 self.assertEqual(
                     denied["hookSpecificOutput"]["permissionDecision"], "deny"
                 )
+
+    def test_structured_ssh_inspection_accepts_only_bounded_remote_reads(self) -> None:
+        allowed = (
+            ["ssh", "example-host", "hostname"],
+            ["ssh", "user@example-host", "cat", "/etc/os-release"],
+            [
+                "ssh",
+                "example-host",
+                "docker",
+                "ps",
+                "--format",
+                "{{.Names}}|{{.Image}}",
+            ],
+            [
+                "ssh",
+                "example-host",
+                "nvidia-smi",
+                "--query-gpu=name,uuid",
+                "--format=csv,noheader",
+            ],
+            ["ssh", "example-host", "systemctl", "is-active", "docker"],
+        )
+        denied = (
+            ["ssh", "-o", "ProxyCommand=helper", "example-host", "hostname"],
+            ["ssh", "example-host", "docker ps"],
+            ["ssh", "example-host", "sudo", "-n", "true"],
+            ["ssh", "example-host", "bash", "-c", "hostname"],
+            ["ssh", "example-host", "ssh", "other-host", "hostname"],
+            ["ssh", "example-host", "docker", "stop", "service"],
+            ["ssh", "example-host", "docker", "exec", "service", "true"],
+            ["ssh", "example-host", "systemctl", "restart", "service"],
+            ["ssh", "example-host", "nvidia-smi", "-pl", "100"],
+            ["ssh", "example-host", "hostname", "replacement"],
+        )
+
+        for argv in allowed:
+            with self.subTest(allowed=argv):
+                self.assertTrue(CLICK_GATE._is_read_only_tokens(argv))
+        for argv in denied:
+            with self.subTest(denied=argv):
+                self.assertFalse(CLICK_GATE._is_read_only_tokens(argv))
+                payload = self.inspect_gate([argv])
+                self.assertEqual(
+                    payload["hookSpecificOutput"]["permissionDecision"], "deny"
+                )
+
+    def test_direct_structured_ssh_read_becomes_an_observation(self) -> None:
+        self.approve_contract()
+        command = (
+            "ssh example-host docker ps --format "
+            "'{{.Names}}|{{.Image}}'"
+        )
+        request, broad, error = CLICK_GATE._inspection_request_from_bash(command)
+        self.assertEqual(error, "")
+        self.assertFalse(broad)
+        self.assertEqual(
+            request,
+            {
+                "version": 1,
+                "commands": [
+                    [
+                        "ssh",
+                        "example-host",
+                        "docker",
+                        "ps",
+                        "--format",
+                        "{{.Names}}|{{.Image}}",
+                    ]
+                ],
+            },
+        )
+        payload = self.pre_tool("Bash", command, "turn-2")
+        rewritten = payload["hookSpecificOutput"]["updatedInput"]["command"]
+        self.assertIn("run-observation", rewritten)
+
+        piped = self.pre_tool(
+            "Bash",
+            "ssh example-host docker ps --format {{.Names}}|{{.Image}}",
+            "turn-2",
+        )
+        self.assertEqual(
+            piped["hookSpecificOutput"]["permissionDecision"], "deny"
+        )
+
+    def test_structured_ssh_execution_preserves_remote_argv_literals(self) -> None:
+        remote_argv = [
+            "docker",
+            "ps",
+            "--format",
+            "{{.Names}}|{{.Image}}",
+            "--filter",
+            "label=owner's service",
+        ]
+        argv = ["ssh", "example-host", *remote_argv]
+        prepared = CLICK_GATE._execution_argv(argv)
+        self.assertEqual(prepared[:2], ["ssh", "example-host"])
+        self.assertEqual(shlex.split(prepared[2], posix=True), remote_argv)
+
+        with mock.patch.object(CLICK_GATE.subprocess, "run") as run:
+            run.return_value.returncode = 0
+            self.assertEqual(CLICK_GATE._execute_argv_commands([argv]), 0)
+        self.assertEqual(run.call_args.args[0], prepared)
+        self.assertFalse(run.call_args.kwargs["check"])
+
+    def test_structured_ssh_execution_keeps_mutations_explicit(self) -> None:
+        remote_argv = ["python3", "tool.py", "--value", "literal|value"]
+        prepared = CLICK_GATE._execution_argv(
+            ["ssh", "example-host", *remote_argv]
+        )
+        self.assertEqual(shlex.split(prepared[2], posix=True), remote_argv)
+        self.assertFalse(
+            CLICK_GATE._is_read_only_tokens(
+                ["ssh", "example-host", *remote_argv]
+            )
+        )
+
+        unsupported = ["ssh", "-p", "2222", "example-host", "hostname"]
+        self.assertEqual(CLICK_GATE._execution_argv(unsupported), unsupported)
+
+    def test_structured_ssh_read_is_valid_targeted_verification(self) -> None:
+        self.approve_contract()
+        payload = self.verify_checks(
+            [
+                {
+                    "argv": ["ssh", "example-host", "hostname"],
+                    "class": "targeted",
+                }
+            ]
+        )
+        output = payload["hookSpecificOutput"]
+        self.assertEqual(output["permissionDecision"], "allow")
 
     def test_structured_inspection_emulates_get_content_cross_platform(self) -> None:
         (self.workspace / "native.txt").write_text(

--- a/tests/test_click_gate.py
+++ b/tests/test_click_gate.py
@@ -429,6 +429,27 @@ class ClickGateTests(unittest.TestCase):
                 "--format=csv,noheader",
             ],
             ["ssh", "example-host", "systemctl", "is-active", "docker"],
+            [
+                "ssh",
+                "example-host",
+                "git",
+                "-C",
+                "/srv/project",
+                "merge-base",
+                "HEAD",
+                "origin/main",
+            ],
+            ["ssh", "example-host", "git", "remote"],
+            ["ssh", "example-host", "git", "remote", "-v"],
+            [
+                "ssh",
+                "example-host",
+                "git",
+                "remote",
+                "get-url",
+                "--all",
+                "origin",
+            ],
         )
         denied = (
             ["ssh", "-o", "ProxyCommand=helper", "example-host", "hostname"],
@@ -441,6 +462,35 @@ class ClickGateTests(unittest.TestCase):
             ["ssh", "example-host", "systemctl", "restart", "service"],
             ["ssh", "example-host", "nvidia-smi", "-pl", "100"],
             ["ssh", "example-host", "hostname", "replacement"],
+            ["ssh", "example-host", "git", "fetch", "origin"],
+            [
+                "ssh",
+                "example-host",
+                "git",
+                "remote",
+                "add",
+                "backup",
+                "url",
+            ],
+            [
+                "ssh",
+                "example-host",
+                "git",
+                "remote",
+                "set-url",
+                "origin",
+                "url",
+            ],
+            ["ssh", "example-host", "git", "remote", "get-url"],
+            [
+                "ssh",
+                "example-host",
+                "git",
+                "remote",
+                "get-url",
+                "origin",
+                "extra",
+            ],
         )
 
         for argv in allowed:
@@ -453,6 +503,42 @@ class ClickGateTests(unittest.TestCase):
                 self.assertEqual(
                     payload["hookSpecificOutput"]["permissionDecision"], "deny"
                 )
+
+    def test_git_remote_read_policy_is_narrow_for_local_and_ssh(self) -> None:
+        allowed_arguments = (
+            ["remote"],
+            ["remote", "-v"],
+            ["remote", "--verbose"],
+            ["remote", "get-url", "origin"],
+            ["remote", "get-url", "--push", "origin"],
+            ["remote", "get-url", "--all", "--push", "origin"],
+        )
+        denied_arguments = (
+            ["remote", "show", "origin"],
+            ["remote", "add", "backup", "url"],
+            ["remote", "remove", "origin"],
+            ["remote", "rename", "origin", "upstream"],
+            ["remote", "set-url", "origin", "url"],
+            ["remote", "update"],
+            ["remote", "prune", "origin"],
+            ["remote", "get-url"],
+            ["remote", "get-url", "--all"],
+            ["remote", "get-url", "--all", "--all", "origin"],
+            ["remote", "get-url", "origin", "--push"],
+        )
+
+        for arguments in allowed_arguments:
+            with self.subTest(allowed=arguments):
+                local = ["git", "-C", "/srv/project", *arguments]
+                remote = ["ssh", "example-host", *local]
+                self.assertTrue(CLICK_GATE._is_read_only_tokens(local))
+                self.assertTrue(CLICK_GATE._is_read_only_tokens(remote))
+        for arguments in denied_arguments:
+            with self.subTest(denied=arguments):
+                local = ["git", "-C", "/srv/project", *arguments]
+                remote = ["ssh", "example-host", *local]
+                self.assertFalse(CLICK_GATE._is_read_only_tokens(local))
+                self.assertFalse(CLICK_GATE._is_read_only_tokens(remote))
 
     def test_direct_structured_ssh_read_becomes_an_observation(self) -> None:
         self.approve_contract()


### PR DESCRIPTION
Hello. Click safely treats SSH as potentially mutating, but this also prevented remote reads such as `git status`, HEAD, remote URLs, and merge-base checks needed to prepare an accurate approval contract. As a result, even safe reads had to be approved as changes and executed through the `mutate` path, or the contract had to be written from assumptions and verified only after approval. This mixed evidence collection with mutation and created unnecessary approval cycles.

This change preserves the existing safety model and reuses Click's local read policy while allowing only the structured form `ssh <target> <executable> <args...>` for bounded reads. SSH options, opaque remote command strings, shell or sudo wrappers, `git fetch`, and remote mutations remain blocked before SSH starts. Validated remote arguments are safely quoted with `shlex.join()`.

Validation results:

- All 135 tests passed
- GitHub Actions CI passed on Ubuntu, macOS, and Windows
- The plugin security scan passed
- Four live Ubuntu reads succeeded in a fresh Codex session
- Five unsafe requests were blocked before SSH execution
- No remote state was changed

Thank you for reviewing this.