### PR TITLE
Fix Windows state lock contention

### DIFF
--- a/hooks/click_gate.py
+++ b/hooks/click_gate.py
@@ -539,7 +539,16 @@ def _state_lock() -> Any:
                 0o600,
             )
             os.write(descriptor, str(os.getpid()).encode())
-        except FileExistsError:
+        except (FileExistsError, PermissionError) as exc:
+            # Windows can report an O_EXCL collision as EACCES while another
+            # process still owns the lock file. Treat that specific shape as
+            # contention and retry instead of failing the observation runner.
+            if (
+                isinstance(exc, PermissionError)
+                and os.name != "nt"
+                and not lock_path.exists()
+            ):
+                raise
             try:
                 stale = time.time() - lock_path.stat().st_mtime > STATE_LOCK_STALE_SECONDS
             except OSError:
@@ -549,7 +558,8 @@ def _state_lock() -> Any:
                     lock_path.unlink()
                 except OSError:
                     pass
-                continue
+                else:
+                    continue
             if time.monotonic() >= deadline:
                 raise OSError("timed out waiting for Click state lock")
             time.sleep(0.025)

--- a/tests/test_click_gate.py
+++ b/tests/test_click_gate.py
@@ -913,6 +913,50 @@ class ClickGateTests(unittest.TestCase):
             denied["hookSpecificOutput"]["permissionDecisionReason"],
         )
 
+    def test_state_lock_retries_windows_permission_contention(self) -> None:
+        with mock.patch.dict(
+            CLICK_GATE.os.environ,
+            {"PLUGIN_DATA": str(self.plugin_data)},
+        ):
+            lock_root = self.plugin_data / "gate-state"
+            lock_root.mkdir(parents=True)
+            lock_path = lock_root / ".state.lock"
+            lock_path.write_text("competing-process", encoding="utf-8")
+            real_open = CLICK_GATE.os.open
+            attempts = 0
+
+            def open_with_windows_contention(
+                path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+                flags: int,
+                mode: int = 0o777,
+            ) -> int:
+                nonlocal attempts
+                attempts += 1
+                if attempts == 1:
+                    raise PermissionError(13, "Permission denied", str(path))
+                return real_open(path, flags, mode)
+
+            def release_competing_lock(_: float) -> None:
+                lock_path.unlink()
+
+            with (
+                mock.patch.object(
+                    CLICK_GATE.os,
+                    "open",
+                    side_effect=open_with_windows_contention,
+                ),
+                mock.patch.object(
+                    CLICK_GATE.time,
+                    "sleep",
+                    side_effect=release_competing_lock,
+                ),
+            ):
+                with CLICK_GATE._state_lock():
+                    self.assertTrue(lock_path.exists())
+
+            self.assertEqual(attempts, 2)
+            self.assertFalse(lock_path.exists())
+
     def test_parallel_observation_results_do_not_leave_running_state(self) -> None:
         self.approve_contract()
         for name in ("a.txt", "b.txt"):


### PR DESCRIPTION
## Summary
- retry Windows `PermissionError` from exclusive state-lock contention
- avoid a tight stale-lock retry when cleanup cannot remove the lock
- add a deterministic regression test for the Windows error shape

## Verification
- `python3 -m unittest discover -s tests -v` (162 passed)
- `python3 scripts/validate_distribution.py`
- `python3 -m compileall -q hooks evals scripts tests`
- `git diff --check`

Fixes the post-merge Windows failure from Actions run 33243277895.