### PR TITLE
Add plugin icon for Codex catalog readiness

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -24,6 +24,7 @@
   "interface": {
     "displayName": "Click",
     "shortDescription": "Approve once, then implement the contract in one shot.",
+    "composerIcon": "./assets/icon.svg",
     "longDescription": "Click asks once whether software changes should use Always ON (recommended) or Manual mode. Always ON applies one compact contract and one later-turn approval before supported software mutations; Manual applies the same workflow only when @Click is selected and then keeps that staged or incomplete approved session contract mutation-locked across turns. Questions, explanations, and simple read-only inspection remain normal. Code review needs no build contract. After approval Click implements in one shot. During an active review or approved build, versioned argv-based inspect, mutate, and verify runners make supported command intent explicit, execute without a shell, reuse evidence, infer minimum verification cost from runner kind and actual scope, detect protected Git content and obvious new implementation paths changed by checks, and enforce the automatically selected verification budget. The Hook blocks parallel replanning and replacement contracts while necessary in-scope implementation details remain flexible. The bundled Fix skill provides the same compact repair flow for direct invocation.",
     "developerName": "Junseok Pak",
     "category": "Productivity",

--- a/assets/icon.svg
+++ b/assets/icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512" role="img" aria-labelledby="title">
+  <title id="title">Click</title>
+  <rect width="512" height="512" rx="96" fill="#111827"/>
+  <rect x="96" y="96" width="320" height="320" rx="72" fill="none" stroke="#22C55E" stroke-width="24"/>
+  <path d="M170 154L344 318L278 326L318 398L266 426L226 350L176 394Z" fill="#F9FAFB" stroke="#111827" stroke-width="14" stroke-linejoin="round"/>
+  <g fill="none" stroke="#22C55E" stroke-width="20" stroke-linecap="round">
+    <path d="M350 164v-42"/>
+    <path d="M386 178l30-30"/>
+    <path d="M400 214h42"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

Prepare Click for submission to the Awesome Codex Plugins catalog without changing runtime behavior.

- add a 512×512 SVG plugin icon at `assets/icon.svg`;
- declare `interface.composerIcon` in `.codex-plugin/plugin.json`.

This addresses the catalog's documented icon requirement. The existing HOL scanner gate still passes at 87/100 with no critical/high findings; its broader all-or-nothing interface-assets check continues to report the pre-existing optional metadata warning for fields beyond `composerIcon`.

## Scope

Manifest/assets only. No Click runtime, hook, state-machine, verification-budget, or approval-flow behavior changes.