### PR TITLE
Release Click v0.22.0 with shared state storage

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/grapefruit0205/click.git",
-        "ref": "v0.21.1"
+        "ref": "v0.22.0"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "click",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "description": "Choose Always ON or @Click Manual. Click turns a software change into one compact plain-language execution contract, waits for approval, then keeps Codex inside that boundary with structured commands and only the primary evidence needed for completion—without repeated planning or repository-wide rescans.",
   "author": {
     "name": "Junseok Pak",

--- a/README.ko.md
+++ b/README.ko.md
@@ -60,7 +60,7 @@ launcher를 사용합니다. launcher는 확장 없는 단일 Bash 명령만 허
 가정하지 말고 정확한 제한은
 [`platforms/antigravity/README.md`](platforms/antigravity/README.md)를 확인하세요.
 
-## v0.21.1로 업데이트
+## v0.22.0으로 업데이트
 
 Click을 이미 설치했다면 Git 마켓플레이스 스냅샷을 명시적으로 갱신하고 플러그인을 다시 설치해야 이번 버전이 적용됩니다.
 
@@ -69,7 +69,7 @@ codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-ChatGPT 데스크톱 앱을 다시 시작하고 갱신된 Click Hook을 검토해 신뢰한 뒤 새 작업을 시작합니다. 기존 모드 설정은 대상 저장소 밖에 그대로 유지됩니다. v0.21.1은 계약이나 증거 schema를 바꾸지 않습니다. `click-gate`를 직접 호출한다면 계속 verify 프로토콜 버전 `2`를 사용하고 모든 check에 승인된 argv `evidence_id`를 넣으며, `pass`에는 발급된 `contract_id`만 전달하고 `done_when`은 구조화된 증거 참조를 사용합니다. 예전 설치가 만든 실행 대기 중 runner 명령은 재사용하지 말고, 갱신된 Hook이 새 명령을 발급하게 합니다.
+ChatGPT 데스크톱 앱을 다시 시작하고 갱신된 Click Hook을 검토해 신뢰한 뒤 새 작업을 시작합니다. 기존 모드 설정은 대상 저장소 밖에 그대로 유지됩니다. v0.22.0은 실험적인 Antigravity launcher 경계를 강화하고 공통 state 저장 primitive를 `click_state.py`로 분리하지만 계약이나 증거 schema는 바꾸지 않습니다. `click-gate`를 직접 호출한다면 계속 verify 프로토콜 버전 `2`를 사용하고 모든 check에 승인된 argv `evidence_id`를 넣으며, `pass`에는 발급된 `contract_id`만 전달하고 `done_when`은 구조화된 증거 참조를 사용합니다. 예전 설치가 만든 실행 대기 중 runner 명령은 재사용하지 말고, 갱신된 Hook이 새 명령을 발급하게 합니다.
 
 나중에 “Click을 Always ON으로 설정해줘” 또는 “Click을 Manual로 설정해줘”라고 바꿀 수 있고, 이 설정은 대상 저장소 밖에 유지됩니다. 정확히 한 turn만 우회하려면 사용자 프롬프트 첫 줄에 `@Click bypass` 또는 자동완성 형식인 `[@Click](plugin://click@click) bypass`를 씁니다. Hook은 같은 turn의 `click-gate bypass` 한 번만 승인하고 active 계약은 그대로 보존합니다. active 계약을 버릴 때는 같은 형식의 `cancel` 명령으로 `click-gate cancel` 한 번을 승인합니다. `@Click` 이름과 명령의 대소문자는 구분하지 않지만 plugin URI는 정확히 일치해야 하며, 명령 줄에 다른 문구를 붙일 수 없습니다. 실제 작업 내용은 둘째 줄부터 이어서 쓸 수 있습니다. 두 권한은 재사용하거나 다음 turn으로 가져갈 수 없습니다. Click은 프로젝트 안에 설정이나 계약 파일을 만들지 않습니다.
 
@@ -311,7 +311,7 @@ Click의 핵심 대상은 다음 두 그룹입니다.
 
 ## 근거와 솔직한 한계
 
-현재 공개 릴리스 v0.21.1은 결정적 suite를 release gate로 사용합니다. 영구 모드, turn 분리 승인, active-contract 잠금, 읽기·계획 anti-loop, ID가 결합된 argv 검증, 증거별 현재 revision 완료, Browser 수집 후 finalize, 외부 attestation의 정직한 한계, 관리형 서버 one-use launch claim과 종료, 저장소 제외 실행 파일 해석, state-root binding, 실행 전 runner claim, 강화된 Git 조회, Git snapshot fail-closed, process 격리, 검증 중 workspace 변경 감지, 배포 일관성, 저장소 정책을 검증 대상으로 둡니다.
+현재 공개 릴리스 v0.22.0은 결정적 suite를 release gate로 사용합니다. 영구 모드, turn 분리 승인, active-contract 잠금, 읽기·계획 anti-loop, ID가 결합된 argv 검증, 증거별 현재 revision 완료, Browser 수집 후 finalize, 외부 attestation의 정직한 한계, 관리형 서버 one-use launch claim과 종료, 저장소 제외 실행 파일 해석, state-root binding, 실행 전 runner claim, 강화된 Git 조회, Git snapshot fail-closed, process 격리, 검증 중 workspace 변경 감지, 공통 state 저장 경계, source·배포본의 sibling-only 시작, 배포 일관성, 저장소 정책을 검증 대상으로 둡니다.
 
 저장소에는 결정적 fixture 기반 정책 검토를 위한 version-18 golden case와 의미 grader도 포함되어 있습니다. 이 자료는 계약 형식과 기대 동작을 검사하며 runtime 생산성을 측정하지 않습니다.
 
@@ -331,7 +331,8 @@ skills/click/                         One-shot 설계·구현 Skill
 skills/click/references/modes.md      영구 모드와 코드 리뷰 동작
 skills/click/references/capability-protocol.md  구조화 runner schema
 skills/fix/                           축약 수정 Skill
-hooks/click_gate.py                   계약·capability·anti-loop·예산 안전망
+hooks/click_state.py                  상태 경로·원자적 저장·잠금
+hooks/click_gate.py                   계약·capability·anti-loop·예산 의미 규칙
 hooks/hooks.json                      라이프사이클 Hook 설정
 evals/                                golden case·의미 grader
 tests/                                Hook·grader·정책 결정적 테스트

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ deduplicated. Browser evidence is not currently supported. See
 [`platforms/antigravity/README.md`](platforms/antigravity/README.md) for the
 exact limits instead of assuming full host parity.
 
-## Update to v0.21.1
+## Update to v0.22.0
 
 If Click is already installed, explicitly refresh its Git marketplace snapshot and reinstall the plugin to load this release:
 
@@ -74,7 +74,7 @@ codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-Restart the ChatGPT desktop app, review and trust the updated Click Hook, and start a new task. Existing mode preferences remain outside the target repository. v0.21.1 does not change the contract or evidence schema: direct `click-gate` callers continue to use verification protocol version `2`, include an approved argv `evidence_id` on every check, pass only the emitted `contract_id`, and use structured `done_when` evidence references. Do not reuse a pending runner command created by an older installation; let the updated Hook issue a fresh rewritten command.
+Restart the ChatGPT desktop app, review and trust the updated Click Hook, and start a new task. Existing mode preferences remain outside the target repository. v0.22.0 hardens the experimental Antigravity launcher boundary and moves shared state-storage primitives into `click_state.py`; it does not change the contract or evidence schema. Direct `click-gate` callers continue to use verification protocol version `2`, include an approved argv `evidence_id` on every check, pass only the emitted `contract_id`, and use structured `done_when` evidence references. Do not reuse a pending runner command created by an older installation; let the updated Hook issue a fresh rewritten command.
 
 You can later say “Set Click to Always ON” or “Set Click to Manual.” Those preferences persist outside the target repository. To bypass Click for exactly one turn, make the first line of that user prompt either `@Click bypass` or the autocomplete form `[@Click](plugin://click@click) bypass`; the Hook authorizes one same-turn `click-gate bypass` and keeps any active contract intact. Use the corresponding `cancel` form to authorize one same-turn `click-gate cancel` and discard the active contract. The `@Click` label and action are case-insensitive, but the plugin URI must match exactly and the directive line cannot contain extra text. The task may continue on later lines. Neither authorization is reusable or carries across turns. Click does not place preference or contract files in your project.
 
@@ -314,7 +314,7 @@ Manual mode or a per-turn bypass is usually better for tiny, obvious, reversible
 
 ## Evidence and honest limits
 
-The v0.21.1 source is release-gated by the deterministic suite. It covers persistent modes, distinct-turn approval, active-contract locking, read and plan anti-loops, evidence-bound argv verification, per-source current-revision completion, Browser observe-then-finalize behavior, explicit non-argv attestation limits, managed-service one-use launch claims and cleanup, repository-excluded executable resolution, state-root binding, pre-execution runner claims, hardened Git inspection, fail-closed Git snapshots, process isolation, verification-time workspace mutation detection, distribution consistency, and repository policy. Required CI runs the suite on Linux, macOS, and Windows; Ubuntu also validates the plugin, marketplace, Click/Fix skills, Python compilation, and whitespace errors.
+The v0.22.0 source is release-gated by the deterministic suite. It covers persistent modes, distinct-turn approval, active-contract locking, read and plan anti-loops, evidence-bound argv verification, per-source current-revision completion, Browser observe-then-finalize behavior, explicit non-argv attestation limits, managed-service one-use launch claims and cleanup, repository-excluded executable resolution, state-root binding, pre-execution runner claims, hardened Git inspection, fail-closed Git snapshots, process isolation, verification-time workspace mutation detection, the shared state-storage boundary, sibling-only source/distribution startup, distribution consistency, and repository policy. Required CI runs the suite on Linux, macOS, and Windows; Ubuntu also validates the plugin, marketplace, Click/Fix skills, Python compilation, and whitespace errors.
 
 The repository also includes version-18 golden cases and a semantic grader for deterministic fixture-based policy review. These artifacts check contract shape and expected behavior; they are not runtime productivity measurements.
 
@@ -334,7 +334,8 @@ skills/click/                         One-shot design-and-build Skill
 skills/click/references/modes.md      Persistent mode and code-review behavior
 skills/click/references/capability-protocol.md  Structured runner schemas
 skills/fix/                           Compact repair Skill
-hooks/click_gate.py                   Contract, capability, anti-loop, and budget guard
+hooks/click_state.py                  State paths, atomic persistence, and locking
+hooks/click_gate.py                   Contract, capability, anti-loop, and budget semantics
 hooks/hooks.json                      Lifecycle Hook configuration
 evals/                                Golden cases and semantic grader
 tests/                                Deterministic Hook, grader, and policy tests

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -60,7 +60,7 @@ launcher 只接受一条不含展开的 Bash 命令；命令串联、重定向�
 [`platforms/antigravity/README.md`](platforms/antigravity/README.md)了解准确
 限制，不要假设宿主功能完全等价。
 
-## 更新到 v0.21.1
+## 更新到 v0.22.0
 
 如果已经安装 Click，需要明确刷新 Git marketplace 快照并重新安装插件，才能加载本版本。
 
@@ -69,7 +69,7 @@ codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-重新启动 ChatGPT 桌面应用，检查并信任更新后的 Click Hook，然后开始一个新任务。现有模式偏好仍保存在目标仓库之外。v0.21.1 不改变契约或证据 schema。直接调用 `click-gate` 时，继续使用 verify 协议版本 `2`，为每项检查提供已批准的 argv `evidence_id`，让 `pass` 只传递已签发的 `contract_id`，并使用结构化 `done_when` 证据引用。不要重复使用旧安装留下的待执行 runner 命令；应让更新后的 Hook 签发一条新命令。
+重新启动 ChatGPT 桌面应用，检查并信任更新后的 Click Hook，然后开始一个新任务。现有模式偏好仍保存在目标仓库之外。v0.22.0 加固了实验性 Antigravity launcher 边界，并把共享状态存储 primitive 分离到 `click_state.py`，但不改变契约或证据 schema。直接调用 `click-gate` 时，继续使用 verify 协议版本 `2`，为每项检查提供已批准的 argv `evidence_id`，让 `pass` 只传递已签发的 `contract_id`，并使用结构化 `done_when` 证据引用。不要重复使用旧安装留下的待执行 runner 命令；应让更新后的 Hook 签发一条新命令。
 
 之后你可以说“Set Click to Always ON”或“Set Click to Manual”，这些偏好会持久保存在目标仓库之外。若只想绕过一个 turn，请把用户提示的第一行写成 `@Click bypass`，或使用自动补全形式 `[@Click](plugin://click@click) bypass`；Hook 只授权同一 turn 的一次 `click-gate bypass`，并保留活动契约。要丢弃活动契约，请使用对应的 `cancel` 形式来授权一次 `click-gate cancel`。`@Click` 标签和动作不区分大小写，但 plugin URI 必须完全匹配，指令行不能包含其他文字；实际任务可以从第二行继续。两种授权都不能重复使用或带到下一个 turn。Click 不会把偏好或契约文件放进你的项目。
 
@@ -318,7 +318,7 @@ Click 面向两类用户：
 
 ## 证据与诚实边界
 
-当前公开版本 v0.21.1 使用确定性 suite 作为 release gate，验证持久模式、跨 turn 批准、active-contract 锁、读取与 plan 防循环、verify v2 的 evidence-id 绑定、逐来源 completion ledger、Browser observe-then-finalize、非 argv attestation 边界、受管服务器的一次性 launch claim 与清理、排除仓库路径的可执行程序解析、state-root binding、runner 执行前 claim、加固的 Git 读取、Git snapshot fail-closed、process 隔离和验证期间 workspace mutation 检测。
+当前公开版本 v0.22.0 使用确定性 suite 作为 release gate，验证持久模式、跨 turn 批准、active-contract 锁、读取与 plan 防循环、verify v2 的 evidence-id 绑定、逐来源 completion ledger、Browser observe-then-finalize、非 argv attestation 边界、受管服务器的一次性 launch claim 与清理、排除仓库路径的可执行程序解析、state-root binding、runner 执行前 claim、加固的 Git 读取、Git snapshot fail-closed、process 隔离、验证期间 workspace mutation 检测、共享状态存储边界、源代码与分发版本的 sibling-only 启动、分发一致性和仓库策略。
 
 仓库还包含用于确定性 fixture 策略审查的 version-18 golden cases 和 semantic grader。这些资料检查契约结构与预期行为，并不测量 runtime 生产力。
 
@@ -338,7 +338,8 @@ skills/click/                         One-shot 设计与构建 Skill
 skills/click/references/modes.md      持久模式与代码审查行为
 skills/click/references/capability-protocol.md  结构化 runner schema
 skills/fix/                           精简修复 Skill
-hooks/click_gate.py                   契约、capability、防循环和预算守卫
+hooks/click_state.py                  状态路径、原子持久化与锁
+hooks/click_gate.py                   契约、capability、防循环和预算语义
 hooks/hooks.json                      生命周期 Hook 配置
 evals/                                Golden cases 和 semantic grader
 tests/                                确定性 Hook、grader 和策略测试

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,12 @@
 # Release notes
 
-## Unreleased v0.22 candidate
+## v0.22.0 — 2026-08-30
+
+Click v0.22.0 hardens the experimental Antigravity adapter and extracts the
+shared runtime state-storage boundary into a dedicated module. Contract JSON,
+evidence protocol, modes, and the one-approval workflow remain unchanged.
+
+### Antigravity launcher boundary
 
 - The experimental Antigravity adapter accepts only the exact absolute Python
   and adapter paths injected by its current `PreInvocation`; basename lookalikes,
@@ -14,6 +20,26 @@
   file/search tools and unrelated MCP, Skill, and Plugin tools remain available.
 - Antigravity parses Click's encoded Windows runner command with the native
   Windows argv parser and still executes the resulting argv without a shell.
+
+### Shared state-storage boundary
+
+- `click_state.py` now owns configuration and state paths, hashed workspace and
+  thread identities, canonical managed-state validation, atomic JSON writes,
+  and the cross-process state lock used by both Codex and Antigravity adapters.
+- Contract policy, capability classification, process execution, and evidence
+  semantics remain in `click_gate.py`; this release intentionally moves only
+  storage primitives so the refactor does not change authorization behavior.
+- Source and Antigravity distribution tests launch each gate with only its
+  sibling runtime modules available, preventing accidental imports from the
+  repository source tree. Existing managed state remains compatible.
+
+### Compatibility and release gate
+
+- Direct `click-gate` integrations continue to use verification protocol
+  version `2`; no contract or evidence migration is required.
+- The exact release candidate is gated by the deterministic suite on Linux,
+  macOS, and Windows plus plugin, marketplace, skill, compilation, whitespace,
+  distribution-consistency, and Plugin Security Scan checks.
 
 ## v0.21.1 — 2026-08-30
 

--- a/dist/antigravity/hooks/antigravity_gate.py
+++ b/dist/antigravity/hooks/antigravity_gate.py
@@ -18,12 +18,13 @@ import sys
 import time
 from typing import Any, Callable
 
-try:
+if __package__:
+    from . import click_gate, click_state
+    from .platform_protocol import AntigravityOutputAdapter, CodexOutputAdapter
+else:  # Executed directly from the bundled hooks directory.
     import click_gate
+    import click_state
     from platform_protocol import AntigravityOutputAdapter, CodexOutputAdapter
-except ModuleNotFoundError:  # Imported as hooks.antigravity_gate in tests.
-    from hooks import click_gate
-    from hooks.platform_protocol import AntigravityOutputAdapter, CodexOutputAdapter
 
 
 ANTIGRAVITY_TOOL_MAP = {
@@ -90,14 +91,14 @@ def _context_digest(value: str) -> str:
 
 
 def _lifecycle_path(conversation_id: str) -> Path:
-    return click_gate._state_root() / (
+    return click_state.state_root() / (
         f"antigravity-lifecycle-{_context_digest(conversation_id)}.json"
     )
 
 
 def _workspace_context_path(workspace: str) -> Path:
     normalized = str(Path(workspace).expanduser().resolve())
-    return click_gate._state_root() / (
+    return click_state.state_root() / (
         f"antigravity-workspace-{_context_digest(normalized)}.json"
     )
 
@@ -212,7 +213,7 @@ def _record_pre_invocation(raw: dict[str, Any]) -> dict[str, Any]:
     conversation_id = _conversation_id(raw)
     workspace = _workspace(raw)
     lifecycle_path = _lifecycle_path(conversation_id)
-    with click_gate._state_lock():
+    with click_state.state_lock():
         lifecycle = _read_json(lifecycle_path)
         prompt, prompt_fingerprint = _latest_user_prompt(raw.get("transcriptPath"))
         epoch = int(lifecycle.get("execution_epoch", 0))
@@ -239,8 +240,8 @@ def _record_pre_invocation(raw: dict[str, Any]) -> dict[str, Any]:
             "awaiting_next_execution": awaiting_next,
             "updated_at": int(time.time()),
         }
-        click_gate._write_json(lifecycle_path, context)
-        click_gate._write_json(_workspace_context_path(workspace), context)
+        click_state.write_json(lifecycle_path, context)
+        click_state.write_json(_workspace_context_path(workspace), context)
         event = _canonical_event(context, prompt=prompt)
         payload = _capture(
             AntigravityOutputAdapter(), click_gate._handle_prompt_submit, event
@@ -436,7 +437,7 @@ def _pre_tool(raw: dict[str, Any]) -> dict[str, Any]:
             return {"decision": "allow"}
         if click_gate._is_read_only_bash(command):
             return _native_run_command_read_denial()
-    with click_gate._state_lock():
+    with click_state.state_lock():
         payload = _capture(
             AntigravityOutputAdapter(), click_gate._handle_pre_tool, event
         )
@@ -452,7 +453,7 @@ def _post_tool(raw: dict[str, Any]) -> dict[str, Any]:
 def _stop(raw: dict[str, Any]) -> dict[str, Any]:
     context = _context_for_raw(raw)
     if context:
-        with click_gate._state_lock():
+        with click_state.state_lock():
             _capture(
                 AntigravityOutputAdapter(),
                 click_gate._handle_session_end,
@@ -465,10 +466,10 @@ def _stop(raw: dict[str, Any]) -> dict[str, Any]:
                 context["awaiting_next_execution"] = True
                 context["last_stop_execution_num"] = raw.get("executionNum")
                 context["updated_at"] = int(time.time())
-                click_gate._write_json(
+                click_state.write_json(
                     _lifecycle_path(str(context["conversation_id"])), context
                 )
-                click_gate._write_json(
+                click_state.write_json(
                     _workspace_context_path(str(context["workspace"])), context
                 )
     return {"decision": "allow"}
@@ -493,7 +494,7 @@ def _control(arguments: list[str]) -> int:
             "tool_input": {"command": shlex.join(["click-gate", *arguments])},
         }
     )
-    with click_gate._state_lock():
+    with click_state.state_lock():
         payload = _capture(CodexOutputAdapter(), click_gate._handle_pre_tool, event)
     output = payload.get("hookSpecificOutput") if isinstance(payload, dict) else None
     if not isinstance(output, dict):

--- a/dist/antigravity/hooks/click_gate.py
+++ b/dist/antigravity/hooks/click_gate.py
@@ -13,7 +13,6 @@ and executed without a shell by inspect, mutate, and verify runners.
 from __future__ import annotations
 
 import base64
-from contextlib import contextmanager
 import hashlib
 import json
 import os
@@ -31,10 +30,40 @@ import zlib
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
-try:
+if __package__:
+    from .click_state import (
+        STATE_LOCK_STALE_SECONDS,
+        STATE_LOCK_TIMEOUT_SECONDS,
+        contract_path as _contract_path,
+        identity_path as _identity_path,
+        managed_state_path as _managed_state_path,
+        mode_path as _mode_path,
+        preference_path as _preference_path,
+        prompt_path as _prompt_path,
+        review_path as _review_path,
+        state_lock as _state_lock,
+        state_path as _state_path,
+        state_root as _state_root,
+        write_json as _write_json,
+    )
+    from .platform_protocol import CodexOutputAdapter, HookOutputAdapter
+else:  # Executed directly from the bundled hooks directory.
+    from click_state import (
+        STATE_LOCK_STALE_SECONDS,
+        STATE_LOCK_TIMEOUT_SECONDS,
+        contract_path as _contract_path,
+        identity_path as _identity_path,
+        managed_state_path as _managed_state_path,
+        mode_path as _mode_path,
+        preference_path as _preference_path,
+        prompt_path as _prompt_path,
+        review_path as _review_path,
+        state_lock as _state_lock,
+        state_path as _state_path,
+        state_root as _state_root,
+        write_json as _write_json,
+    )
     from platform_protocol import CodexOutputAdapter, HookOutputAdapter
-except ModuleNotFoundError:  # Imported as hooks.click_gate by tests or adapters.
-    from hooks.platform_protocol import CodexOutputAdapter, HookOutputAdapter
 
 
 CONTROL_COMMAND = "click-gate"
@@ -112,8 +141,6 @@ MUTATION_RUNNING_TTL_SECONDS = 10 * 60
 VERIFY_RUNNING_TTL_SECONDS = 60 * 60
 EPHEMERAL_STATE_TTL_SECONDS = 7 * 24 * 60 * 60
 COMPLETED_CONTRACT_TTL_SECONDS = 30 * 24 * 60 * 60
-STATE_LOCK_TIMEOUT_SECONDS = 5
-STATE_LOCK_STALE_SECONDS = 30
 DEFAULT_MODES = {"on", "manual"}
 SHELL_EXECUTABLES = {
     "bash",
@@ -451,125 +478,6 @@ def _read_event() -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError("hook input must be a JSON object")
     return value
-
-
-def _state_root() -> Path:
-    configured = os.environ.get("PLUGIN_DATA")
-    if configured:
-        return Path(configured) / "gate-state"
-    return Path(tempfile.gettempdir()) / "click-plugin-data" / "gate-state"
-
-
-def _preference_path() -> Path:
-    configured = os.environ.get("CLICK_CONFIG_HOME")
-    if configured:
-        return Path(configured) / "preferences.json"
-    if os.name == "nt":
-        base = os.environ.get("LOCALAPPDATA") or os.environ.get("APPDATA")
-        if base:
-            return Path(base) / "Click" / "preferences.json"
-    base = os.environ.get("XDG_CONFIG_HOME")
-    if base:
-        return Path(base) / "click" / "preferences.json"
-    return Path.home() / ".config" / "click" / "preferences.json"
-
-
-def _identity_path(event: dict[str, Any], scope: str) -> Path:
-    identity = {
-        "session_id": str(event.get("session_id", "")),
-        "cwd": str(event.get("cwd", "")),
-    }
-    if scope in {"turn", "review"}:
-        identity["turn_id"] = str(event.get("turn_id", ""))
-    encoded = json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
-    name = f"{scope}-{hashlib.sha256(encoded).hexdigest()}.json"
-    return _state_root() / name
-
-
-def _state_path(event: dict[str, Any]) -> Path:
-    return _identity_path(event, "turn")
-
-
-def _mode_path(event: dict[str, Any]) -> Path:
-    return _identity_path(event, "session")
-
-
-def _contract_path(event: dict[str, Any]) -> Path:
-    return _identity_path(event, "session-contract")
-
-
-def _prompt_path(event: dict[str, Any]) -> Path:
-    return _identity_path(event, "session-prompt")
-
-
-def _review_path(event: dict[str, Any]) -> Path:
-    return _identity_path(event, "review")
-
-
-def _write_json(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        encoding="utf-8",
-        dir=path.parent,
-        prefix=".gate-",
-        delete=False,
-    ) as handle:
-        json.dump(payload, handle, ensure_ascii=False, separators=(",", ":"))
-        temporary = Path(handle.name)
-    temporary.chmod(0o600)
-    os.replace(temporary, path)
-
-
-@contextmanager
-def _state_lock() -> Any:
-    root = _state_root()
-    root.mkdir(mode=0o700, parents=True, exist_ok=True)
-    lock_path = root / ".state.lock"
-    deadline = time.monotonic() + STATE_LOCK_TIMEOUT_SECONDS
-    descriptor: int | None = None
-    while descriptor is None:
-        try:
-            descriptor = os.open(
-                lock_path,
-                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
-                0o600,
-            )
-            os.write(descriptor, str(os.getpid()).encode())
-        except (FileExistsError, PermissionError) as exc:
-            # Windows can report an O_EXCL collision as EACCES while another
-            # process still owns the lock file. Treat that specific shape as
-            # contention and retry instead of failing the observation runner.
-            if (
-                isinstance(exc, PermissionError)
-                and os.name != "nt"
-                and not lock_path.exists()
-            ):
-                raise
-            try:
-                stale = time.time() - lock_path.stat().st_mtime > STATE_LOCK_STALE_SECONDS
-            except OSError:
-                stale = False
-            if stale:
-                try:
-                    lock_path.unlink()
-                except OSError:
-                    pass
-                else:
-                    continue
-            if time.monotonic() >= deadline:
-                raise OSError("timed out waiting for Click state lock")
-            time.sleep(0.025)
-    try:
-        yield
-    finally:
-        try:
-            os.close(descriptor)
-        finally:
-            try:
-                lock_path.unlink()
-            except OSError:
-                pass
 
 
 def _write_state(event: dict[str, Any], status: str, contract_digest: str = "") -> None:
@@ -4774,23 +4682,6 @@ def _managed_contract_path(path: Path) -> bool:
 
 def _managed_observation_path(path: Path) -> bool:
     return _managed_state_path(path, ("session-contract-", "review-"))
-
-
-def _managed_state_path(path: Path, prefixes: tuple[str, ...]) -> bool:
-    try:
-        if not path.is_absolute():
-            return False
-        resolved_path = path.resolve(strict=True)
-        lexical_path = Path(os.path.abspath(path))
-        resolved_root = _state_root().resolve(strict=True)
-        return (
-            lexical_path == resolved_path
-            and resolved_path.parent == resolved_root
-            and resolved_path.name.startswith(prefixes)
-            and resolved_path.suffix == ".json"
-        )
-    except (OSError, RuntimeError):
-        return False
 
 
 def _service_snapshot(path: Path, service_id: str) -> dict[str, Any] | None:

--- a/dist/antigravity/hooks/click_state.py
+++ b/dist/antigravity/hooks/click_state.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Filesystem identity, persistence, and locking for Click hook state.
+
+This module is intentionally unaware of contracts, capabilities, runners, and
+evidence semantics.  It is the lowest-level storage boundary shared by the
+Codex and Antigravity adapters.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import hashlib
+import json
+import os
+from pathlib import Path
+import tempfile
+import time
+from typing import Any, Iterator
+
+
+STATE_LOCK_TIMEOUT_SECONDS = 5
+STATE_LOCK_STALE_SECONDS = 30
+
+
+def state_root() -> Path:
+    configured = os.environ.get("PLUGIN_DATA")
+    if configured:
+        return Path(configured) / "gate-state"
+    return Path(tempfile.gettempdir()) / "click-plugin-data" / "gate-state"
+
+
+def preference_path() -> Path:
+    configured = os.environ.get("CLICK_CONFIG_HOME")
+    if configured:
+        return Path(configured) / "preferences.json"
+    if os.name == "nt":
+        base = os.environ.get("LOCALAPPDATA") or os.environ.get("APPDATA")
+        if base:
+            return Path(base) / "Click" / "preferences.json"
+    base = os.environ.get("XDG_CONFIG_HOME")
+    if base:
+        return Path(base) / "click" / "preferences.json"
+    return Path.home() / ".config" / "click" / "preferences.json"
+
+
+def identity_path(event: dict[str, Any], scope: str) -> Path:
+    identity = {
+        "session_id": str(event.get("session_id", "")),
+        "cwd": str(event.get("cwd", "")),
+    }
+    if scope in {"turn", "review"}:
+        identity["turn_id"] = str(event.get("turn_id", ""))
+    encoded = json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+    name = f"{scope}-{hashlib.sha256(encoded).hexdigest()}.json"
+    return state_root() / name
+
+
+def state_path(event: dict[str, Any]) -> Path:
+    return identity_path(event, "turn")
+
+
+def mode_path(event: dict[str, Any]) -> Path:
+    return identity_path(event, "session")
+
+
+def contract_path(event: dict[str, Any]) -> Path:
+    return identity_path(event, "session-contract")
+
+
+def prompt_path(event: dict[str, Any]) -> Path:
+    return identity_path(event, "session-prompt")
+
+
+def review_path(event: dict[str, Any]) -> Path:
+    return identity_path(event, "review")
+
+
+def managed_state_path(path: Path, prefixes: tuple[str, ...]) -> bool:
+    """Return whether *path* is one canonical managed state file."""
+    try:
+        if not path.is_absolute():
+            return False
+        resolved_path = path.resolve(strict=True)
+        lexical_path = Path(os.path.abspath(path))
+        resolved_root = state_root().resolve(strict=True)
+        return (
+            lexical_path == resolved_path
+            and resolved_path.parent == resolved_root
+            and resolved_path.name.startswith(prefixes)
+            and resolved_path.suffix == ".json"
+        )
+    except (OSError, RuntimeError):
+        return False
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=".gate-",
+        delete=False,
+    ) as handle:
+        json.dump(payload, handle, ensure_ascii=False, separators=(",", ":"))
+        temporary = Path(handle.name)
+    temporary.chmod(0o600)
+    os.replace(temporary, path)
+
+
+@contextmanager
+def state_lock() -> Iterator[None]:
+    root = state_root()
+    root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    lock_path = root / ".state.lock"
+    deadline = time.monotonic() + STATE_LOCK_TIMEOUT_SECONDS
+    descriptor: int | None = None
+    while descriptor is None:
+        try:
+            descriptor = os.open(
+                lock_path,
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                0o600,
+            )
+            os.write(descriptor, str(os.getpid()).encode())
+        except (FileExistsError, PermissionError) as exc:
+            # Windows can report an O_EXCL collision as EACCES while another
+            # process still owns the lock file. Treat that specific shape as
+            # contention and retry instead of failing the observation runner.
+            if (
+                isinstance(exc, PermissionError)
+                and os.name != "nt"
+                and not lock_path.exists()
+            ):
+                raise
+            try:
+                stale = time.time() - lock_path.stat().st_mtime > STATE_LOCK_STALE_SECONDS
+            except OSError:
+                stale = False
+            if stale:
+                try:
+                    lock_path.unlink()
+                except OSError:
+                    pass
+                else:
+                    continue
+            if time.monotonic() >= deadline:
+                raise OSError("timed out waiting for Click state lock")
+            time.sleep(0.025)
+    try:
+        yield
+    finally:
+        try:
+            os.close(descriptor)
+        finally:
+            try:
+                lock_path.unlink()
+            except OSError:
+                pass

--- a/dist/antigravity/hooks/click_state.py
+++ b/dist/antigravity/hooks/click_state.py
@@ -82,9 +82,12 @@ def managed_state_path(path: Path, prefixes: tuple[str, ...]) -> bool:
             return False
         resolved_path = path.resolve(strict=True)
         lexical_path = Path(os.path.abspath(path))
+        lexical_root = Path(os.path.abspath(state_root()))
         resolved_root = state_root().resolve(strict=True)
         return (
-            lexical_path == resolved_path
+            path == lexical_path
+            and lexical_path.parent == lexical_root
+            and not path.is_symlink()
             and resolved_path.parent == resolved_root
             and resolved_path.name.startswith(prefixes)
             and resolved_path.suffix == ".json"

--- a/dist/antigravity/hooks/click_state.py
+++ b/dist/antigravity/hooks/click_state.py
@@ -82,11 +82,9 @@ def managed_state_path(path: Path, prefixes: tuple[str, ...]) -> bool:
             return False
         resolved_path = path.resolve(strict=True)
         lexical_path = Path(os.path.abspath(path))
-        lexical_root = Path(os.path.abspath(state_root()))
         resolved_root = state_root().resolve(strict=True)
         return (
             path == lexical_path
-            and lexical_path.parent == lexical_root
             and not path.is_symlink()
             and resolved_path.parent == resolved_root
             and resolved_path.name.startswith(prefixes)

--- a/hooks/antigravity_gate.py
+++ b/hooks/antigravity_gate.py
@@ -18,12 +18,13 @@ import sys
 import time
 from typing import Any, Callable
 
-try:
+if __package__:
+    from . import click_gate, click_state
+    from .platform_protocol import AntigravityOutputAdapter, CodexOutputAdapter
+else:  # Executed directly from the bundled hooks directory.
     import click_gate
+    import click_state
     from platform_protocol import AntigravityOutputAdapter, CodexOutputAdapter
-except ModuleNotFoundError:  # Imported as hooks.antigravity_gate in tests.
-    from hooks import click_gate
-    from hooks.platform_protocol import AntigravityOutputAdapter, CodexOutputAdapter
 
 
 ANTIGRAVITY_TOOL_MAP = {
@@ -90,14 +91,14 @@ def _context_digest(value: str) -> str:
 
 
 def _lifecycle_path(conversation_id: str) -> Path:
-    return click_gate._state_root() / (
+    return click_state.state_root() / (
         f"antigravity-lifecycle-{_context_digest(conversation_id)}.json"
     )
 
 
 def _workspace_context_path(workspace: str) -> Path:
     normalized = str(Path(workspace).expanduser().resolve())
-    return click_gate._state_root() / (
+    return click_state.state_root() / (
         f"antigravity-workspace-{_context_digest(normalized)}.json"
     )
 
@@ -212,7 +213,7 @@ def _record_pre_invocation(raw: dict[str, Any]) -> dict[str, Any]:
     conversation_id = _conversation_id(raw)
     workspace = _workspace(raw)
     lifecycle_path = _lifecycle_path(conversation_id)
-    with click_gate._state_lock():
+    with click_state.state_lock():
         lifecycle = _read_json(lifecycle_path)
         prompt, prompt_fingerprint = _latest_user_prompt(raw.get("transcriptPath"))
         epoch = int(lifecycle.get("execution_epoch", 0))
@@ -239,8 +240,8 @@ def _record_pre_invocation(raw: dict[str, Any]) -> dict[str, Any]:
             "awaiting_next_execution": awaiting_next,
             "updated_at": int(time.time()),
         }
-        click_gate._write_json(lifecycle_path, context)
-        click_gate._write_json(_workspace_context_path(workspace), context)
+        click_state.write_json(lifecycle_path, context)
+        click_state.write_json(_workspace_context_path(workspace), context)
         event = _canonical_event(context, prompt=prompt)
         payload = _capture(
             AntigravityOutputAdapter(), click_gate._handle_prompt_submit, event
@@ -436,7 +437,7 @@ def _pre_tool(raw: dict[str, Any]) -> dict[str, Any]:
             return {"decision": "allow"}
         if click_gate._is_read_only_bash(command):
             return _native_run_command_read_denial()
-    with click_gate._state_lock():
+    with click_state.state_lock():
         payload = _capture(
             AntigravityOutputAdapter(), click_gate._handle_pre_tool, event
         )
@@ -452,7 +453,7 @@ def _post_tool(raw: dict[str, Any]) -> dict[str, Any]:
 def _stop(raw: dict[str, Any]) -> dict[str, Any]:
     context = _context_for_raw(raw)
     if context:
-        with click_gate._state_lock():
+        with click_state.state_lock():
             _capture(
                 AntigravityOutputAdapter(),
                 click_gate._handle_session_end,
@@ -465,10 +466,10 @@ def _stop(raw: dict[str, Any]) -> dict[str, Any]:
                 context["awaiting_next_execution"] = True
                 context["last_stop_execution_num"] = raw.get("executionNum")
                 context["updated_at"] = int(time.time())
-                click_gate._write_json(
+                click_state.write_json(
                     _lifecycle_path(str(context["conversation_id"])), context
                 )
-                click_gate._write_json(
+                click_state.write_json(
                     _workspace_context_path(str(context["workspace"])), context
                 )
     return {"decision": "allow"}
@@ -493,7 +494,7 @@ def _control(arguments: list[str]) -> int:
             "tool_input": {"command": shlex.join(["click-gate", *arguments])},
         }
     )
-    with click_gate._state_lock():
+    with click_state.state_lock():
         payload = _capture(CodexOutputAdapter(), click_gate._handle_pre_tool, event)
     output = payload.get("hookSpecificOutput") if isinstance(payload, dict) else None
     if not isinstance(output, dict):

--- a/hooks/click_gate.py
+++ b/hooks/click_gate.py
@@ -13,7 +13,6 @@ and executed without a shell by inspect, mutate, and verify runners.
 from __future__ import annotations
 
 import base64
-from contextlib import contextmanager
 import hashlib
 import json
 import os
@@ -31,10 +30,40 @@ import zlib
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
-try:
+if __package__:
+    from .click_state import (
+        STATE_LOCK_STALE_SECONDS,
+        STATE_LOCK_TIMEOUT_SECONDS,
+        contract_path as _contract_path,
+        identity_path as _identity_path,
+        managed_state_path as _managed_state_path,
+        mode_path as _mode_path,
+        preference_path as _preference_path,
+        prompt_path as _prompt_path,
+        review_path as _review_path,
+        state_lock as _state_lock,
+        state_path as _state_path,
+        state_root as _state_root,
+        write_json as _write_json,
+    )
+    from .platform_protocol import CodexOutputAdapter, HookOutputAdapter
+else:  # Executed directly from the bundled hooks directory.
+    from click_state import (
+        STATE_LOCK_STALE_SECONDS,
+        STATE_LOCK_TIMEOUT_SECONDS,
+        contract_path as _contract_path,
+        identity_path as _identity_path,
+        managed_state_path as _managed_state_path,
+        mode_path as _mode_path,
+        preference_path as _preference_path,
+        prompt_path as _prompt_path,
+        review_path as _review_path,
+        state_lock as _state_lock,
+        state_path as _state_path,
+        state_root as _state_root,
+        write_json as _write_json,
+    )
     from platform_protocol import CodexOutputAdapter, HookOutputAdapter
-except ModuleNotFoundError:  # Imported as hooks.click_gate by tests or adapters.
-    from hooks.platform_protocol import CodexOutputAdapter, HookOutputAdapter
 
 
 CONTROL_COMMAND = "click-gate"
@@ -112,8 +141,6 @@ MUTATION_RUNNING_TTL_SECONDS = 10 * 60
 VERIFY_RUNNING_TTL_SECONDS = 60 * 60
 EPHEMERAL_STATE_TTL_SECONDS = 7 * 24 * 60 * 60
 COMPLETED_CONTRACT_TTL_SECONDS = 30 * 24 * 60 * 60
-STATE_LOCK_TIMEOUT_SECONDS = 5
-STATE_LOCK_STALE_SECONDS = 30
 DEFAULT_MODES = {"on", "manual"}
 SHELL_EXECUTABLES = {
     "bash",
@@ -451,125 +478,6 @@ def _read_event() -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError("hook input must be a JSON object")
     return value
-
-
-def _state_root() -> Path:
-    configured = os.environ.get("PLUGIN_DATA")
-    if configured:
-        return Path(configured) / "gate-state"
-    return Path(tempfile.gettempdir()) / "click-plugin-data" / "gate-state"
-
-
-def _preference_path() -> Path:
-    configured = os.environ.get("CLICK_CONFIG_HOME")
-    if configured:
-        return Path(configured) / "preferences.json"
-    if os.name == "nt":
-        base = os.environ.get("LOCALAPPDATA") or os.environ.get("APPDATA")
-        if base:
-            return Path(base) / "Click" / "preferences.json"
-    base = os.environ.get("XDG_CONFIG_HOME")
-    if base:
-        return Path(base) / "click" / "preferences.json"
-    return Path.home() / ".config" / "click" / "preferences.json"
-
-
-def _identity_path(event: dict[str, Any], scope: str) -> Path:
-    identity = {
-        "session_id": str(event.get("session_id", "")),
-        "cwd": str(event.get("cwd", "")),
-    }
-    if scope in {"turn", "review"}:
-        identity["turn_id"] = str(event.get("turn_id", ""))
-    encoded = json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
-    name = f"{scope}-{hashlib.sha256(encoded).hexdigest()}.json"
-    return _state_root() / name
-
-
-def _state_path(event: dict[str, Any]) -> Path:
-    return _identity_path(event, "turn")
-
-
-def _mode_path(event: dict[str, Any]) -> Path:
-    return _identity_path(event, "session")
-
-
-def _contract_path(event: dict[str, Any]) -> Path:
-    return _identity_path(event, "session-contract")
-
-
-def _prompt_path(event: dict[str, Any]) -> Path:
-    return _identity_path(event, "session-prompt")
-
-
-def _review_path(event: dict[str, Any]) -> Path:
-    return _identity_path(event, "review")
-
-
-def _write_json(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        encoding="utf-8",
-        dir=path.parent,
-        prefix=".gate-",
-        delete=False,
-    ) as handle:
-        json.dump(payload, handle, ensure_ascii=False, separators=(",", ":"))
-        temporary = Path(handle.name)
-    temporary.chmod(0o600)
-    os.replace(temporary, path)
-
-
-@contextmanager
-def _state_lock() -> Any:
-    root = _state_root()
-    root.mkdir(mode=0o700, parents=True, exist_ok=True)
-    lock_path = root / ".state.lock"
-    deadline = time.monotonic() + STATE_LOCK_TIMEOUT_SECONDS
-    descriptor: int | None = None
-    while descriptor is None:
-        try:
-            descriptor = os.open(
-                lock_path,
-                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
-                0o600,
-            )
-            os.write(descriptor, str(os.getpid()).encode())
-        except (FileExistsError, PermissionError) as exc:
-            # Windows can report an O_EXCL collision as EACCES while another
-            # process still owns the lock file. Treat that specific shape as
-            # contention and retry instead of failing the observation runner.
-            if (
-                isinstance(exc, PermissionError)
-                and os.name != "nt"
-                and not lock_path.exists()
-            ):
-                raise
-            try:
-                stale = time.time() - lock_path.stat().st_mtime > STATE_LOCK_STALE_SECONDS
-            except OSError:
-                stale = False
-            if stale:
-                try:
-                    lock_path.unlink()
-                except OSError:
-                    pass
-                else:
-                    continue
-            if time.monotonic() >= deadline:
-                raise OSError("timed out waiting for Click state lock")
-            time.sleep(0.025)
-    try:
-        yield
-    finally:
-        try:
-            os.close(descriptor)
-        finally:
-            try:
-                lock_path.unlink()
-            except OSError:
-                pass
 
 
 def _write_state(event: dict[str, Any], status: str, contract_digest: str = "") -> None:
@@ -4774,23 +4682,6 @@ def _managed_contract_path(path: Path) -> bool:
 
 def _managed_observation_path(path: Path) -> bool:
     return _managed_state_path(path, ("session-contract-", "review-"))
-
-
-def _managed_state_path(path: Path, prefixes: tuple[str, ...]) -> bool:
-    try:
-        if not path.is_absolute():
-            return False
-        resolved_path = path.resolve(strict=True)
-        lexical_path = Path(os.path.abspath(path))
-        resolved_root = _state_root().resolve(strict=True)
-        return (
-            lexical_path == resolved_path
-            and resolved_path.parent == resolved_root
-            and resolved_path.name.startswith(prefixes)
-            and resolved_path.suffix == ".json"
-        )
-    except (OSError, RuntimeError):
-        return False
 
 
 def _service_snapshot(path: Path, service_id: str) -> dict[str, Any] | None:

--- a/hooks/click_state.py
+++ b/hooks/click_state.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Filesystem identity, persistence, and locking for Click hook state.
+
+This module is intentionally unaware of contracts, capabilities, runners, and
+evidence semantics.  It is the lowest-level storage boundary shared by the
+Codex and Antigravity adapters.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import hashlib
+import json
+import os
+from pathlib import Path
+import tempfile
+import time
+from typing import Any, Iterator
+
+
+STATE_LOCK_TIMEOUT_SECONDS = 5
+STATE_LOCK_STALE_SECONDS = 30
+
+
+def state_root() -> Path:
+    configured = os.environ.get("PLUGIN_DATA")
+    if configured:
+        return Path(configured) / "gate-state"
+    return Path(tempfile.gettempdir()) / "click-plugin-data" / "gate-state"
+
+
+def preference_path() -> Path:
+    configured = os.environ.get("CLICK_CONFIG_HOME")
+    if configured:
+        return Path(configured) / "preferences.json"
+    if os.name == "nt":
+        base = os.environ.get("LOCALAPPDATA") or os.environ.get("APPDATA")
+        if base:
+            return Path(base) / "Click" / "preferences.json"
+    base = os.environ.get("XDG_CONFIG_HOME")
+    if base:
+        return Path(base) / "click" / "preferences.json"
+    return Path.home() / ".config" / "click" / "preferences.json"
+
+
+def identity_path(event: dict[str, Any], scope: str) -> Path:
+    identity = {
+        "session_id": str(event.get("session_id", "")),
+        "cwd": str(event.get("cwd", "")),
+    }
+    if scope in {"turn", "review"}:
+        identity["turn_id"] = str(event.get("turn_id", ""))
+    encoded = json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+    name = f"{scope}-{hashlib.sha256(encoded).hexdigest()}.json"
+    return state_root() / name
+
+
+def state_path(event: dict[str, Any]) -> Path:
+    return identity_path(event, "turn")
+
+
+def mode_path(event: dict[str, Any]) -> Path:
+    return identity_path(event, "session")
+
+
+def contract_path(event: dict[str, Any]) -> Path:
+    return identity_path(event, "session-contract")
+
+
+def prompt_path(event: dict[str, Any]) -> Path:
+    return identity_path(event, "session-prompt")
+
+
+def review_path(event: dict[str, Any]) -> Path:
+    return identity_path(event, "review")
+
+
+def managed_state_path(path: Path, prefixes: tuple[str, ...]) -> bool:
+    """Return whether *path* is one canonical managed state file."""
+    try:
+        if not path.is_absolute():
+            return False
+        resolved_path = path.resolve(strict=True)
+        lexical_path = Path(os.path.abspath(path))
+        resolved_root = state_root().resolve(strict=True)
+        return (
+            lexical_path == resolved_path
+            and resolved_path.parent == resolved_root
+            and resolved_path.name.startswith(prefixes)
+            and resolved_path.suffix == ".json"
+        )
+    except (OSError, RuntimeError):
+        return False
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=".gate-",
+        delete=False,
+    ) as handle:
+        json.dump(payload, handle, ensure_ascii=False, separators=(",", ":"))
+        temporary = Path(handle.name)
+    temporary.chmod(0o600)
+    os.replace(temporary, path)
+
+
+@contextmanager
+def state_lock() -> Iterator[None]:
+    root = state_root()
+    root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    lock_path = root / ".state.lock"
+    deadline = time.monotonic() + STATE_LOCK_TIMEOUT_SECONDS
+    descriptor: int | None = None
+    while descriptor is None:
+        try:
+            descriptor = os.open(
+                lock_path,
+                os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                0o600,
+            )
+            os.write(descriptor, str(os.getpid()).encode())
+        except (FileExistsError, PermissionError) as exc:
+            # Windows can report an O_EXCL collision as EACCES while another
+            # process still owns the lock file. Treat that specific shape as
+            # contention and retry instead of failing the observation runner.
+            if (
+                isinstance(exc, PermissionError)
+                and os.name != "nt"
+                and not lock_path.exists()
+            ):
+                raise
+            try:
+                stale = time.time() - lock_path.stat().st_mtime > STATE_LOCK_STALE_SECONDS
+            except OSError:
+                stale = False
+            if stale:
+                try:
+                    lock_path.unlink()
+                except OSError:
+                    pass
+                else:
+                    continue
+            if time.monotonic() >= deadline:
+                raise OSError("timed out waiting for Click state lock")
+            time.sleep(0.025)
+    try:
+        yield
+    finally:
+        try:
+            os.close(descriptor)
+        finally:
+            try:
+                lock_path.unlink()
+            except OSError:
+                pass

--- a/hooks/click_state.py
+++ b/hooks/click_state.py
@@ -82,9 +82,12 @@ def managed_state_path(path: Path, prefixes: tuple[str, ...]) -> bool:
             return False
         resolved_path = path.resolve(strict=True)
         lexical_path = Path(os.path.abspath(path))
+        lexical_root = Path(os.path.abspath(state_root()))
         resolved_root = state_root().resolve(strict=True)
         return (
-            lexical_path == resolved_path
+            path == lexical_path
+            and lexical_path.parent == lexical_root
+            and not path.is_symlink()
             and resolved_path.parent == resolved_root
             and resolved_path.name.startswith(prefixes)
             and resolved_path.suffix == ".json"

--- a/hooks/click_state.py
+++ b/hooks/click_state.py
@@ -82,11 +82,9 @@ def managed_state_path(path: Path, prefixes: tuple[str, ...]) -> bool:
             return False
         resolved_path = path.resolve(strict=True)
         lexical_path = Path(os.path.abspath(path))
-        lexical_root = Path(os.path.abspath(state_root()))
         resolved_root = state_root().resolve(strict=True)
         return (
             path == lexical_path
-            and lexical_path.parent == lexical_root
             and not path.is_symlink()
             and resolved_path.parent == resolved_root
             and resolved_path.name.startswith(prefixes)

--- a/scripts/build_antigravity_distribution.py
+++ b/scripts/build_antigravity_distribution.py
@@ -13,6 +13,7 @@ DESTINATION = ROOT / "dist" / "antigravity"
 
 HOOK_FILES = (
     "__init__.py",
+    "click_state.py",
     "click_gate.py",
     "platform_protocol.py",
     "antigravity_gate.py",

--- a/tests/test_click_gate.py
+++ b/tests/test_click_gate.py
@@ -28,7 +28,11 @@ HOOK_CONFIG = Path(
 CLICK_GATE_SPEC = importlib.util.spec_from_file_location("click_gate_under_test", SCRIPT)
 assert CLICK_GATE_SPEC is not None and CLICK_GATE_SPEC.loader is not None
 CLICK_GATE = importlib.util.module_from_spec(CLICK_GATE_SPEC)
-CLICK_GATE_SPEC.loader.exec_module(CLICK_GATE)
+sys.path.insert(0, str(SCRIPT.parent.resolve()))
+try:
+    CLICK_GATE_SPEC.loader.exec_module(CLICK_GATE)
+finally:
+    sys.path.pop(0)
 
 
 def mark_git_boundary(root: Path) -> None:

--- a/tests/test_click_state.py
+++ b/tests/test_click_state.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import stat
+import tempfile
+import unittest
+from unittest import mock
+
+from hooks import click_gate, click_state
+
+
+class ClickStateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.plugin_data = Path(self.temporary.name) / "plugin-data"
+        self.config_home = Path(self.temporary.name) / "config"
+        self.environment = mock.patch.dict(
+            os.environ,
+            {
+                "PLUGIN_DATA": str(self.plugin_data),
+                "CLICK_CONFIG_HOME": str(self.config_home),
+            },
+        )
+        self.environment.start()
+        self.addCleanup(self.environment.stop)
+        self.event = {
+            "session_id": "session-1",
+            "turn_id": "turn-1",
+            "cwd": str(Path(self.temporary.name) / "workspace"),
+        }
+
+    def test_identity_paths_preserve_session_and_turn_scopes(self) -> None:
+        next_turn = {**self.event, "turn_id": "turn-2"}
+
+        self.assertNotEqual(
+            click_state.state_path(self.event), click_state.state_path(next_turn)
+        )
+        self.assertNotEqual(
+            click_state.review_path(self.event), click_state.review_path(next_turn)
+        )
+        for resolver in (
+            click_state.mode_path,
+            click_state.contract_path,
+            click_state.prompt_path,
+        ):
+            with self.subTest(resolver=resolver.__name__):
+                self.assertEqual(resolver(self.event), resolver(next_turn))
+
+        paths = (
+            click_state.state_path(self.event),
+            click_state.mode_path(self.event),
+            click_state.contract_path(self.event),
+            click_state.prompt_path(self.event),
+            click_state.review_path(self.event),
+        )
+        for path in paths:
+            with self.subTest(path=path.name):
+                self.assertEqual(path.parent, click_state.state_root())
+                self.assertNotIn("session-1", path.name)
+                self.assertNotIn("turn-1", path.name)
+
+    def test_write_json_atomically_replaces_content(self) -> None:
+        path = click_state.state_root() / "sample.json"
+        click_state.write_json(path, {"status": "first"})
+        click_state.write_json(path, {"status": "second", "revision": 2})
+
+        self.assertEqual(
+            json.loads(path.read_text(encoding="utf-8")),
+            {"status": "second", "revision": 2},
+        )
+        self.assertEqual(list(path.parent.glob(".gate-*")), [])
+        if os.name != "nt":
+            self.assertEqual(stat.S_IMODE(path.stat().st_mode), 0o600)
+
+    def test_managed_state_paths_reject_external_relative_and_symlink_paths(self) -> None:
+        managed = click_state.state_root() / "session-contract-managed.json"
+        click_state.write_json(managed, {"status": "approved"})
+        self.assertTrue(
+            click_state.managed_state_path(managed, ("session-contract-",))
+        )
+        self.assertFalse(
+            click_state.managed_state_path(
+                Path("session-contract-managed.json"), ("session-contract-",)
+            )
+        )
+
+        external = Path(self.temporary.name) / "session-contract-external.json"
+        external.write_text("{}", encoding="utf-8")
+        self.assertFalse(
+            click_state.managed_state_path(external, ("session-contract-",))
+        )
+        link = click_state.state_root() / "session-contract-link.json"
+        try:
+            link.symlink_to(external)
+        except (NotImplementedError, OSError):
+            pass
+        else:
+            self.assertFalse(
+                click_state.managed_state_path(link, ("session-contract-",))
+            )
+
+    def test_click_gate_keeps_compatibility_aliases_for_state_primitives(self) -> None:
+        aliases = {
+            "_state_root": click_state.state_root,
+            "_preference_path": click_state.preference_path,
+            "_identity_path": click_state.identity_path,
+            "_state_path": click_state.state_path,
+            "_mode_path": click_state.mode_path,
+            "_contract_path": click_state.contract_path,
+            "_managed_state_path": click_state.managed_state_path,
+            "_prompt_path": click_state.prompt_path,
+            "_review_path": click_state.review_path,
+            "_write_json": click_state.write_json,
+            "_state_lock": click_state.state_lock,
+        }
+        for name, expected in aliases.items():
+            with self.subTest(name=name):
+                self.assertIs(getattr(click_gate, name), expected)
+        self.assertEqual(
+            click_gate.STATE_LOCK_TIMEOUT_SECONDS,
+            click_state.STATE_LOCK_TIMEOUT_SECONDS,
+        )
+        self.assertEqual(
+            click_gate.STATE_LOCK_STALE_SECONDS,
+            click_state.STATE_LOCK_STALE_SECONDS,
+        )
+
+    def test_state_module_does_not_depend_on_click_gate(self) -> None:
+        source = Path(click_state.__file__).read_text(encoding="utf-8")
+        self.assertNotIn("import click_gate", source)
+        self.assertNotIn("from hooks import click_gate", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_click_state.py
+++ b/tests/test_click_state.py
@@ -59,8 +59,8 @@ class ClickStateTests(unittest.TestCase):
         for path in paths:
             with self.subTest(path=path.name):
                 self.assertEqual(path.parent, click_state.state_root())
-                self.assertNotIn("session-1", path.name)
-                self.assertNotIn("turn-1", path.name)
+                digest = path.stem.rsplit("-", 1)[-1]
+                self.assertRegex(digest, r"^[0-9a-f]{64}$")
 
     def test_write_json_atomically_replaces_content(self) -> None:
         path = click_state.state_root() / "sample.json"
@@ -80,6 +80,11 @@ class ClickStateTests(unittest.TestCase):
         click_state.write_json(managed, {"status": "approved"})
         self.assertTrue(
             click_state.managed_state_path(managed, ("session-contract-",))
+        )
+        self.assertTrue(
+            click_state.managed_state_path(
+                managed.resolve(strict=True), ("session-contract-",)
+            )
         )
         self.assertFalse(
             click_state.managed_state_path(

--- a/tests/test_distribution_validation.py
+++ b/tests/test_distribution_validation.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import json
+import os
 from pathlib import Path
+import subprocess
+import sys
+import tempfile
 import unittest
 
 from scripts.validate_distribution import _release_notes_error, validate
@@ -13,18 +18,58 @@ class DistributionValidationTests(unittest.TestCase):
     def test_public_distribution_is_self_consistent(self) -> None:
         self.assertEqual(validate(ROOT), [])
 
+    def test_source_and_antigravity_gate_load_only_sibling_runtime_modules(self) -> None:
+        hook_directories = (
+            ROOT / "hooks",
+            ROOT / "dist" / "antigravity" / "hooks",
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            isolated = Path(temporary)
+            event = {
+                "session_id": "distribution-smoke",
+                "turn_id": "turn-1",
+                "cwd": str(isolated),
+                "prompt": "inspect the project",
+            }
+            for index, hook_directory in enumerate(hook_directories):
+                with self.subTest(hook_directory=hook_directory):
+                    environment = os.environ.copy()
+                    environment.update(
+                        {
+                            "PLUGIN_DATA": str(isolated / f"plugin-data-{index}"),
+                            "CLICK_CONFIG_HOME": str(isolated / f"config-{index}"),
+                            "PYTHONNOUSERSITE": "1",
+                            "PYTHONPATH": str(hook_directory.resolve()),
+                        }
+                    )
+                    result = subprocess.run(
+                        [
+                            sys.executable,
+                            str((hook_directory / "click_gate.py").resolve()),
+                            "prompt-submit",
+                        ],
+                        input=json.dumps(event),
+                        cwd=isolated,
+                        env=environment,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                    )
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertIsInstance(json.loads(result.stdout), dict)
+
     def test_release_notes_allow_only_the_explicit_next_minor_candidate(self) -> None:
-        stable = "## v0.21.1 — 2026-08-30\n"
-        self.assertEqual(_release_notes_error(stable, "0.21.1"), "")
-        current = "## Unreleased v0.22 candidate — evidence\n\n## v0.21.1\n"
-        self.assertEqual(_release_notes_error(current, "0.21.1"), "")
+        stable = "## v0.22.0 — 2026-08-30\n"
+        self.assertEqual(_release_notes_error(stable, "0.22.0"), "")
+        current = "## Unreleased v0.23 candidate — evidence\n\n## v0.22.0\n"
+        self.assertEqual(_release_notes_error(current, "0.22.0"), "")
         for invalid in (
-            "## Unreleased — evidence\n\n## v0.21.1\n",
-            "## Unreleased v0.23 candidate\n\n## v0.21.1\n",
-            "## Unreleased v0.22 candidate\n## Unreleased v0.22 candidate — two\n## v0.21.1\n",
+            "## Unreleased — evidence\n\n## v0.22.0\n",
+            "## Unreleased v0.24 candidate\n\n## v0.22.0\n",
+            "## Unreleased v0.23 candidate\n## Unreleased v0.23 candidate — two\n## v0.22.0\n",
         ):
             with self.subTest(invalid=invalid):
-                self.assertIn("next-minor candidate", _release_notes_error(invalid, "0.21.1"))
+                self.assertIn("next-minor candidate", _release_notes_error(invalid, "0.22.0"))
 
 
 if __name__ == "__main__":

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -20,7 +20,7 @@ class RepositoryPolicyTests(unittest.TestCase):
             (ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
         )
         self.assertEqual(manifest["name"], "click")
-        self.assertEqual(manifest["version"], "0.21.1")
+        self.assertEqual(manifest["version"], "0.22.0")
         self.assertEqual(manifest["license"], "MIT")
         self.assertIn("always on", manifest["description"].lower())
         self.assertIn("manual", manifest["description"].lower())
@@ -251,7 +251,7 @@ class RepositoryPolicyTests(unittest.TestCase):
         self.assertEqual(marketplace["name"], "click")
         self.assertEqual(marketplace["plugins"][0]["name"], "click")
         self.assertEqual(
-            marketplace["plugins"][0]["source"]["ref"], "v0.21.1"
+            marketplace["plugins"][0]["source"]["ref"], "v0.22.0"
         )
 
     def test_ci_enforces_distribution_compilation_and_diff_validation(self) -> None:
@@ -266,14 +266,15 @@ class RepositoryPolicyTests(unittest.TestCase):
         self.assertIn("workflow_dispatch:", workflow)
         self.assertTrue((ROOT / "scripts" / "validate_distribution.py").is_file())
 
-    def test_release_documents_identify_v0211_and_preserve_v021_history(self) -> None:
+    def test_release_documents_identify_v0220_and_preserve_release_history(self) -> None:
         for readme_name in README_NAMES:
             with self.subTest(readme=readme_name):
                 readme = (ROOT / readme_name).read_text(encoding="utf-8")
-                self.assertIn("v0.21.1", readme)
+                self.assertIn("v0.22.0", readme)
                 self.assertIn("v0.21.0", readme)
                 self.assertIn("version-18", readme)
         notes = (ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8")
+        self.assertIn("## v0.22.0", notes)
         self.assertIn("## v0.21.1", notes)
         self.assertIn("## v0.21.0", notes)
         self.assertIn("## v0.20.0", notes)
@@ -419,11 +420,15 @@ class RepositoryPolicyTests(unittest.TestCase):
         self.assertIn("UserPromptSubmit", hook_config["hooks"])
 
     def test_runtime_hook_has_no_external_python_dependency(self) -> None:
-        source = (ROOT / "hooks" / "click_gate.py").read_text(encoding="utf-8")
-        for forbidden in ("requests", "yaml", "pydantic", "openai"):
-            with self.subTest(forbidden=forbidden):
-                self.assertNotIn(f"import {forbidden}", source)
-                self.assertNotIn(f"from {forbidden}", source)
+        sources = {
+            name: (ROOT / "hooks" / name).read_text(encoding="utf-8")
+            for name in ("click_gate.py", "click_state.py")
+        }
+        for name, source in sources.items():
+            for forbidden in ("requests", "yaml", "pydantic", "openai"):
+                with self.subTest(name=name, forbidden=forbidden):
+                    self.assertNotIn(f"import {forbidden}", source)
+                    self.assertNotIn(f"from {forbidden}", source)
 
     def test_compact_contract_replaces_the_verbose_execution_fields(self) -> None:
         hook = (ROOT / "hooks" / "click_gate.py").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- extract configuration paths, managed-state validation, atomic JSON persistence, and cross-process locking into `click_state.py`
- make Codex and experimental Antigravity adapters share the state-storage boundary without changing contract or evidence semantics
- harden Antigravity launcher parsing already prepared for v0.22.0
- publish aligned v0.22.0 manifest, marketplace ref, release notes, and multilingual upgrade docs

## Local verification

- `python3 -m unittest discover -s tests -v` — 243 tests passed, 1 platform-specific skip on Linux
- `python3 scripts/validate_distribution.py`
- plugin manifest validation
- Click and Fix skill validation
- `python3 -m compileall -q hooks dist/antigravity/hooks scripts tests`
- `git diff --check`

No contract or evidence schema migration is required.