### PR TITLE
Support safe read-only SSH Git inspection

### DIFF
--- a/hooks/click_gate.py
+++ b/hooks/click_gate.py
@@ -26,6 +26,7 @@ import sys
 import tempfile
 import time
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 
 CONTROL_COMMAND = "click-gate"
@@ -217,7 +218,9 @@ READ_ONLY_GIT_SUBCOMMANDS = {
     "log",
     "ls-files",
     "ls-tree",
+    "merge-base",
     "name-rev",
+    "remote",
     "rev-parse",
     "show",
     "status",
@@ -264,7 +267,9 @@ GIT_READ_ONLY_EXACT_OPTIONS = {
         "-d", "-r", "-t", "-l", "--long", "-z", "--name-only", "--name-status",
         "--object-only", "--full-name", "--full-tree",
     },
+    "merge-base": {"--all", "--octopus", "--independent", "--is-ancestor", "--fork-point"},
     "name-rev": {"--tags", "--all", "--stdin", "--name-only", "--no-undefined", "--always"},
+    "remote": {"--all", "--push"},
     "rev-parse": {
         "--verify", "--short", "--abbrev-ref", "--symbolic-full-name", "--show-toplevel",
         "--show-prefix", "--show-cdup", "--git-dir", "--is-inside-work-tree",
@@ -337,6 +342,9 @@ RG_OPTIONS_WITH_VALUES = {
     "--type-not",
 }
 ENVIRONMENT_ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+SSH_TARGET = re.compile(r"^[A-Za-z0-9_.-]+(?:@[A-Za-z0-9_.-]+)?$")
+SSH_READ_ONLY_GIT_SUBCOMMANDS = {"merge-base", "remote", "rev-parse", "status"}
+GIT_REMOTE_NAME = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 
 def _emit(payload: dict[str, Any]) -> None:
@@ -1155,6 +1163,20 @@ def _git_option_allowed(subcommand: str, token: str) -> bool:
     return False
 
 
+def _is_read_only_git_remote_arguments(arguments: list[str]) -> bool:
+    if not arguments or arguments[0] != "get-url":
+        return False
+    remote_names = [
+        argument
+        for argument in arguments[1:]
+        if argument not in {"--", "--all", "--push"}
+    ]
+    return (
+        len(remote_names) == 1
+        and GIT_REMOTE_NAME.fullmatch(remote_names[0]) is not None
+    )
+
+
 def _parse_read_only_git_tokens(
     tokens: list[str],
 ) -> tuple[list[str], str, list[str]] | None:
@@ -1202,6 +1224,8 @@ def _parse_read_only_git_tokens(
             continue
         if argument.startswith("-") and not _git_option_allowed(subcommand, argument):
             return None
+    if subcommand == "remote" and not _is_read_only_git_remote_arguments(arguments):
+        return None
     return global_arguments, subcommand, arguments
 
 
@@ -1932,7 +1956,30 @@ def _get_content_paths(tokens: list[str]) -> list[str] | None:
     return paths or None
 
 
-def _is_read_only_tokens(tokens: list[str]) -> bool:
+def _structured_ssh_parts(tokens: list[str]) -> tuple[str, list[str]] | None:
+    if len(tokens) < 4 or Path(tokens[0]).name.lower() != "ssh":
+        return None
+    target = tokens[1]
+    remote_argv = tokens[2:]
+    if target.startswith("-") or not SSH_TARGET.fullmatch(target):
+        return None
+    if remote_argv[0] != "git":
+        return None
+    parsed = _parse_read_only_git_tokens(remote_argv)
+    if parsed is None or parsed[1] not in SSH_READ_ONLY_GIT_SUBCOMMANDS:
+        return None
+    if parsed[1] == "rev-parse":
+        positional = [
+            argument
+            for argument in parsed[2]
+            if argument != "--" and not argument.startswith("-")
+        ]
+        if positional != ["HEAD"]:
+            return None
+    return target, remote_argv
+
+
+def _is_local_read_only_tokens(tokens: list[str]) -> bool:
     if not tokens:
         return False
     if ENVIRONMENT_ASSIGNMENT.match(tokens[0]):
@@ -1981,6 +2028,14 @@ def _is_read_only_tokens(tokens: list[str]) -> bool:
     ):
         return False
     return True
+
+
+def _is_read_only_tokens(tokens: list[str]) -> bool:
+    if not tokens:
+        return False
+    if Path(tokens[0]).name.lower() == "ssh":
+        return _structured_ssh_parts(tokens) is not None
+    return _is_local_read_only_tokens(tokens)
 
 
 def _is_read_only_bash(command: str) -> bool:
@@ -2598,18 +2653,88 @@ def _decode_encoded_request(encoded: str, label: str) -> tuple[str, str]:
         return "", f"Click {label} runner received an invalid request."
 
 
+def _execution_argv(argv: list[str]) -> list[str]:
+    parts = _structured_ssh_parts(argv)
+    if parts is None:
+        return argv
+    target, remote_argv = parts
+    safe_git_argv, error = _build_read_only_git_argv(remote_argv)
+    if error or safe_git_argv is None:
+        return argv
+    return [
+        argv[0],
+        "-F",
+        "none",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ClearAllForwardings=yes",
+        "-o",
+        "ForwardAgent=no",
+        "-o",
+        "PermitLocalCommand=no",
+        "-o",
+        "RemoteCommand=none",
+        "-o",
+        "RequestTTY=no",
+        target,
+        shlex.join(safe_git_argv),
+    ]
+
+
+def _is_git_remote_output_request(argv: list[str]) -> bool:
+    parts = _structured_ssh_parts(argv)
+    git_argv = parts[1] if parts is not None else argv
+    return _git_subcommand(git_argv) == "remote"
+
+
+def _redact_git_remote_url(value: str) -> str:
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        if "://" not in value:
+            return value
+        scheme, remainder = value.split("://", 1)
+        remainder = remainder.rsplit("@", 1)[-1]
+        return f"{scheme}://{remainder.split('?', 1)[0].split('#', 1)[0]}"
+    if parsed.scheme and parsed.netloc:
+        netloc = parsed.netloc.rsplit("@", 1)[-1]
+        return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
+    if re.fullmatch(r"[^/@\s]+@[^/\s:]+:.+", value):
+        return value.rsplit("@", 1)[-1].split("?", 1)[0].split("#", 1)[0]
+    return value
+
+
+def _redact_git_remote_output(data: bytes) -> bytes:
+    lines = []
+    for line in data.decode("utf-8", errors="replace").splitlines(keepends=True):
+        value = line.rstrip("\r\n")
+        lines.append(_redact_git_remote_url(value) + line[len(value) :])
+    return "".join(lines).encode()
+
+
 def _execute_argv_commands(
     commands: list[list[str]], stdout_file: Any | None = None, stderr_file: Any | None = None
 ) -> int:
     exit_code = 0
     for argv in commands:
         try:
+            redact = _is_git_remote_output_request(argv)
             result = subprocess.run(
-                argv,
-                stdout=stdout_file,
-                stderr=stderr_file,
+                _execution_argv(argv),
+                stdout=subprocess.PIPE if redact else stdout_file,
+                stderr=subprocess.PIPE if redact else stderr_file,
                 check=False,
             )
+            if redact:
+                _write_runner_stream(
+                    stdout_file, _redact_git_remote_output(result.stdout or b"")
+                )
+                _write_runner_stream(
+                    stderr_file,
+                    _redact_git_remote_output(result.stderr or b""),
+                    error=True,
+                )
             exit_code = int(result.returncode)
         except OSError as exc:
             message = f"Click could not start `{argv[0]}`: {exc}\n"
@@ -2671,13 +2796,23 @@ def _execute_read_only_git(
         )
         return 2
     try:
+        redact = _is_git_remote_output_request(argv)
         result = subprocess.run(
             safe_argv,
-            stdout=stdout_file,
-            stderr=stderr_file,
+            stdout=subprocess.PIPE if redact else stdout_file,
+            stderr=subprocess.PIPE if redact else stderr_file,
             env=_sanitized_git_environment(),
             check=False,
         )
+        if redact:
+            _write_runner_stream(
+                stdout_file, _redact_git_remote_output(result.stdout or b"")
+            )
+            _write_runner_stream(
+                stderr_file,
+                _redact_git_remote_output(result.stderr or b""),
+                error=True,
+            )
         return int(result.returncode)
     except OSError as exc:
         _write_runner_stream(

--- a/hooks/click_gate.py
+++ b/hooks/click_gate.py
@@ -1957,7 +1957,7 @@ def _get_content_paths(tokens: list[str]) -> list[str] | None:
 
 
 def _structured_ssh_parts(tokens: list[str]) -> tuple[str, list[str]] | None:
-    if len(tokens) < 4 or Path(tokens[0]).name.lower() != "ssh":
+    if len(tokens) < 4 or tokens[0].lower() not in {"ssh", "ssh.exe"}:
         return None
     target = tokens[1]
     remote_argv = tokens[2:]
@@ -2662,7 +2662,7 @@ def _execution_argv(argv: list[str]) -> list[str]:
     if error or safe_git_argv is None:
         return argv
     return [
-        argv[0],
+        "ssh",
         "-F",
         "none",
         "-o",

--- a/tests/test_click_gate.py
+++ b/tests/test_click_gate.py
@@ -10,6 +10,7 @@ import sys
 import tempfile
 import time
 import unittest
+from unittest import mock
 
 
 SCRIPT = Path(
@@ -507,6 +508,155 @@ class ClickGateTests(unittest.TestCase):
                 self.assertEqual(
                     denied["hookSpecificOutput"]["permissionDecision"], "deny"
                 )
+
+    def test_structured_ssh_inspection_reuses_bounded_git_policy(self) -> None:
+        allowed = (
+            ["ssh", "example-host", "git", "status", "--short"],
+            ["ssh", "user@example-host", "git", "rev-parse", "HEAD"],
+            ["ssh", "example-host", "git", "merge-base", "HEAD", "origin/main"],
+            ["ssh", "example-host", "git", "remote", "get-url", "origin"],
+            [
+                "ssh",
+                "example-host",
+                "git",
+                "remote",
+                "get-url",
+                "--all",
+                "origin",
+            ],
+        )
+        denied = (
+            ["ssh", "-o", "ProxyCommand=helper", "example-host", "git", "status"],
+            ["ssh", "example-host", "git status"],
+            ["ssh", "example-host", "hostname"],
+            ["ssh", "example-host", "docker", "ps"],
+            ["ssh", "example-host", "systemctl", "status", "service"],
+            ["ssh", "example-host", "nvidia-smi", "-L"],
+            ["ssh", "example-host", "sudo", "-n", "true"],
+            ["ssh", "example-host", "bash", "-c", "git status"],
+            ["ssh", "example-host", "ssh", "other-host", "git", "status"],
+            ["ssh", "example-host", "git", "fetch"],
+            ["ssh", "example-host", "git", "log", "-1"],
+            ["ssh", "example-host", "git", "rev-parse", "origin/main"],
+            ["ssh", "example-host", "git", "remote", "-v"],
+            ["ssh", "example-host", "git", "remote", "set-url", "origin", "x"],
+        )
+
+        for argv in allowed:
+            with self.subTest(allowed=argv):
+                self.assertTrue(CLICK_GATE._is_read_only_tokens(argv))
+        for argv in denied:
+            with self.subTest(denied=argv):
+                self.assertFalse(CLICK_GATE._is_read_only_tokens(argv))
+                payload = self.inspect_gate([argv])
+                self.assertEqual(
+                    payload["hookSpecificOutput"]["permissionDecision"], "deny"
+                )
+
+    def test_direct_structured_ssh_read_becomes_an_observation(self) -> None:
+        self.approve_contract()
+        command = "ssh example-host git status --short"
+        request, broad, error = CLICK_GATE._inspection_request_from_bash(command)
+        self.assertEqual(error, "")
+        self.assertFalse(broad)
+        self.assertEqual(
+            request,
+            {
+                "version": 1,
+                "commands": [
+                    ["ssh", "example-host", "git", "status", "--short"]
+                ],
+            },
+        )
+        payload = self.pre_tool("Bash", command, "turn-2")
+        rewritten = payload["hookSpecificOutput"]["updatedInput"]["command"]
+        self.assertIn("run-observation", rewritten)
+
+        piped = self.pre_tool(
+            "Bash",
+            "ssh example-host git status --short | head -1",
+            "turn-2",
+        )
+        self.assertEqual(
+            piped["hookSpecificOutput"]["permissionDecision"], "deny"
+        )
+
+    def test_structured_ssh_execution_preserves_remote_argv_literals(self) -> None:
+        remote_argv = [
+            "git",
+            "merge-base",
+            "HEAD",
+            "literal|value;still-one-argument",
+        ]
+        argv = ["ssh", "example-host", *remote_argv]
+        prepared = CLICK_GATE._execution_argv(argv)
+        safe_git_argv, error = CLICK_GATE._build_read_only_git_argv(remote_argv)
+        self.assertEqual(error, "")
+        self.assertEqual(prepared[:3], ["ssh", "-F", "none"])
+        self.assertIn("PermitLocalCommand=no", prepared)
+        self.assertIn("ClearAllForwardings=yes", prepared)
+        self.assertEqual(prepared[-2], "example-host")
+        self.assertEqual(shlex.split(prepared[-1], posix=True), safe_git_argv)
+
+        with mock.patch.object(CLICK_GATE.subprocess, "run") as run:
+            run.return_value.returncode = 0
+            self.assertEqual(CLICK_GATE._execute_argv_commands([argv]), 0)
+        self.assertEqual(run.call_args.args[0], prepared)
+        self.assertFalse(run.call_args.kwargs["check"])
+
+    def test_structured_ssh_execution_keeps_mutations_explicit(self) -> None:
+        remote_argv = ["python3", "tool.py", "--value", "literal|value"]
+        argv = ["ssh", "example-host", *remote_argv]
+        self.assertEqual(CLICK_GATE._execution_argv(argv), argv)
+        self.assertFalse(
+            CLICK_GATE._is_read_only_tokens(argv)
+        )
+
+        unsupported = ["ssh", "-p", "2222", "example-host", "git", "status"]
+        self.assertEqual(CLICK_GATE._execution_argv(unsupported), unsupported)
+
+    def test_structured_ssh_read_is_valid_targeted_verification(self) -> None:
+        self.approve_contract()
+        payload = self.verify_checks(
+            [
+                {
+                    "argv": ["ssh", "example-host", "git", "status", "--short"],
+                    "class": "targeted",
+                }
+            ]
+        )
+        output = payload["hookSpecificOutput"]
+        self.assertEqual(output["permissionDecision"], "allow")
+
+    def test_git_remote_output_redacts_credentials_and_query_tokens(self) -> None:
+        output = CLICK_GATE._redact_git_remote_output(
+            b"https://user:token@example.com/repo.git?access_token=secret\n"
+            b"ssh://user:password@example.com/repo.git#secret\n"
+            b"token@example.com:owner/repo.git\n"
+        )
+        self.assertEqual(
+            output,
+            b"https://example.com/repo.git\n"
+            b"ssh://example.com/repo.git\n"
+            b"example.com:owner/repo.git\n",
+        )
+        self.assertNotIn(b"token", output)
+        self.assertNotIn(b"password", output)
+        self.assertNotIn(b"secret", output)
+
+    def test_structured_ssh_remote_url_is_redacted_before_output(self) -> None:
+        argv = ["ssh", "example-host", "git", "remote", "get-url", "origin"]
+        with tempfile.TemporaryFile() as stdout_file, tempfile.TemporaryFile() as stderr_file:
+            with mock.patch.object(CLICK_GATE.subprocess, "run") as run:
+                run.return_value.returncode = 0
+                run.return_value.stdout = b"https://user:secret@example.com/repo.git\n"
+                run.return_value.stderr = b""
+                self.assertEqual(
+                    CLICK_GATE._execute_argv_commands([argv], stdout_file, stderr_file),
+                    0,
+                )
+            stdout_file.seek(0)
+            self.assertEqual(stdout_file.read(), b"https://example.com/repo.git\n")
 
     def test_structured_inspection_emulates_get_content_cross_platform(self) -> None:
         (self.workspace / "native.txt").write_text(
@@ -2264,6 +2414,10 @@ class ClickGateTests(unittest.TestCase):
             ["git", "cat-file", "--filters", "HEAD:README.md"],
             ["git", "cat-file", "--textconv", "HEAD:README.md"],
             ["git", "show", "--textconv", "HEAD"],
+            ["git", "remote"],
+            ["git", "remote", "-v"],
+            ["git", "remote", "set-url", "origin", "https://example.com/repo.git"],
+            ["git", "remote", "add", "backup", "https://example.com/repo.git"],
         )
         for argv in commands:
             with self.subTest(argv=argv):
@@ -2277,6 +2431,8 @@ class ClickGateTests(unittest.TestCase):
             ["git", "status", "--short"],
             ["git", "diff", "--check"],
             ["git", "log", "--oneline"],
+            ["git", "merge-base", "HEAD", "origin/main"],
+            ["git", "remote", "get-url", "origin"],
         ):
             with self.subTest(argv=argv):
                 request, _, error = CLICK_GATE._validate_inspection_request(

--- a/tests/test_click_gate.py
+++ b/tests/test_click_gate.py
@@ -527,6 +527,7 @@ class ClickGateTests(unittest.TestCase):
         )
         denied = (
             ["ssh", "-o", "ProxyCommand=helper", "example-host", "git", "status"],
+            ["/tmp/ssh", "example-host", "git", "status"],
             ["ssh", "example-host", "git status"],
             ["ssh", "example-host", "hostname"],
             ["ssh", "example-host", "docker", "ps"],


### PR DESCRIPTION
Hello. This replaces #5 after rebasing onto the latest `main` and incorporating the review feedback.

Click blocks SSH as potentially mutating, which previously also blocked the remote Git reads needed to prepare an accurate approval contract. Agents therefore had to request mutation approval merely to inspect repository state, or write a contract from unverified assumptions and verify it only after approval.

This revision preserves the existing safety model. It reuses Click's read-only Git parser and safe argv builder, and only permits structured SSH calls for `git status`, `git rev-parse HEAD`, `git merge-base`, and `git remote get-url`. It adds no separate Git allowlist. SSH config is ignored with `-F none`; forwarding, local commands, remote-command overrides, TTY, SSH options, shells, `sudo`, nested SSH, and Git writes are blocked before connection. Credentials, query strings, and fragments are redacted from remote URL output. The earlier Docker, systemd, NVIDIA, host, file-inspection, and documentation changes have been removed.

Validation results:

- All 146 tests passed on Python 3.10
- GitHub Actions CI passed on Ubuntu, macOS, and Windows
- The Plugin Security Scan passed
- Four live Ubuntu Git reads succeeded in a fresh Codex session
- Unsafe requests were blocked before SSH execution
- No remote state was changed

Thank you for the detailed review.