### PR TITLE
Release Click v0.20.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/grapefruit0205/click.git",
-        "ref": "v0.19.0"
+        "ref": "v0.20.0"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "click",
-  "version": "0.19.0",
-  "description": "Choose Always ON or Manual once; Manual uses @Click. Approve one compact plain-language execution contract, then use structured commands, managed local services, and bounded primary evidence to reduce observable implementation and shadow-verification loops.",
+  "version": "0.20.0",
+  "description": "Choose Always ON or @Click Manual. Click turns a software change into one compact plain-language execution contract, waits for approval, then keeps Codex inside that boundary with structured commands and only the primary evidence needed for completion—without repeated planning or repository-wide rescans.",
   "author": {
     "name": "Junseok Pak",
     "url": "https://github.com/grapefruit0205"
@@ -23,9 +23,9 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Click",
-    "shortDescription": "Approve once, then implement the contract in one shot.",
+    "shortDescription": "Approve one clear boundary, then build and verify without replanning.",
     "composerIcon": "./assets/icon.svg",
-    "longDescription": "Click asks once whether software changes should use Always ON (recommended) or Manual mode. Always ON applies one compact contract and one later-turn approval before supported software mutations; Manual applies the same workflow only when @Click is selected and then keeps that staged or incomplete approved session contract mutation-locked across turns. Staging validates the contract JSON once and emits an opaque contract_id; the later approval passes only that id, never the JSON again. Questions, explanations, simple read-only inspection, and code review remain lightweight. After approval Click implements in one shot. A structured evidence registry assigns each completion condition one cheapest sufficient primary evidence source by id. Local argv checks have an automatically scope-inferred budget; a referenced Browser source has one three-call, ninety-second representative-session budget and long timed progression is rejected. Long-running development servers use a Click-owned supervisor and exact stop lifecycle instead of a foreground mutation. Structured inspect, mutate, service, and verify capabilities execute without a shell in isolated child process groups, reject direct process-control executables, reuse evidence, and detect verification-time workspace changes. The Hook blocks parallel replanning, replacement contracts, and post-completion shadow verification while necessary in-scope implementation details remain flexible. The bundled Fix skill provides the same compact repair flow for direct invocation.",
+    "longDescription": "Click turns a software change into one plain-language contract you approve once, then keeps Codex inside that boundary until the implementation and agreed checks are complete. Choose Always ON (recommended) for software changes or Manual with @Click. Staging validates the contract JSON once and emits an opaque contract_id; the later approval passes only that id, never the JSON again. Questions, explanations, simple read-only inspection, and code review remain lightweight. After approval Click implements in one shot. A structured evidence registry assigns each completion condition one cheapest sufficient primary evidence source by id. Local argv checks have an automatically scope-inferred budget; a referenced Browser source has one three-call, ninety-second representative-session budget and long timed progression is rejected. Long-running development servers use a Click-owned supervisor and exact stop lifecycle instead of a foreground mutation. Structured inspect, mutate, service, and verify capabilities execute without a shell in isolated child process groups, reject direct process-control executables, reuse evidence, and detect verification-time workspace changes. The Hook blocks parallel replanning, replacement contracts, and post-completion shadow verification while necessary in-scope implementation details remain flexible. The bundled Fix skill provides the same compact repair flow for direct invocation.",
     "developerName": "Junseok Pak",
     "category": "Productivity",
     "capabilities": [
@@ -33,12 +33,9 @@
     ],
     "websiteURL": "https://github.com/grapefruit0205/click",
     "defaultPrompt": [
-      "Use Click to stage one compact developer execution contract, choose and automatically budget a verification scale, explain it plainly, and wait for one later-turn approval before implementation.",
-      "Use Click to design and implement this change in one approved shot, blocking observable tool loops and using one final verification batch.",
-      "Set Click to Always ON for software changes while keeping questions and read-only inspection normal.",
-      "Use Click's structured capability runners to inspect, implement, and verify this approved change without guessing whether shell text is read-only or writable.",
-      "Use Click's read-only review guard to review this code without repeated repository scans.",
-      "Use Fix to translate this bug report into a compact repair contract and ask once before repairing it."
+      "Use Click to agree on one clear boundary, approve it once, then implement and run only the checks needed to finish.",
+      "Set Click to Always ON for software changes while keeping questions and read-only inspection lightweight.",
+      "Use Click's read-only review guard to review this code without repeated repository scans."
     ]
   }
 }

--- a/COMMUNITY_POSTS.md
+++ b/COMMUNITY_POSTS.md
@@ -25,7 +25,7 @@ On first use, you choose **Always ON** or **Manual**.
 
 For a code change, Click turns the request and repository context into one compact contract: outcome, boundary, must-hold behavior, build approach, verification scale, and a plain-language explanation. It stages and shows that contract, then requires a later user turn for the one approval. After that, the Hook rejects replacement contracts, matched replanning, repeated successful observations, repository-wide rescans, and verification outside the approved budget.
 
-The v0.19 candidate tightens the places where a guard can become either too loose or too annoying. Staging validates the contract JSON once and emits an opaque `contract_id`; a later approval passes only that id, never the JSON again. An activated Manual contract remains mutation-locked across later turns until its emitted id is passed. Verification cost uses runner kind and actual scope, so broad filters and many files cannot masquerade as one targeted test, while one exact integration test is no longer forced to deep. Common Windows, uv, lint, build, typecheck, Cargo, Go, and exact Node checks are recognized. Git-backed checks warn about every new non-ignored path and fail stale for obvious new source, configuration, or migration paths. The versioned argv-based `inspect`, `mutate`, `service`, and `verify` requests execute accepted commands without a shell. This is a local workflow guard—not a security sandbox or a claim of perfect tool coverage.
+Click v0.20 keeps the same approve-once workflow while tightening the places where a guard can become either too loose or too annoying. Staging validates the contract JSON once and emits an opaque `contract_id`; a later approval passes only that id, never the JSON again. Each completion condition points to one cheapest sufficient primary evidence source, and Browser evidence is limited to one representative session. Supported local development servers use a managed start/stop lifecycle instead of holding the task open. The versioned argv-based `inspect`, `mutate`, `service`, and `verify` requests execute accepted commands without a shell in isolated child process groups and reject direct process-control executables. This is a local workflow guard—not a security sandbox or a measured claim of faster or more accurate results.
 
 This is not a claim that Click invents better architecture than the model. The model already knows how to design software. Click's job is narrower: keep the agent inside one visible boundary and stop observable execution loops after approval.
 
@@ -42,6 +42,15 @@ Install:
 codex plugin marketplace add grapefruit0205/click
 codex plugin add click@click
 ```
+
+Already using Click? v0.20 requires an explicit refresh and reinstall:
+
+```bash
+codex plugin marketplace upgrade click
+codex plugin add click@click
+```
+
+Restart the ChatGPT desktop app and start a new task after reviewing the updated Hook.
 
 Repository: https://github.com/grapefruit0205/click
 
@@ -86,7 +95,7 @@ Repository: https://github.com/grapefruit0205/click
 
 코드 변경 요청에서는 저장소 맥락을 바탕으로 결과, 범위, 반드시 지킬 동작, 최소 구현 경로, 검증 규모, 쉬운 설명을 하나의 축약 계약으로 만듭니다. 계약을 stage해 보여준 뒤 다음 사용자 turn의 승인 한 번을 기다립니다. 승인하면 Hook이 대체 계약, 일치하는 재계획, 성공한 동일 조회, 저장소 전체 재탐색, 검증 예산 밖의 광범위 테스트를 제한합니다.
 
-v0.19 후보는 안전망이 너무 느슨하거나 지나치게 답답해지는 지점을 함께 줄였습니다. 계약 JSON은 stage에서 한 번만 검증하고 불투명한 `contract_id`를 발급하며, 다음 승인 turn에는 JSON을 다시 보내지 않고 그 id만 pass합니다. 한 번 활성화한 Manual 계약은 발급 id를 pass할 때까지 다음 turn에서도 mutation을 막습니다. 검증 비용은 runner 종류와 실제 범위를 나눠 보므로 넓은 filter나 여러 파일을 targeted 하나로 속일 수 없고, 정확한 integration test 하나를 무조건 deep으로 과차단하지도 않습니다. Windows·uv·lint·build·typecheck·Cargo·Go·정확한 Node 검사를 지원합니다. Git 기반 검증은 새 non-ignored 경로를 모두 경고하고 명백한 source·config·migration 신규 경로는 stale 실패시킵니다. argv 기반 `inspect`·`mutate`·`service`·`verify`는 허용 명령을 shell 없이 실행합니다. 모든 도구를 완벽히 막는 보안 샌드박스는 아닙니다.
+Click v0.20은 승인 한 번의 흐름을 유지하면서 안전망이 너무 느슨하거나 지나치게 답답해지는 지점을 함께 줄였습니다. 계약 JSON은 stage에서 한 번만 검증하고 불투명한 `contract_id`를 발급하며, 다음 승인 turn에는 JSON을 다시 보내지 않고 그 id만 pass합니다. 각 완료 조건은 충분하면서 가장 싼 주 근거 하나를 가리키고 Browser 근거는 대표 세션 한 번으로 제한합니다. 지원되는 로컬 개발 서버는 작업을 붙잡는 foreground 실행 대신 관리형 시작·종료 수명주기를 사용합니다. argv 기반 `inspect`·`mutate`·`service`·`verify`는 허용 명령을 shell 없이 격리된 자식 process group에서 실행하고 직접 process-control 실행 파일을 차단합니다. 모든 도구를 완벽히 막는 보안 샌드박스나 더 빠르고 정확하다는 측정된 주장은 아닙니다.
 
 Click이 모델보다 더 좋은 아키텍처를 발명한다고 주장하지는 않습니다. 모델은 이미 소프트웨어 설계를 할 수 있습니다. Click의 역할은 더 좁습니다. **승인한 경계를 눈에 보이게 고정하고, 승인 뒤 관찰 가능한 실행 루프를 줄이는 것**입니다.
 
@@ -103,6 +112,15 @@ Click이 모델보다 더 좋은 아키텍처를 발명한다고 주장하지는
 codex plugin marketplace add grapefruit0205/click
 codex plugin add click@click
 ```
+
+기존 Click 사용자는 v0.20을 사용하려면 명시적으로 마켓플레이스를 갱신하고 플러그인을 다시 설치해야 합니다.
+
+```bash
+codex plugin marketplace upgrade click
+codex plugin add click@click
+```
+
+갱신된 Hook을 검토한 뒤 ChatGPT 데스크톱 앱을 다시 시작하고 새 작업을 시작하세요.
 
 저장소: https://github.com/grapefruit0205/click
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -5,15 +5,15 @@
 [![CI](https://github.com/grapefruit0205/click/actions/workflows/ci.yml/badge.svg)](https://github.com/grapefruit0205/click/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-> 구현 경계를 한 번 승인하고, 다시 계획하지 않고, 한 번만 검증합니다.
+> 무엇을 바꾸고 무엇을 지킬지 한 번 합의한 뒤, 그 경계 안에서 구현과 필요한 검증을 끝냅니다.
 
-Click은 성능 좋은 모델이 소프트웨어 작업에서 계획을 다시 세우고, 같은 파일을 다시 읽고, 저장소를 다시 훑고, 검증을 과하게 반복하는 데 지친 사람을 위한 Codex 플러그인입니다. 처음 한 번 **Always ON(추천)** 또는 **Manual**을 선택합니다. Always ON은 소프트웨어 생성·수정·삭제·리팩터링·수리에 자동 적용되고, Manual은 `@Click`을 멘션했을 때만 적용됩니다.
+Click은 코딩 에이전트와 소프트웨어 변경을 한 번 합의한 뒤, 계획을 다시 쓰거나 저장소 전체를 다시 훑거나 같은 결과를 다른 도구로 재확인하지 않고 끝까지 진행하고 싶은 사용자를 위한 Codex 플러그인입니다. 요청과 관련 저장소 맥락을 짧은 계약—무엇을 바꿀지, 무엇을 반드시 지킬지, 어떤 근거면 완료인지—으로 만들고 쉬운 말로 설명한 뒤 승인을 기다립니다. 승인 후에는 구현과 검증을 그 경계 안에 유지합니다.
 
-변경 요청에서는 가장 좁은 관련 저장소 맥락을 확인하고, 요청을 축약 실행 계약으로 번역하고, 같은 내용을 쉬운 말로 설명한 뒤 코드 수정 전에 한 번만 승인을 요청합니다. 승인 뒤에는 그 경계 안에서 One-shot으로 구현합니다. 활성 작업 중에는 버전이 있는 argv 기반 `inspect`·`mutate`·`verify` runner로 지원 명령의 의도를 분명히 하고 shell 없이 실행합니다. Hook은 관찰 가능한 재읽기·재탐색·재계획·예산 밖 검증 루프를 막되, 승인된 범위 안에서 필요한 구현 선택은 열어 둡니다.
+소프트웨어 변경에 기본 적용하려면 **Always ON(추천)**을, `@Click`을 부른 작업에만 적용하려면 **Manual**을 선택합니다. 질문·설명·단순 조회·수정 없는 코드 리뷰는 가볍게 유지됩니다.
 
-Always ON이어도 질문·설명·단순 조회는 평소처럼 처리합니다. 코드 리뷰도 구현 계약이나 승인이 필요하지 않습니다. 대신 읽기 전용 anti-loop 안전망을 적용해 처음 필요한 근거 수집은 허용하고, 성공한 동일 shell 조회와 저장소 전체 재탐색 반복을 막습니다.
+## 핵심 목적
 
-Click은 아키텍처 패턴 선택기나 완전한 명세 시스템이 아닙니다. 사용자가 모듈러 모노리스, 이벤트 드리븐, 배치, 함수형 중 하나를 미리 고를 필요가 없습니다. 요청한 동작과 기존 시스템에 실제로 필요한 최소 설계 언어를 Click이 도출합니다.
+Click의 핵심 목적은 사용자가 승인한 하나의 변경 경계를 제안부터 구현과 필요한 검증까지 유지하는 것입니다. 더 큰 명세를 만들거나 아키텍처 패턴을 대신 선택하는 도구가 아닙니다. 무엇을 바꿀지, 무엇을 지킬지, 어떤 근거면 충분한지를 명확히 한 뒤 관찰 가능한 재계획·저장소 전체 재탐색·중복 검증을 제한하면서 승인 범위 안의 필요한 구현 선택은 열어 둡니다.
 
 ## 빠르게 시작하기
 
@@ -33,6 +33,17 @@ ChatGPT 데스크톱 앱을 다시 시작하고 포함된 Click Hook을 검토�
 ```text
 @Click 주문 취소 기능을 추가해줘. 중복 환불을 방지하고 기존 API 호환성을 유지해야 해.
 ```
+
+## v0.20.0으로 업데이트
+
+Click을 이미 설치했다면 Git 마켓플레이스 스냅샷을 명시적으로 갱신하고 플러그인을 다시 설치해야 이번 버전이 적용됩니다.
+
+```bash
+codex plugin marketplace upgrade click
+codex plugin add click@click
+```
+
+ChatGPT 데스크톱 앱을 다시 시작하고 갱신된 Click Hook을 검토해 신뢰한 뒤 새 작업을 시작합니다. 기존 모드 설정은 대상 저장소 밖에 그대로 유지됩니다. `click-gate`를 직접 호출하는 자동화가 있다면 `pass`에 계약 JSON 대신 발급된 `contract_id`를 전달하고, 인라인 `done_when` 문자열을 구조화된 증거 참조로 바꿔야 합니다.
 
 나중에 “Click을 Always ON으로 설정해줘” 또는 “Click을 Manual로 설정해줘”라고 바꿀 수 있고, 이 설정은 대상 저장소 밖에 유지됩니다. 정확히 한 turn만 우회하려면 사용자 프롬프트 첫 줄에 `@Click bypass` 또는 자동완성 형식인 `[@Click](plugin://click@click) bypass`를 씁니다. Hook은 같은 turn의 `click-gate bypass` 한 번만 승인하고 active 계약은 그대로 보존합니다. active 계약을 버릴 때는 같은 형식의 `cancel` 명령으로 `click-gate cancel` 한 번을 승인합니다. `@Click` 이름과 명령의 대소문자는 구분하지 않지만 plugin URI는 정확히 일치해야 하며, 명령 줄에 다른 문구를 붙일 수 없습니다. 실제 작업 내용은 둘째 줄부터 이어서 쓸 수 있습니다. 두 권한은 재사용하거나 다음 turn으로 가져갈 수 없습니다. Click은 프로젝트 안에 설정이나 계약 파일을 만들지 않습니다.
 
@@ -264,7 +275,7 @@ Click의 핵심 대상은 다음 두 그룹입니다.
 
 ## 근거와 솔직한 한계
 
-v0.19.0 소스는 결정적 suite를 release gate로 사용합니다. 영구 모드, turn 분리 승인, active-contract 잠금, 읽기·계획 anti-loop, 범위 중심 로컬 검증, 구조화된 증거 참조, Browser 주 증거 할당과 예산, 관리형 서버 시작·종료, Node 파일 검사, 강화된 Git 조회, process 격리, 검증 중 workspace 변경 감지, 배포 일관성, 저장소 정책을 다룹니다. 필수 CI는 Linux·macOS·Windows에서 suite를 실행하고 Ubuntu에서는 plugin·marketplace·Click/Fix Skill·Python compilation·whitespace도 검증합니다.
+v0.20.0 소스는 결정적 suite를 release gate로 사용합니다. 영구 모드, turn 분리 승인, active-contract 잠금, 읽기·계획 anti-loop, 범위 중심 로컬 검증, 구조화된 증거 참조, Browser 주 증거 할당과 예산, 관리형 서버 시작·종료, Node 파일 검사, 강화된 Git 조회, process 격리, 검증 중 workspace 변경 감지, 배포 일관성, 저장소 정책을 다룹니다. 필수 CI는 Linux·macOS·Windows에서 suite를 실행하고 Ubuntu에서는 plugin·marketplace·Click/Fix Skill·Python compilation·whitespace도 검증합니다.
 
 저장소에는 결정적 fixture 기반 정책 검토를 위한 version 17 golden case와 의미 grader도 포함되어 있습니다. 이 자료는 계약 형식과 기대 동작을 검사하며 runtime 생산성을 측정하지 않습니다.
 

--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ Community link: [LINUX DO](https://linux.do/)
 [![CI](https://github.com/grapefruit0205/click/actions/workflows/ci.yml/badge.svg)](https://github.com/grapefruit0205/click/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-> Approve the boundary once. Build without replanning. Verify once.
+> Agree once on what changes and what must hold. Then finish implementation and the necessary checks inside that boundary.
 
-Click is a Codex plugin for people tired of capable models repeatedly planning, rereading, rescanning, and over-verifying software work. On first use, choose **Always ON (recommended)** or **Manual**. Always ON applies Click automatically to software creation, modification, deletion, refactoring, and repair. Manual applies it only when you mention `@Click`.
+Click is a Codex plugin for people who want coding agents to agree on a software change once and then finish it without repeatedly rewriting the plan, rescanning the repository, or proving the same result twice. It turns your request and the relevant repository context into a short contract—what will change, what must stay true, and what evidence will count—explains it plainly, waits for approval, then keeps implementation and verification inside that boundary.
 
-For a change, Click reads the narrowest relevant repository context, translates the request into one compact execution contract, explains the same meaning plainly, and asks for one approval before editing. After approval it implements inside that boundary in one shot. During active work, versioned argv-based `inspect`, `mutate`, and `verify` runners make supported command intent explicit and execute it without a shell. The Hook blocks observable rereading, rescanning, replanning, and out-of-budget verification loops while leaving necessary in-scope implementation choices open.
+Choose **Always ON (recommended)** for software changes by default or **Manual** for tasks where you mention `@Click`. Questions, explanations, simple lookup, and read-only review remain lightweight.
 
-Questions, explanations, and simple read-only inspection remain normal in Always ON mode. Code review also needs no build contract or approval; Click instead applies a read-only anti-loop guard that allows initial evidence gathering but blocks repeated successful structured reads and repeat repository-wide inventory.
+## Core purpose
 
-Click is not an architecture-pattern picker or a full specification system. You do not need to choose “modular monolith,” “event-driven,” “batch,” or “functional” up front. Click derives the smallest design language that the requested behavior and existing system actually need.
+Click's core purpose is to preserve one user-approved boundary from proposal through implementation and necessary verification. It is not a larger specification system or an architecture-pattern picker. Click makes three things explicit—what changes, what must stay true, and what evidence is enough—then blocks observable replanning, repeated repository-wide exploration, and duplicate verification while leaving necessary in-scope implementation choices open.
 
 ## Quick start
 
@@ -35,6 +35,17 @@ Choose Always ON for the default experience. Choose Manual if you prefer explici
 ```text
 @Click Add order cancellation. Prevent duplicate refunds and preserve the existing API.
 ```
+
+## Update to v0.20.0
+
+If Click is already installed, explicitly refresh its Git marketplace snapshot and reinstall the plugin to load this release:
+
+```bash
+codex plugin marketplace upgrade click
+codex plugin add click@click
+```
+
+Restart the ChatGPT desktop app, review and trust the updated Click Hook, and start a new task. Existing mode preferences remain outside the target repository. If you call `click-gate` directly, update `pass` to use the emitted `contract_id` instead of contract JSON and migrate inline `done_when` strings to structured evidence references.
 
 You can later say “Set Click to Always ON” or “Set Click to Manual.” Those preferences persist outside the target repository. To bypass Click for exactly one turn, make the first line of that user prompt either `@Click bypass` or the autocomplete form `[@Click](plugin://click@click) bypass`; the Hook authorizes one same-turn `click-gate bypass` and keeps any active contract intact. Use the corresponding `cancel` form to authorize one same-turn `click-gate cancel` and discard the active contract. The `@Click` label and action are case-insensitive, but the plugin URI must match exactly and the directive line cannot contain extra text. The task may continue on later lines. Neither authorization is reusable or carries across turns. Click does not place preference or contract files in your project.
 
@@ -266,7 +277,7 @@ Manual mode or a per-turn bypass is usually better for tiny, obvious, reversible
 
 ## Evidence and honest limits
 
-The v0.19.0 source is release-gated by the deterministic suite. It covers persistent modes, distinct-turn approval, active-contract locking, read and plan anti-loops, scope-aware local verification, structured evidence references, Browser primary-source assignment and budgets, managed server start/stop cleanup, Node file checks, hardened Git inspection, process isolation, verification-time workspace mutation detection, distribution consistency, and repository policy. Required CI runs the suite on Linux, macOS, and Windows; Ubuntu also validates the plugin, marketplace, Click/Fix skills, Python compilation, and whitespace errors.
+The v0.20.0 source is release-gated by the deterministic suite. It covers persistent modes, distinct-turn approval, active-contract locking, read and plan anti-loops, scope-aware local verification, structured evidence references, Browser primary-source assignment and budgets, managed server start/stop cleanup, Node file checks, hardened Git inspection, process isolation, verification-time workspace mutation detection, distribution consistency, and repository policy. Required CI runs the suite on Linux, macOS, and Windows; Ubuntu also validates the plugin, marketplace, Click/Fix skills, Python compilation, and whitespace errors.
 
 The repository also includes version-17 golden cases and a semantic grader for deterministic fixture-based policy review. These artifacts check contract shape and expected behavior; they are not runtime productivity measurements.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,15 +5,15 @@
 [![CI](https://github.com/grapefruit0205/click/actions/workflows/ci.yml/badge.svg)](https://github.com/grapefruit0205/click/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-> 只批准一次边界。不重新规划地构建。只验证一次。
+> 一次约定要改什么、必须守住什么，然后在这个边界内完成实现和必要验证。
 
-Click 是一个 Codex 插件，面向厌倦高能力模型在软件工作中反复规划、重复读取、重新扫描和过度验证的用户。首次使用时，可选择 **Always ON（推荐）** 或 **Manual**。Always ON 会自动将 Click 应用于软件的创建、修改、删除、重构和修复；Manual 则只在你提到 `@Click` 时应用。
+Click 是一款面向 Codex 的插件，适合希望与编码代理只约定一次软件变更，然后不再反复改写计划、重新扫描整个仓库或用不同工具重复证明同一结果的用户。它会把请求和相关仓库上下文整理成一份简短契约——要改什么、必须保持什么、什么证据算完成——用易懂语言解释并等待批准，随后让实现和验证始终留在这个边界内。
 
-面对一个变更，Click 会读取最小范围的相关仓库上下文，把请求翻译成一份精简的执行契约，用通俗语言解释同一含义，并在编辑前只请求一次批准。批准后，它会在该边界内 One-shot 实现。工作进行期间，带版本且基于 argv 的 `inspect`、`mutate` 和 `verify` runner 会明确表达受支持命令的意图，并在不使用 shell 的情况下执行。Hook 会阻止可观察到的重复读取、重新扫描、重新规划和超出预算的重复验证，同时允许在范围内选择必要的实现方式。
+若希望默认应用于软件变更，请选择 **Always ON（推荐）**；若只想在提及 `@Click` 的任务中使用，请选择 **Manual**。提问、解释、简单查询和只读代码审查仍保持轻量。
 
-在 Always ON 模式下，提问、解释和简单的只读检查仍按普通方式处理。代码审查也不需要构建契约或批准；Click 会改用只读防循环守卫，允许首次收集证据，但阻止重复的成功结构化读取和再次扫描整个仓库清单。
+## 核心目的
 
-Click 不是架构模式选择器，也不是完整的规格系统。你不需要预先选择“模块化单体”“事件驱动”“批处理”或“函数式”。Click 会根据所需行为和现有系统，推导出实际需要的最小设计语言。
+Click 的核心目的是让用户批准的一条变更边界，从提案一直保持到实现和必要验证完成。它不是用来制造更大的规格，也不会代替用户选择架构模式。Click 会明确要改什么、必须保持什么、什么证据已经足够，并限制可观察到的重复规划、全仓库重复探索和重复验证，同时保留批准范围内必要的实现选择。
 
 ## 快速开始
 
@@ -33,6 +33,17 @@ Use Always ON for future software changes (recommended), or Manual only when I m
 ```text
 @Click 添加订单取消功能。防止重复退款，并保持现有 API 兼容。
 ```
+
+## 更新到 v0.20.0
+
+如果已经安装 Click，需要明确刷新 Git marketplace 快照并重新安装插件，才能加载本版本。
+
+```bash
+codex plugin marketplace upgrade click
+codex plugin add click@click
+```
+
+重新启动 ChatGPT 桌面应用，检查并信任更新后的 Click Hook，然后开始一个新任务。现有模式偏好仍保存在目标仓库之外。如果自动化直接调用 `click-gate`，请让 `pass` 使用发出的 `contract_id` 而不是契约 JSON，并把内联 `done_when` 字符串迁移为结构化证据引用。
 
 之后你可以说“Set Click to Always ON”或“Set Click to Manual”，这些偏好会持久保存在目标仓库之外。若只想绕过一个 turn，请把用户提示的第一行写成 `@Click bypass`，或使用自动补全形式 `[@Click](plugin://click@click) bypass`；Hook 只授权同一 turn 的一次 `click-gate bypass`，并保留活动契约。要丢弃活动契约，请使用对应的 `cancel` 形式来授权一次 `click-gate cancel`。`@Click` 标签和动作不区分大小写，但 plugin URI 必须完全匹配，指令行不能包含其他文字；实际任务可以从第二行继续。两种授权都不能重复使用或带到下一个 turn。Click 不会把偏好或契约文件放进你的项目。
 
@@ -264,7 +275,7 @@ Click 面向两类用户：
 
 ## 证据与诚实边界
 
-v0.19.0 源码以确定性 suite 作为 release gate。覆盖内容包括：持久模式、跨 turn 批准、active-contract 锁、读取与 plan 防循环、范围感知的本地验证、结构化证据引用、Browser 主要证据分配和预算、受管服务器启动与停止、Node 文件检查、加固的 Git 读取、process 隔离、验证期间 workspace mutation 检测、发布一致性和仓库策略。必需 CI 会在 Linux、macOS 和 Windows 运行该 suite，并在 Ubuntu 额外验证 plugin、marketplace、Click/Fix Skill、Python compilation 和 whitespace。
+v0.20.0 源码以确定性 suite 作为 release gate。覆盖内容包括：持久模式、跨 turn 批准、active-contract 锁、读取与 plan 防循环、范围感知的本地验证、结构化证据引用、Browser 主要证据分配和预算、受管服务器启动与停止、Node 文件检查、加固的 Git 读取、process 隔离、验证期间 workspace mutation 检测、发布一致性和仓库策略。必需 CI 会在 Linux、macOS 和 Windows 运行该 suite，并在 Ubuntu 额外验证 plugin、marketplace、Click/Fix Skill、Python compilation 和 whitespace。
 
 仓库还包含用于确定性 fixture 策略审查的 version-17 golden cases 和 semantic grader。这些资料检查契约结构与预期行为，并不测量 runtime 生产力。
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,21 @@
 # Release notes
 
-## v0.19.0 — 2026-08-29
+## v0.20.0 — 2026-08-29
 
-Click v0.19.0 makes the cheapest-evidence policy observable at the Browser boundary and removes the foreground-server failure mode that inflated one-shot game work.
+Click v0.20.0 keeps the one-contract, one-approval workflow while making its purpose clearer: agree once on what will change, what must stay true, and what evidence will count, then keep implementation and necessary verification inside that boundary without observable replanning, repository-wide rescans, or duplicate proof.
+
+### Upgrade required
+
+Existing Click users must refresh the marketplace snapshot and reinstall the plugin to load v0.20.0:
+
+```bash
+codex plugin marketplace upgrade click
+codex plugin add click@click
+```
+
+Restart the ChatGPT desktop app, review and trust the updated Click Hook, and start a new task so the new Skill and Hook definitions are loaded.
+
+If you call `click-gate` directly, update `pass` to send the emitted `contract_id` instead of contract JSON, and migrate inline `done_when` strings to structured condition objects that reference `verification.evidence` ids.
 
 ### Contract-id approval and lean skill routing
 
@@ -20,7 +33,7 @@ Click v0.19.0 makes the cheapest-evidence policy observable at the Browser bound
 - Browser evidence is reset by a later mutation, is required before a Browser-assigned contract can complete, and cannot be repeated after current-revision completion.
 - CI runs feature-branch commits through `pull_request` only and reserves the `push` trigger for `main`, eliminating the duplicate three-OS matrix that previously ran when a pushed branch also had a PR.
 
-### Faster local feedback
+### Managed local execution
 
 - Recognizable development servers use `click-gate service` with `start` and `stop` requests. A Click-owned supervisor retains the exact child handle, isolates its process group, stops it on request or `SessionEnd`, and enforces a two-hour final lifetime ceiling.
 - Foreground server forms are rejected by `click-gate mutate`, preventing a long-running child from holding the implementation command open. Direct process-control executables remain blocked.
@@ -28,7 +41,7 @@ Click v0.19.0 makes the cheapest-evidence policy observable at the Browser bound
 
 ### Release gate
 
-- The plugin manifest, repository marketplace, deterministic policy tests, READMEs, and release notes identify v0.19.0.
+- The plugin manifest, repository marketplace, deterministic policy tests, READMEs, and release notes identify v0.20.0.
 - The tag and GitHub Release must point to the exact protected-main commit that passes the full local suite and required GitHub Actions checks.
 
 ## v0.18.0 — 2026-08-29

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -20,7 +20,7 @@ class RepositoryPolicyTests(unittest.TestCase):
             (ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
         )
         self.assertEqual(manifest["name"], "click")
-        self.assertEqual(manifest["version"], "0.19.0")
+        self.assertEqual(manifest["version"], "0.20.0")
         self.assertEqual(manifest["license"], "MIT")
         self.assertIn("always on", manifest["description"].lower())
         self.assertIn("manual", manifest["description"].lower())
@@ -51,6 +51,14 @@ class RepositoryPolicyTests(unittest.TestCase):
         self.assertIn("anti-loop", manifest["keywords"])
         self.assertIn("@Click", manifest["description"])
         self.assertIn("structured", manifest["description"].lower())
+        self.assertIn("keeps codex inside that boundary", manifest["description"].lower())
+        self.assertEqual(
+            manifest["interface"]["shortDescription"],
+            "Approve one clear boundary, then build and verify without replanning.",
+        )
+        self.assertLessEqual(len(manifest["interface"]["defaultPrompt"]), 3)
+        for prompt in manifest["interface"]["defaultPrompt"]:
+            self.assertLessEqual(len(prompt), 128)
 
     def test_readmes_use_plugin_mention_as_the_default_invocation(self) -> None:
         for readme_name in README_NAMES:
@@ -200,7 +208,7 @@ class RepositoryPolicyTests(unittest.TestCase):
         self.assertEqual(marketplace["name"], "click")
         self.assertEqual(marketplace["plugins"][0]["name"], "click")
         self.assertEqual(
-            marketplace["plugins"][0]["source"]["ref"], "v0.19.0"
+            marketplace["plugins"][0]["source"]["ref"], "v0.20.0"
         )
 
     def test_ci_enforces_distribution_compilation_and_diff_validation(self) -> None:
@@ -215,14 +223,25 @@ class RepositoryPolicyTests(unittest.TestCase):
         self.assertIn("workflow_dispatch:", workflow)
         self.assertTrue((ROOT / "scripts" / "validate_distribution.py").is_file())
 
-    def test_release_documents_identify_v019_without_an_unreleased_heading(self) -> None:
+    def test_release_documents_identify_v020_without_an_unreleased_heading(self) -> None:
         for readme_name in README_NAMES:
             with self.subTest(readme=readme_name):
                 readme = (ROOT / readme_name).read_text(encoding="utf-8")
-                self.assertIn("v0.19.0", readme)
+                self.assertIn("v0.20.0", readme)
         notes = (ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8")
-        self.assertIn("## v0.19.0", notes)
+        self.assertIn("## v0.20.0", notes)
         self.assertNotIn("## Unreleased", notes)
+
+    def test_readmes_explain_the_core_purpose_and_v020_update(self) -> None:
+        english = (ROOT / "README.md").read_text(encoding="utf-8")
+        korean = (ROOT / "README.ko.md").read_text(encoding="utf-8")
+        chinese = (ROOT / "README.zh-CN.md").read_text(encoding="utf-8")
+        for readme in (english, korean, chinese):
+            self.assertIn("codex plugin marketplace upgrade click", readme)
+            self.assertIn("codex plugin add click@click", readme)
+        self.assertIn("## Core purpose", english)
+        self.assertIn("## 핵심 목적", korean)
+        self.assertIn("## 核心目的", chinese)
 
     def test_click_supports_always_on_while_fix_remains_explicit(self) -> None:
         for skill_name in ("click", "fix"):


### PR DESCRIPTION
## Summary\n\n- publish Click v0.20.0 from the accumulated post-v0.18 work\n- state the core purpose clearly across the manifest and three READMEs\n- tell existing users to refresh the click marketplace, reinstall the plugin, restart the app, and start a new task\n- document contract-id and structured-evidence migration for direct click-gate callers\n\n## Verification\n\n- distribution validator\n- plugin validator\n- Click and Fix skill validators\n- Python compileall\n- 163 deterministic tests\n- git diff --check