### PR TITLE
Release Click v0.23.0 with process runner module

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/grapefruit0205/click.git",
-        "ref": "v0.22.0"
+        "ref": "v0.23.0"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "click",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Choose Always ON or @Click Manual. Click turns a software change into one compact plain-language execution contract, waits for approval, then keeps Codex inside that boundary with structured commands and only the primary evidence needed for completion—without repeated planning or repository-wide rescans.",
   "author": {
     "name": "Junseok Pak",

--- a/README.ko.md
+++ b/README.ko.md
@@ -60,7 +60,7 @@ launcher를 사용합니다. launcher는 확장 없는 단일 Bash 명령만 허
 가정하지 말고 정확한 제한은
 [`platforms/antigravity/README.md`](platforms/antigravity/README.md)를 확인하세요.
 
-## v0.22.0으로 업데이트
+## v0.23.0으로 업데이트
 
 Click을 이미 설치했다면 Git 마켓플레이스 스냅샷을 명시적으로 갱신하고 플러그인을 다시 설치해야 이번 버전이 적용됩니다.
 
@@ -69,7 +69,7 @@ codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-ChatGPT 데스크톱 앱을 다시 시작하고 갱신된 Click Hook을 검토해 신뢰한 뒤 새 작업을 시작합니다. 기존 모드 설정은 대상 저장소 밖에 그대로 유지됩니다. v0.22.0은 실험적인 Antigravity launcher 경계를 강화하고 공통 state 저장 primitive를 `click_state.py`로 분리하지만 계약이나 증거 schema는 바꾸지 않습니다. `click-gate`를 직접 호출한다면 계속 verify 프로토콜 버전 `2`를 사용하고 모든 check에 승인된 argv `evidence_id`를 넣으며, `pass`에는 발급된 `contract_id`만 전달하고 `done_when`은 구조화된 증거 참조를 사용합니다. 예전 설치가 만든 실행 대기 중 runner 명령은 재사용하지 말고, 갱신된 Hook이 새 명령을 발급하게 합니다.
+ChatGPT 데스크톱 앱을 다시 시작하고 갱신된 Click Hook을 검토해 신뢰한 뒤 새 작업을 시작합니다. 기존 모드 설정은 대상 저장소 밖에 그대로 유지됩니다. v0.23.0은 공통 shell-free 프로세스 실행, child group 격리·종료, 제한된 출력 복사를 `click_process.py`로 옮기며, 실행 파일 신뢰·Git/SSH 정책·계약·증거 의미는 gate에 그대로 둡니다. `click-gate`를 직접 호출한다면 계속 verify 프로토콜 버전 `2`를 사용하고 모든 check에 승인된 argv `evidence_id`를 넣으며, `pass`에는 발급된 `contract_id`만 전달하고 `done_when`은 구조화된 증거 참조를 사용합니다. 예전 설치가 만든 실행 대기 중 runner 명령은 재사용하지 말고, 갱신된 Hook이 새 명령을 발급하게 합니다.
 
 나중에 “Click을 Always ON으로 설정해줘” 또는 “Click을 Manual로 설정해줘”라고 바꿀 수 있고, 이 설정은 대상 저장소 밖에 유지됩니다. 정확히 한 turn만 우회하려면 사용자 프롬프트 첫 줄에 `@Click bypass` 또는 자동완성 형식인 `[@Click](plugin://click@click) bypass`를 씁니다. Hook은 같은 turn의 `click-gate bypass` 한 번만 승인하고 active 계약은 그대로 보존합니다. active 계약을 버릴 때는 같은 형식의 `cancel` 명령으로 `click-gate cancel` 한 번을 승인합니다. `@Click` 이름과 명령의 대소문자는 구분하지 않지만 plugin URI는 정확히 일치해야 하며, 명령 줄에 다른 문구를 붙일 수 없습니다. 실제 작업 내용은 둘째 줄부터 이어서 쓸 수 있습니다. 두 권한은 재사용하거나 다음 turn으로 가져갈 수 없습니다. Click은 프로젝트 안에 설정이나 계약 파일을 만들지 않습니다.
 
@@ -311,7 +311,7 @@ Click의 핵심 대상은 다음 두 그룹입니다.
 
 ## 근거와 솔직한 한계
 
-현재 공개 릴리스 v0.22.0은 결정적 suite를 release gate로 사용합니다. 영구 모드, turn 분리 승인, active-contract 잠금, 읽기·계획 anti-loop, ID가 결합된 argv 검증, 증거별 현재 revision 완료, Browser 수집 후 finalize, 외부 attestation의 정직한 한계, 관리형 서버 one-use launch claim과 종료, 저장소 제외 실행 파일 해석, state-root binding, 실행 전 runner claim, 강화된 Git 조회, Git snapshot fail-closed, process 격리, 검증 중 workspace 변경 감지, 공통 state 저장 경계, source·배포본의 sibling-only 시작, 배포 일관성, 저장소 정책을 검증 대상으로 둡니다.
+현재 공개 릴리스 v0.23.0은 결정적 suite를 release gate로 사용합니다. 영구 모드, turn 분리 승인, active-contract 잠금, 읽기·계획 anti-loop, ID가 결합된 argv 검증, 증거별 현재 revision 완료, Browser 수집 후 finalize, 외부 attestation의 정직한 한계, 관리형 서버 one-use launch claim과 종료, 저장소 제외 실행 파일 해석, state-root binding, 실행 전 runner claim, 강화된 Git 조회, Git snapshot fail-closed, process 격리, 검증 중 workspace 변경 감지, 공통 state 저장·process mechanics 경계, source·배포본의 sibling-only 시작, 배포 일관성, 저장소 정책을 검증 대상으로 둡니다.
 
 저장소에는 결정적 fixture 기반 정책 검토를 위한 version-18 golden case와 의미 grader도 포함되어 있습니다. 이 자료는 계약 형식과 기대 동작을 검사하며 runtime 생산성을 측정하지 않습니다.
 
@@ -332,7 +332,8 @@ skills/click/references/modes.md      영구 모드와 코드 리뷰 동작
 skills/click/references/capability-protocol.md  구조화 runner schema
 skills/fix/                           축약 수정 Skill
 hooks/click_state.py                  상태 경로·원자적 저장·잠금
-hooks/click_gate.py                   계약·capability·anti-loop·예산 의미 규칙
+hooks/click_process.py                shell-free 프로세스 실행·격리·종료
+hooks/click_gate.py                   계약 정책·capability 조율·anti-loop·예산
 hooks/hooks.json                      라이프사이클 Hook 설정
 evals/                                golden case·의미 grader
 tests/                                Hook·grader·정책 결정적 테스트

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ deduplicated. Browser evidence is not currently supported. See
 [`platforms/antigravity/README.md`](platforms/antigravity/README.md) for the
 exact limits instead of assuming full host parity.
 
-## Update to v0.22.0
+## Update to v0.23.0
 
 If Click is already installed, explicitly refresh its Git marketplace snapshot and reinstall the plugin to load this release:
 
@@ -74,7 +74,7 @@ codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-Restart the ChatGPT desktop app, review and trust the updated Click Hook, and start a new task. Existing mode preferences remain outside the target repository. v0.22.0 hardens the experimental Antigravity launcher boundary and moves shared state-storage primitives into `click_state.py`; it does not change the contract or evidence schema. Direct `click-gate` callers continue to use verification protocol version `2`, include an approved argv `evidence_id` on every check, pass only the emitted `contract_id`, and use structured `done_when` evidence references. Do not reuse a pending runner command created by an older installation; let the updated Hook issue a fresh rewritten command.
+Restart the ChatGPT desktop app, review and trust the updated Click Hook, and start a new task. Existing mode preferences remain outside the target repository. v0.23.0 moves shared shell-free process execution, child-group isolation and termination, and bounded output copying into `click_process.py`; executable trust, Git/SSH policy, contracts, and evidence semantics remain in the gate. Direct `click-gate` callers continue to use verification protocol version `2`, include an approved argv `evidence_id` on every check, pass only the emitted `contract_id`, and use structured `done_when` evidence references. Do not reuse a pending runner command created by an older installation; let the updated Hook issue a fresh rewritten command.
 
 You can later say “Set Click to Always ON” or “Set Click to Manual.” Those preferences persist outside the target repository. To bypass Click for exactly one turn, make the first line of that user prompt either `@Click bypass` or the autocomplete form `[@Click](plugin://click@click) bypass`; the Hook authorizes one same-turn `click-gate bypass` and keeps any active contract intact. Use the corresponding `cancel` form to authorize one same-turn `click-gate cancel` and discard the active contract. The `@Click` label and action are case-insensitive, but the plugin URI must match exactly and the directive line cannot contain extra text. The task may continue on later lines. Neither authorization is reusable or carries across turns. Click does not place preference or contract files in your project.
 
@@ -314,7 +314,7 @@ Manual mode or a per-turn bypass is usually better for tiny, obvious, reversible
 
 ## Evidence and honest limits
 
-The v0.22.0 source is release-gated by the deterministic suite. It covers persistent modes, distinct-turn approval, active-contract locking, read and plan anti-loops, evidence-bound argv verification, per-source current-revision completion, Browser observe-then-finalize behavior, explicit non-argv attestation limits, managed-service one-use launch claims and cleanup, repository-excluded executable resolution, state-root binding, pre-execution runner claims, hardened Git inspection, fail-closed Git snapshots, process isolation, verification-time workspace mutation detection, the shared state-storage boundary, sibling-only source/distribution startup, distribution consistency, and repository policy. Required CI runs the suite on Linux, macOS, and Windows; Ubuntu also validates the plugin, marketplace, Click/Fix skills, Python compilation, and whitespace errors.
+The v0.23.0 source is release-gated by the deterministic suite. It covers persistent modes, distinct-turn approval, active-contract locking, read and plan anti-loops, evidence-bound argv verification, per-source current-revision completion, Browser observe-then-finalize behavior, explicit non-argv attestation limits, managed-service one-use launch claims and cleanup, repository-excluded executable resolution, state-root binding, pre-execution runner claims, hardened Git inspection, fail-closed Git snapshots, process isolation, verification-time workspace mutation detection, the shared state-storage and process-mechanics boundaries, sibling-only source/distribution startup, distribution consistency, and repository policy. Required CI runs the suite on Linux, macOS, and Windows; Ubuntu also validates the plugin, marketplace, Click/Fix skills, Python compilation, and whitespace errors.
 
 The repository also includes version-18 golden cases and a semantic grader for deterministic fixture-based policy review. These artifacts check contract shape and expected behavior; they are not runtime productivity measurements.
 
@@ -335,7 +335,8 @@ skills/click/references/modes.md      Persistent mode and code-review behavior
 skills/click/references/capability-protocol.md  Structured runner schemas
 skills/fix/                           Compact repair Skill
 hooks/click_state.py                  State paths, atomic persistence, and locking
-hooks/click_gate.py                   Contract, capability, anti-loop, and budget semantics
+hooks/click_process.py                Shell-free process execution, isolation, and termination
+hooks/click_gate.py                   Contract policy, capability orchestration, anti-loop, and budgets
 hooks/hooks.json                      Lifecycle Hook configuration
 evals/                                Golden cases and semantic grader
 tests/                                Deterministic Hook, grader, and policy tests

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -60,7 +60,7 @@ launcher 只接受一条不含展开的 Bash 命令；命令串联、重定向�
 [`platforms/antigravity/README.md`](platforms/antigravity/README.md)了解准确
 限制，不要假设宿主功能完全等价。
 
-## 更新到 v0.22.0
+## 更新到 v0.23.0
 
 如果已经安装 Click，需要明确刷新 Git marketplace 快照并重新安装插件，才能加载本版本。
 
@@ -69,7 +69,7 @@ codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-重新启动 ChatGPT 桌面应用，检查并信任更新后的 Click Hook，然后开始一个新任务。现有模式偏好仍保存在目标仓库之外。v0.22.0 加固了实验性 Antigravity launcher 边界，并把共享状态存储 primitive 分离到 `click_state.py`，但不改变契约或证据 schema。直接调用 `click-gate` 时，继续使用 verify 协议版本 `2`，为每项检查提供已批准的 argv `evidence_id`，让 `pass` 只传递已签发的 `contract_id`，并使用结构化 `done_when` 证据引用。不要重复使用旧安装留下的待执行 runner 命令；应让更新后的 Hook 签发一条新命令。
+重新启动 ChatGPT 桌面应用，检查并信任更新后的 Click Hook，然后开始一个新任务。现有模式偏好仍保存在目标仓库之外。v0.23.0 把共享的无 shell 进程执行、子进程组隔离与终止以及有界输出复制移入 `click_process.py`；可执行文件信任、Git/SSH 策略、契约和证据语义仍留在 gate 中。直接调用 `click-gate` 时，继续使用 verify 协议版本 `2`，为每项检查提供已批准的 argv `evidence_id`，让 `pass` 只传递已签发的 `contract_id`，并使用结构化 `done_when` 证据引用。不要重复使用旧安装留下的待执行 runner 命令；应让更新后的 Hook 签发一条新命令。
 
 之后你可以说“Set Click to Always ON”或“Set Click to Manual”，这些偏好会持久保存在目标仓库之外。若只想绕过一个 turn，请把用户提示的第一行写成 `@Click bypass`，或使用自动补全形式 `[@Click](plugin://click@click) bypass`；Hook 只授权同一 turn 的一次 `click-gate bypass`，并保留活动契约。要丢弃活动契约，请使用对应的 `cancel` 形式来授权一次 `click-gate cancel`。`@Click` 标签和动作不区分大小写，但 plugin URI 必须完全匹配，指令行不能包含其他文字；实际任务可以从第二行继续。两种授权都不能重复使用或带到下一个 turn。Click 不会把偏好或契约文件放进你的项目。
 
@@ -318,7 +318,7 @@ Click 面向两类用户：
 
 ## 证据与诚实边界
 
-当前公开版本 v0.22.0 使用确定性 suite 作为 release gate，验证持久模式、跨 turn 批准、active-contract 锁、读取与 plan 防循环、verify v2 的 evidence-id 绑定、逐来源 completion ledger、Browser observe-then-finalize、非 argv attestation 边界、受管服务器的一次性 launch claim 与清理、排除仓库路径的可执行程序解析、state-root binding、runner 执行前 claim、加固的 Git 读取、Git snapshot fail-closed、process 隔离、验证期间 workspace mutation 检测、共享状态存储边界、源代码与分发版本的 sibling-only 启动、分发一致性和仓库策略。
+当前公开版本 v0.23.0 使用确定性 suite 作为 release gate，验证持久模式、跨 turn 批准、active-contract 锁、读取与 plan 防循环、verify v2 的 evidence-id 绑定、逐来源 completion ledger、Browser observe-then-finalize、非 argv attestation 边界、受管服务器的一次性 launch claim 与清理、排除仓库路径的可执行程序解析、state-root binding、runner 执行前 claim、加固的 Git 读取、Git snapshot fail-closed、process 隔离、验证期间 workspace mutation 检测、共享状态存储与 process mechanics 边界、源代码与分发版本的 sibling-only 启动、分发一致性和仓库策略。
 
 仓库还包含用于确定性 fixture 策略审查的 version-18 golden cases 和 semantic grader。这些资料检查契约结构与预期行为，并不测量 runtime 生产力。
 
@@ -339,7 +339,8 @@ skills/click/references/modes.md      持久模式与代码审查行为
 skills/click/references/capability-protocol.md  结构化 runner schema
 skills/fix/                           精简修复 Skill
 hooks/click_state.py                  状态路径、原子持久化与锁
-hooks/click_gate.py                   契约、capability、防循环和预算语义
+hooks/click_process.py                无 shell 的进程执行、隔离与终止
+hooks/click_gate.py                   契约策略、capability 编排、防循环与预算
 hooks/hooks.json                      生命周期 Hook 配置
 evals/                                Golden cases 和 semantic grader
 tests/                                确定性 Hook、grader 和策略测试

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,40 @@
 # Release notes
 
+## v0.23.0 — 2026-08-30
+
+Click v0.23.0 extracts the shared shell-free process mechanics into a small,
+standard-library-only module. Contract JSON, evidence protocol, modes, approval
+behavior, executable trust, and Git/SSH policy remain unchanged.
+
+### Shared process boundary
+
+- `click_process.py` now owns synchronous argv execution, managed-process
+  spawning, platform-specific child-process-group isolation and termination,
+  and bounded runner-output copying.
+- Every shared runner still executes an already-authorized argv with
+  `shell=False`; synchronous execution also remains `check=False`. The gate
+  continues to resolve trusted executables and construct sanitized environments
+  before invoking this process layer.
+- `click_gate.py` retains contract and capability policy, state transitions,
+  one-use runner claims, Git/SSH restrictions, service and verification
+  orchestration, workspace snapshots, budgets, and evidence semantics.
+  Compatibility aliases preserve the existing internal test and direct-caller
+  surface while modularization proceeds incrementally.
+- Evidence-ledger modularization is intentionally not included in this release;
+  verification protocol version `2` and its stored completion state are unchanged.
+
+### Distribution and release gate
+
+- Codex and the generated Antigravity distribution bundle the same
+  `click_process.py` and `click_gate.py` sources. Antigravity's adapter-specific
+  host launcher remains separate because its lifecycle semantics differ.
+- Dedicated regressions cover POSIX and Windows isolation, graceful and forced
+  termination paths, shell-free run/spawn calls, bounded output, one-way module
+  dependencies, and sibling-only distribution startup.
+- The exact release candidate is gated by the deterministic suite on Linux,
+  macOS, and Windows plus plugin, marketplace, skill, compilation, whitespace,
+  distribution-consistency, and Plugin Security Scan checks.
+
 ## v0.22.0 — 2026-08-30
 
 Click v0.22.0 hardens the experimental Antigravity adapter and extracts the

--- a/dist/antigravity/hooks/click_gate.py
+++ b/dist/antigravity/hooks/click_gate.py
@@ -21,7 +21,6 @@ import re
 import secrets
 import shlex
 import shutil
-import signal
 import subprocess
 import sys
 import tempfile
@@ -31,6 +30,7 @@ from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
 if __package__:
+    from . import click_process
     from .click_state import (
         STATE_LOCK_STALE_SECONDS,
         STATE_LOCK_TIMEOUT_SECONDS,
@@ -48,6 +48,7 @@ if __package__:
     )
     from .platform_protocol import CodexOutputAdapter, HookOutputAdapter
 else:  # Executed directly from the bundled hooks directory.
+    import click_process
     from click_state import (
         STATE_LOCK_STALE_SECONDS,
         STATE_LOCK_TIMEOUT_SECONDS,
@@ -64,6 +65,13 @@ else:  # Executed directly from the bundled hooks directory.
         write_json as _write_json,
     )
     from platform_protocol import CodexOutputAdapter, HookOutputAdapter
+
+
+# Compatibility aliases for direct callers and the existing deterministic
+# suite. Runtime process mechanics live in the one-way click_process boundary.
+_copy_limited_output = click_process.copy_limited_output
+_isolated_subprocess_kwargs = click_process.isolated_subprocess_kwargs
+_terminate_managed_child = click_process.terminate_process_group
 
 
 CONTROL_COMMAND = "click-gate"
@@ -4017,18 +4025,6 @@ def _record_observation_result(
     return True
 
 
-def _copy_limited_output(handle: Any, target: Any, remaining: int) -> int:
-    copied = 0
-    while copied < remaining:
-        chunk = handle.read(min(16_384, remaining - copied))
-        if not chunk:
-            break
-        target.write(chunk)
-        target.flush()
-        copied += len(chunk)
-    return copied
-
-
 def _decode_encoded_request(encoded: str, label: str) -> tuple[str, str]:
     try:
         return base64.urlsafe_b64decode(encoded.encode()).decode(), ""
@@ -4238,12 +4234,6 @@ def _execution_argv(argv: list[str]) -> list[str]:
     ]
 
 
-def _isolated_subprocess_kwargs() -> dict[str, Any]:
-    if os.name == "nt":
-        return {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
-    return {"start_new_session": True}
-
-
 def _is_git_remote_output_request(argv: list[str]) -> bool:
     parts = _structured_ssh_parts(argv)
     git_argv = parts[1] if parts is not None else argv
@@ -4303,7 +4293,7 @@ def _execute_argv_commands(
                     )
                     return 2
                 execution_argv[0] = executable
-            result = subprocess.run(
+            result = click_process.run_argv(
                 execution_argv,
                 stdout=subprocess.PIPE if redact else stdout_file,
                 stderr=subprocess.PIPE if redact else stderr_file,
@@ -4312,8 +4302,6 @@ def _execute_argv_commands(
                     if trusted_read_only
                     else None
                 ),
-                check=False,
-                **_isolated_subprocess_kwargs(),
             )
             if redact:
                 _write_runner_stream(
@@ -4404,13 +4392,11 @@ def _execute_read_only_git(
     safe_argv[0] = executable
     try:
         redact = _is_git_remote_output_request(argv)
-        result = subprocess.run(
+        result = click_process.run_argv(
             safe_argv,
             stdout=subprocess.PIPE if redact else stdout_file,
             stderr=subprocess.PIPE if redact else stderr_file,
             env=_sanitized_git_environment(workspace=workspace),
-            check=False,
-            **_isolated_subprocess_kwargs(),
         )
         if redact:
             _write_runner_stream(
@@ -4788,30 +4774,6 @@ def _claim_service_runner(
     return ""
 
 
-def _terminate_managed_child(child: subprocess.Popen[Any]) -> int:
-    if child.poll() is not None:
-        return int(child.returncode or 0)
-    try:
-        if os.name == "nt":
-            ctrl_break = getattr(signal, "CTRL_BREAK_EVENT", None)
-            if ctrl_break is not None:
-                child.send_signal(ctrl_break)
-            else:
-                child.terminate()
-        else:
-            os.killpg(child.pid, signal.SIGTERM)
-        return int(child.wait(timeout=3))
-    except (OSError, subprocess.TimeoutExpired):
-        try:
-            if os.name == "nt":
-                child.kill()
-            else:
-                os.killpg(child.pid, signal.SIGKILL)
-            return int(child.wait(timeout=3))
-        except (OSError, subprocess.TimeoutExpired):
-            return 1
-
-
 def _run_service_supervisor(arguments: list[str]) -> int:
     if len(arguments) != 5:
         return 2
@@ -4846,14 +4808,13 @@ def _run_service_supervisor(arguments: list[str]) -> int:
             )
         return 2
     try:
-        child = subprocess.Popen(
+        child = click_process.spawn_argv(
             _execution_argv(request["argv"]),
             cwd=cwd,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             close_fds=True,
-            **_isolated_subprocess_kwargs(),
         )
     except OSError:
         with _state_lock():
@@ -4953,13 +4914,12 @@ def _run_service_start(arguments: list[str]) -> int:
         encoded,
     ]
     try:
-        subprocess.Popen(
+        click_process.spawn_argv(
             supervisor,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             close_fds=True,
-            **_isolated_subprocess_kwargs(),
         )
     except OSError as exc:
         with _state_lock():
@@ -5020,7 +4980,7 @@ def _git_capture(cwd: Path, arguments: list[str]) -> bytes | None:
     if error or executable is None:
         return None
     try:
-        result = subprocess.run(
+        result = click_process.run_argv(
             [
                 executable,
                 "--no-pager",
@@ -5033,8 +4993,6 @@ def _git_capture(cwd: Path, arguments: list[str]) -> bytes | None:
             env=_sanitized_git_environment(workspace=cwd),
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
-            check=False,
-            **_isolated_subprocess_kwargs(),
         )
     except OSError:
         return None

--- a/dist/antigravity/hooks/click_process.py
+++ b/dist/antigravity/hooks/click_process.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Shell-free operating-system process mechanics for Click runners.
+
+This module deliberately knows nothing about contracts, capabilities, trusted
+executables, Git/SSH policy, state claims, or evidence. Callers must complete
+those decisions before passing an argv sequence here.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import signal
+import subprocess
+from typing import Any, Mapping, Sequence
+
+
+def isolated_subprocess_kwargs() -> dict[str, Any]:
+    if os.name == "nt":
+        return {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+    return {"start_new_session": True}
+
+
+def run_argv(
+    argv: Sequence[str],
+    *,
+    cwd: str | Path | None = None,
+    env: Mapping[str, str] | None = None,
+    stdin: Any | None = None,
+    stdout: Any | None = None,
+    stderr: Any | None = None,
+) -> subprocess.CompletedProcess[Any]:
+    """Run one already-authorized argv without a shell in an isolated group."""
+    return subprocess.run(
+        list(argv),
+        cwd=cwd,
+        env=env,
+        stdin=stdin,
+        stdout=stdout,
+        stderr=stderr,
+        check=False,
+        shell=False,
+        **isolated_subprocess_kwargs(),
+    )
+
+
+def spawn_argv(
+    argv: Sequence[str],
+    *,
+    cwd: str | Path | None = None,
+    env: Mapping[str, str] | None = None,
+    stdin: Any | None = None,
+    stdout: Any | None = None,
+    stderr: Any | None = None,
+    close_fds: bool = True,
+) -> subprocess.Popen[Any]:
+    """Spawn one already-authorized argv without a shell in an isolated group."""
+    return subprocess.Popen(
+        list(argv),
+        cwd=cwd,
+        env=env,
+        stdin=stdin,
+        stdout=stdout,
+        stderr=stderr,
+        close_fds=close_fds,
+        shell=False,
+        **isolated_subprocess_kwargs(),
+    )
+
+
+def terminate_process_group(
+    child: subprocess.Popen[Any], *, grace_seconds: float = 3.0
+) -> int:
+    """Stop an isolated child group, escalating once when graceful stop fails."""
+    if child.poll() is not None:
+        return int(child.returncode or 0)
+    try:
+        if os.name == "nt":
+            ctrl_break = getattr(signal, "CTRL_BREAK_EVENT", None)
+            if ctrl_break is not None:
+                child.send_signal(ctrl_break)
+            else:
+                child.terminate()
+        else:
+            os.killpg(child.pid, signal.SIGTERM)
+        return int(child.wait(timeout=grace_seconds))
+    except (OSError, subprocess.TimeoutExpired):
+        try:
+            if os.name == "nt":
+                child.kill()
+            else:
+                os.killpg(child.pid, signal.SIGKILL)
+            return int(child.wait(timeout=grace_seconds))
+        except (OSError, subprocess.TimeoutExpired):
+            return 1
+
+
+def copy_limited_output(
+    source: Any,
+    target: Any,
+    remaining: int,
+    *,
+    chunk_size: int = 16_384,
+) -> int:
+    """Copy at most *remaining* bytes and return the number actually copied."""
+    copied = 0
+    while copied < remaining:
+        chunk = source.read(min(chunk_size, remaining - copied))
+        if not chunk:
+            break
+        target.write(chunk)
+        target.flush()
+        copied += len(chunk)
+    return copied

--- a/hooks/click_gate.py
+++ b/hooks/click_gate.py
@@ -21,7 +21,6 @@ import re
 import secrets
 import shlex
 import shutil
-import signal
 import subprocess
 import sys
 import tempfile
@@ -31,6 +30,7 @@ from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
 if __package__:
+    from . import click_process
     from .click_state import (
         STATE_LOCK_STALE_SECONDS,
         STATE_LOCK_TIMEOUT_SECONDS,
@@ -48,6 +48,7 @@ if __package__:
     )
     from .platform_protocol import CodexOutputAdapter, HookOutputAdapter
 else:  # Executed directly from the bundled hooks directory.
+    import click_process
     from click_state import (
         STATE_LOCK_STALE_SECONDS,
         STATE_LOCK_TIMEOUT_SECONDS,
@@ -64,6 +65,13 @@ else:  # Executed directly from the bundled hooks directory.
         write_json as _write_json,
     )
     from platform_protocol import CodexOutputAdapter, HookOutputAdapter
+
+
+# Compatibility aliases for direct callers and the existing deterministic
+# suite. Runtime process mechanics live in the one-way click_process boundary.
+_copy_limited_output = click_process.copy_limited_output
+_isolated_subprocess_kwargs = click_process.isolated_subprocess_kwargs
+_terminate_managed_child = click_process.terminate_process_group
 
 
 CONTROL_COMMAND = "click-gate"
@@ -4017,18 +4025,6 @@ def _record_observation_result(
     return True
 
 
-def _copy_limited_output(handle: Any, target: Any, remaining: int) -> int:
-    copied = 0
-    while copied < remaining:
-        chunk = handle.read(min(16_384, remaining - copied))
-        if not chunk:
-            break
-        target.write(chunk)
-        target.flush()
-        copied += len(chunk)
-    return copied
-
-
 def _decode_encoded_request(encoded: str, label: str) -> tuple[str, str]:
     try:
         return base64.urlsafe_b64decode(encoded.encode()).decode(), ""
@@ -4238,12 +4234,6 @@ def _execution_argv(argv: list[str]) -> list[str]:
     ]
 
 
-def _isolated_subprocess_kwargs() -> dict[str, Any]:
-    if os.name == "nt":
-        return {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
-    return {"start_new_session": True}
-
-
 def _is_git_remote_output_request(argv: list[str]) -> bool:
     parts = _structured_ssh_parts(argv)
     git_argv = parts[1] if parts is not None else argv
@@ -4303,7 +4293,7 @@ def _execute_argv_commands(
                     )
                     return 2
                 execution_argv[0] = executable
-            result = subprocess.run(
+            result = click_process.run_argv(
                 execution_argv,
                 stdout=subprocess.PIPE if redact else stdout_file,
                 stderr=subprocess.PIPE if redact else stderr_file,
@@ -4312,8 +4302,6 @@ def _execute_argv_commands(
                     if trusted_read_only
                     else None
                 ),
-                check=False,
-                **_isolated_subprocess_kwargs(),
             )
             if redact:
                 _write_runner_stream(
@@ -4404,13 +4392,11 @@ def _execute_read_only_git(
     safe_argv[0] = executable
     try:
         redact = _is_git_remote_output_request(argv)
-        result = subprocess.run(
+        result = click_process.run_argv(
             safe_argv,
             stdout=subprocess.PIPE if redact else stdout_file,
             stderr=subprocess.PIPE if redact else stderr_file,
             env=_sanitized_git_environment(workspace=workspace),
-            check=False,
-            **_isolated_subprocess_kwargs(),
         )
         if redact:
             _write_runner_stream(
@@ -4788,30 +4774,6 @@ def _claim_service_runner(
     return ""
 
 
-def _terminate_managed_child(child: subprocess.Popen[Any]) -> int:
-    if child.poll() is not None:
-        return int(child.returncode or 0)
-    try:
-        if os.name == "nt":
-            ctrl_break = getattr(signal, "CTRL_BREAK_EVENT", None)
-            if ctrl_break is not None:
-                child.send_signal(ctrl_break)
-            else:
-                child.terminate()
-        else:
-            os.killpg(child.pid, signal.SIGTERM)
-        return int(child.wait(timeout=3))
-    except (OSError, subprocess.TimeoutExpired):
-        try:
-            if os.name == "nt":
-                child.kill()
-            else:
-                os.killpg(child.pid, signal.SIGKILL)
-            return int(child.wait(timeout=3))
-        except (OSError, subprocess.TimeoutExpired):
-            return 1
-
-
 def _run_service_supervisor(arguments: list[str]) -> int:
     if len(arguments) != 5:
         return 2
@@ -4846,14 +4808,13 @@ def _run_service_supervisor(arguments: list[str]) -> int:
             )
         return 2
     try:
-        child = subprocess.Popen(
+        child = click_process.spawn_argv(
             _execution_argv(request["argv"]),
             cwd=cwd,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             close_fds=True,
-            **_isolated_subprocess_kwargs(),
         )
     except OSError:
         with _state_lock():
@@ -4953,13 +4914,12 @@ def _run_service_start(arguments: list[str]) -> int:
         encoded,
     ]
     try:
-        subprocess.Popen(
+        click_process.spawn_argv(
             supervisor,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             close_fds=True,
-            **_isolated_subprocess_kwargs(),
         )
     except OSError as exc:
         with _state_lock():
@@ -5020,7 +4980,7 @@ def _git_capture(cwd: Path, arguments: list[str]) -> bytes | None:
     if error or executable is None:
         return None
     try:
-        result = subprocess.run(
+        result = click_process.run_argv(
             [
                 executable,
                 "--no-pager",
@@ -5033,8 +4993,6 @@ def _git_capture(cwd: Path, arguments: list[str]) -> bytes | None:
             env=_sanitized_git_environment(workspace=cwd),
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
-            check=False,
-            **_isolated_subprocess_kwargs(),
         )
     except OSError:
         return None

--- a/hooks/click_process.py
+++ b/hooks/click_process.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Shell-free operating-system process mechanics for Click runners.
+
+This module deliberately knows nothing about contracts, capabilities, trusted
+executables, Git/SSH policy, state claims, or evidence. Callers must complete
+those decisions before passing an argv sequence here.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import signal
+import subprocess
+from typing import Any, Mapping, Sequence
+
+
+def isolated_subprocess_kwargs() -> dict[str, Any]:
+    if os.name == "nt":
+        return {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+    return {"start_new_session": True}
+
+
+def run_argv(
+    argv: Sequence[str],
+    *,
+    cwd: str | Path | None = None,
+    env: Mapping[str, str] | None = None,
+    stdin: Any | None = None,
+    stdout: Any | None = None,
+    stderr: Any | None = None,
+) -> subprocess.CompletedProcess[Any]:
+    """Run one already-authorized argv without a shell in an isolated group."""
+    return subprocess.run(
+        list(argv),
+        cwd=cwd,
+        env=env,
+        stdin=stdin,
+        stdout=stdout,
+        stderr=stderr,
+        check=False,
+        shell=False,
+        **isolated_subprocess_kwargs(),
+    )
+
+
+def spawn_argv(
+    argv: Sequence[str],
+    *,
+    cwd: str | Path | None = None,
+    env: Mapping[str, str] | None = None,
+    stdin: Any | None = None,
+    stdout: Any | None = None,
+    stderr: Any | None = None,
+    close_fds: bool = True,
+) -> subprocess.Popen[Any]:
+    """Spawn one already-authorized argv without a shell in an isolated group."""
+    return subprocess.Popen(
+        list(argv),
+        cwd=cwd,
+        env=env,
+        stdin=stdin,
+        stdout=stdout,
+        stderr=stderr,
+        close_fds=close_fds,
+        shell=False,
+        **isolated_subprocess_kwargs(),
+    )
+
+
+def terminate_process_group(
+    child: subprocess.Popen[Any], *, grace_seconds: float = 3.0
+) -> int:
+    """Stop an isolated child group, escalating once when graceful stop fails."""
+    if child.poll() is not None:
+        return int(child.returncode or 0)
+    try:
+        if os.name == "nt":
+            ctrl_break = getattr(signal, "CTRL_BREAK_EVENT", None)
+            if ctrl_break is not None:
+                child.send_signal(ctrl_break)
+            else:
+                child.terminate()
+        else:
+            os.killpg(child.pid, signal.SIGTERM)
+        return int(child.wait(timeout=grace_seconds))
+    except (OSError, subprocess.TimeoutExpired):
+        try:
+            if os.name == "nt":
+                child.kill()
+            else:
+                os.killpg(child.pid, signal.SIGKILL)
+            return int(child.wait(timeout=grace_seconds))
+        except (OSError, subprocess.TimeoutExpired):
+            return 1
+
+
+def copy_limited_output(
+    source: Any,
+    target: Any,
+    remaining: int,
+    *,
+    chunk_size: int = 16_384,
+) -> int:
+    """Copy at most *remaining* bytes and return the number actually copied."""
+    copied = 0
+    while copied < remaining:
+        chunk = source.read(min(chunk_size, remaining - copied))
+        if not chunk:
+            break
+        target.write(chunk)
+        target.flush()
+        copied += len(chunk)
+    return copied

--- a/scripts/build_antigravity_distribution.py
+++ b/scripts/build_antigravity_distribution.py
@@ -13,6 +13,7 @@ DESTINATION = ROOT / "dist" / "antigravity"
 
 HOOK_FILES = (
     "__init__.py",
+    "click_process.py",
     "click_state.py",
     "click_gate.py",
     "platform_protocol.py",

--- a/tests/test_click_gate.py
+++ b/tests/test_click_gate.py
@@ -34,6 +34,8 @@ try:
 finally:
     sys.path.pop(0)
 
+CLICK_PROCESS = CLICK_GATE.click_process
+
 
 def mark_git_boundary(root: Path) -> None:
     marker = root / ".git"
@@ -1256,15 +1258,15 @@ class ClickGateTests(unittest.TestCase):
         self.assertEqual(error, "")
 
     def test_subprocess_isolation_kwargs_are_platform_specific(self) -> None:
-        with mock.patch.object(CLICK_GATE.os, "name", "posix"):
+        with mock.patch.object(CLICK_PROCESS.os, "name", "posix"):
             self.assertEqual(
                 CLICK_GATE._isolated_subprocess_kwargs(),
                 {"start_new_session": True},
             )
         with (
-            mock.patch.object(CLICK_GATE.os, "name", "nt"),
+            mock.patch.object(CLICK_PROCESS.os, "name", "nt"),
             mock.patch.object(
-                CLICK_GATE.subprocess,
+                CLICK_PROCESS.subprocess,
                 "CREATE_NEW_PROCESS_GROUP",
                 512,
                 create=True,
@@ -1279,9 +1281,11 @@ class ClickGateTests(unittest.TestCase):
         isolated = {"start_new_session": True}
         with (
             mock.patch.object(
-                CLICK_GATE, "_isolated_subprocess_kwargs", return_value=isolated
+                CLICK_PROCESS,
+                "isolated_subprocess_kwargs",
+                return_value=isolated,
             ) as isolation,
-            mock.patch.object(CLICK_GATE.subprocess, "run") as run,
+            mock.patch.object(CLICK_PROCESS.subprocess, "run") as run,
         ):
             run.return_value.returncode = 0
             run.return_value.stdout = b"captured\n"
@@ -4961,8 +4965,8 @@ class ClickGateTests(unittest.TestCase):
                 {"PLUGIN_DATA": str(self.plugin_data)},
             ),
             mock.patch.object(
-                CLICK_GATE.subprocess,
-                "Popen",
+                CLICK_PROCESS,
+                "spawn_argv",
                 side_effect=launch_supervisor,
             ) as popen,
         ):
@@ -5026,7 +5030,7 @@ class ClickGateTests(unittest.TestCase):
                         CLICK_GATE.os.environ,
                         {"PLUGIN_DATA": str(self.plugin_data)},
                     ),
-                    mock.patch.object(CLICK_GATE.subprocess, "Popen") as popen,
+                    mock.patch.object(CLICK_PROCESS, "spawn_argv") as popen,
                 ):
                     self.assertEqual(CLICK_GATE._run_service_start(arguments), 2)
                 popen.assert_not_called()
@@ -5091,7 +5095,9 @@ class ClickGateTests(unittest.TestCase):
                 CLICK_GATE.os.environ,
                 {"PLUGIN_DATA": str(self.plugin_data)},
             ),
-            mock.patch.object(CLICK_GATE.subprocess, "Popen", return_value=child) as popen,
+            mock.patch.object(
+                CLICK_PROCESS, "spawn_argv", return_value=child
+            ) as popen,
             mock.patch.object(CLICK_GATE.time, "sleep"),
         ):
             self.assertEqual(CLICK_GATE._run_service_supervisor(arguments), 2)
@@ -5160,7 +5166,7 @@ class ClickGateTests(unittest.TestCase):
                 CLICK_GATE.os.environ,
                 {"PLUGIN_DATA": str(self.plugin_data)},
             ),
-            mock.patch.object(CLICK_GATE.subprocess, "Popen") as popen,
+            mock.patch.object(CLICK_PROCESS, "spawn_argv") as popen,
         ):
             self.assertEqual(CLICK_GATE._run_service_supervisor(arguments), 2)
         popen.assert_not_called()
@@ -5204,7 +5210,7 @@ class ClickGateTests(unittest.TestCase):
                 CLICK_GATE.os.environ,
                 {"PLUGIN_DATA": str(self.plugin_data)},
             ),
-            mock.patch.object(CLICK_GATE.subprocess, "Popen") as popen,
+            mock.patch.object(CLICK_PROCESS, "spawn_argv") as popen,
         ):
             self.assertEqual(CLICK_GATE._run_service_start(arguments), 2)
         popen.assert_not_called()

--- a/tests/test_click_process.py
+++ b/tests/test_click_process.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import ast
+import io
+import os
+from pathlib import Path
+import signal
+import subprocess
+import unittest
+from unittest import mock
+
+from hooks import click_gate, click_process
+
+
+class ClickProcessTests(unittest.TestCase):
+    def test_process_module_does_not_depend_on_gate_state_or_evidence(self) -> None:
+        source = Path(click_process.__file__).read_text(encoding="utf-8")
+        imported: set[str] = set()
+        for node in ast.walk(ast.parse(source)):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                imported.add(module)
+                imported.update(
+                    f"{module}.{alias.name}".strip(".") for alias in node.names
+                )
+
+        for forbidden in ("click_gate", "click_state", "evidence"):
+            with self.subTest(forbidden=forbidden):
+                self.assertFalse(
+                    any(forbidden in name.split(".") for name in imported),
+                    imported,
+                )
+
+    def test_gate_keeps_compatibility_aliases_for_process_primitives(self) -> None:
+        aliases = {
+            "_copy_limited_output": click_process.copy_limited_output,
+            "_isolated_subprocess_kwargs": click_process.isolated_subprocess_kwargs,
+            "_terminate_managed_child": click_process.terminate_process_group,
+        }
+        for name, expected in aliases.items():
+            with self.subTest(name=name):
+                self.assertIs(getattr(click_gate, name), expected)
+
+    def test_isolation_kwargs_are_platform_specific(self) -> None:
+        with mock.patch.object(click_process.os, "name", "posix"):
+            self.assertEqual(
+                click_process.isolated_subprocess_kwargs(),
+                {"start_new_session": True},
+            )
+        with (
+            mock.patch.object(click_process.os, "name", "nt"),
+            mock.patch.object(
+                click_process.subprocess,
+                "CREATE_NEW_PROCESS_GROUP",
+                512,
+                create=True,
+            ),
+        ):
+            self.assertEqual(
+                click_process.isolated_subprocess_kwargs(),
+                {"creationflags": 512},
+            )
+
+    def test_run_argv_is_shell_free_and_uses_an_isolated_group(self) -> None:
+        completed = mock.Mock(spec=subprocess.CompletedProcess)
+        with (
+            mock.patch.object(
+                click_process,
+                "isolated_subprocess_kwargs",
+                return_value={"start_new_session": True},
+            ),
+            mock.patch.object(
+                click_process.subprocess,
+                "run",
+                return_value=completed,
+            ) as run,
+        ):
+            result = click_process.run_argv(
+                ("tool", "--flag"),
+                cwd=Path("workspace"),
+                env={"SAFE": "1"},
+                stdout=subprocess.PIPE,
+            )
+
+        self.assertIs(result, completed)
+        run.assert_called_once_with(
+            ["tool", "--flag"],
+            cwd=Path("workspace"),
+            env={"SAFE": "1"},
+            stdin=None,
+            stdout=subprocess.PIPE,
+            stderr=None,
+            check=False,
+            shell=False,
+            start_new_session=True,
+        )
+
+    def test_spawn_argv_is_shell_free_and_uses_an_isolated_group(self) -> None:
+        child = mock.Mock(spec=subprocess.Popen)
+        with (
+            mock.patch.object(
+                click_process,
+                "isolated_subprocess_kwargs",
+                return_value={"creationflags": 512},
+            ),
+            mock.patch.object(
+                click_process.subprocess,
+                "Popen",
+                return_value=child,
+            ) as popen,
+        ):
+            result = click_process.spawn_argv(
+                ("service", "start"),
+                cwd="workspace",
+                stderr=subprocess.DEVNULL,
+                close_fds=False,
+            )
+
+        self.assertIs(result, child)
+        popen.assert_called_once_with(
+            ["service", "start"],
+            cwd="workspace",
+            env=None,
+            stdin=None,
+            stdout=None,
+            stderr=subprocess.DEVNULL,
+            close_fds=False,
+            shell=False,
+            creationflags=512,
+        )
+
+    @unittest.skipIf(os.name == "nt", "POSIX process groups are unavailable")
+    def test_terminate_process_group_uses_posix_group_signals(self) -> None:
+        child = mock.Mock()
+        child.pid = 4242
+        child.poll.return_value = None
+        child.wait.return_value = 0
+        with (
+            mock.patch.object(click_process.os, "name", "posix"),
+            mock.patch.object(click_process.os, "killpg", create=True) as killpg,
+        ):
+            result = click_process.terminate_process_group(
+                child, grace_seconds=0.25
+            )
+
+        self.assertEqual(result, 0)
+        killpg.assert_called_once_with(4242, signal.SIGTERM)
+        child.wait.assert_called_once_with(timeout=0.25)
+
+    @unittest.skipIf(os.name == "nt", "POSIX process groups are unavailable")
+    def test_terminate_process_group_escalates_after_timeout(self) -> None:
+        child = mock.Mock()
+        child.pid = 4242
+        child.poll.return_value = None
+        child.wait.side_effect = [
+            subprocess.TimeoutExpired("service", 0.25),
+            -9,
+        ]
+        with (
+            mock.patch.object(click_process.os, "name", "posix"),
+            mock.patch.object(click_process.os, "killpg", create=True) as killpg,
+        ):
+            result = click_process.terminate_process_group(
+                child, grace_seconds=0.25
+            )
+
+        self.assertEqual(result, -9)
+        self.assertEqual(
+            killpg.call_args_list,
+            [
+                mock.call(4242, signal.SIGTERM),
+                mock.call(4242, signal.SIGKILL),
+            ],
+        )
+        self.assertEqual(
+            child.wait.call_args_list,
+            [mock.call(timeout=0.25), mock.call(timeout=0.25)],
+        )
+
+    def test_terminate_process_group_uses_windows_control_break(self) -> None:
+        child = mock.Mock()
+        child.poll.return_value = None
+        child.wait.return_value = 0
+        with (
+            mock.patch.object(click_process.os, "name", "nt"),
+            mock.patch.object(
+                click_process.signal,
+                "CTRL_BREAK_EVENT",
+                21,
+                create=True,
+            ),
+        ):
+            result = click_process.terminate_process_group(child)
+
+        self.assertEqual(result, 0)
+        child.send_signal.assert_called_once_with(21)
+        child.terminate.assert_not_called()
+        child.kill.assert_not_called()
+
+    def test_windows_termination_falls_back_when_control_break_is_missing(self) -> None:
+        child = mock.Mock()
+        child.poll.return_value = None
+        child.wait.return_value = 0
+        with (
+            mock.patch.object(click_process.os, "name", "nt"),
+            mock.patch.object(
+                click_process.signal,
+                "CTRL_BREAK_EVENT",
+                None,
+                create=True,
+            ),
+        ):
+            result = click_process.terminate_process_group(child)
+
+        self.assertEqual(result, 0)
+        child.send_signal.assert_not_called()
+        child.terminate.assert_called_once_with()
+        child.kill.assert_not_called()
+
+    def test_windows_termination_escalates_to_kill_after_timeout(self) -> None:
+        child = mock.Mock()
+        child.poll.return_value = None
+        child.wait.side_effect = [
+            subprocess.TimeoutExpired("service", 0.25),
+            1,
+        ]
+        with (
+            mock.patch.object(click_process.os, "name", "nt"),
+            mock.patch.object(
+                click_process.signal,
+                "CTRL_BREAK_EVENT",
+                21,
+                create=True,
+            ),
+        ):
+            result = click_process.terminate_process_group(
+                child, grace_seconds=0.25
+            )
+
+        self.assertEqual(result, 1)
+        child.send_signal.assert_called_once_with(21)
+        child.kill.assert_called_once_with()
+        self.assertEqual(
+            child.wait.call_args_list,
+            [mock.call(timeout=0.25), mock.call(timeout=0.25)],
+        )
+
+    def test_copy_limited_output_stops_at_the_exact_byte_cap(self) -> None:
+        source = io.BytesIO(b"0123456789")
+        target = io.BytesIO()
+
+        copied = click_process.copy_limited_output(
+            source, target, 6, chunk_size=4
+        )
+
+        self.assertEqual(copied, 6)
+        self.assertEqual(target.getvalue(), b"012345")
+        self.assertEqual(source.read(), b"6789")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_distribution_validation.py
+++ b/tests/test_distribution_validation.py
@@ -59,17 +59,17 @@ class DistributionValidationTests(unittest.TestCase):
                     self.assertIsInstance(json.loads(result.stdout), dict)
 
     def test_release_notes_allow_only_the_explicit_next_minor_candidate(self) -> None:
-        stable = "## v0.22.0 — 2026-08-30\n"
-        self.assertEqual(_release_notes_error(stable, "0.22.0"), "")
-        current = "## Unreleased v0.23 candidate — evidence\n\n## v0.22.0\n"
-        self.assertEqual(_release_notes_error(current, "0.22.0"), "")
+        stable = "## v0.23.0 — 2026-08-30\n"
+        self.assertEqual(_release_notes_error(stable, "0.23.0"), "")
+        current = "## Unreleased v0.24 candidate — evidence\n\n## v0.23.0\n"
+        self.assertEqual(_release_notes_error(current, "0.23.0"), "")
         for invalid in (
-            "## Unreleased — evidence\n\n## v0.22.0\n",
-            "## Unreleased v0.24 candidate\n\n## v0.22.0\n",
-            "## Unreleased v0.23 candidate\n## Unreleased v0.23 candidate — two\n## v0.22.0\n",
+            "## Unreleased — evidence\n\n## v0.23.0\n",
+            "## Unreleased v0.25 candidate\n\n## v0.23.0\n",
+            "## Unreleased v0.24 candidate\n## Unreleased v0.24 candidate — two\n## v0.23.0\n",
         ):
             with self.subTest(invalid=invalid):
-                self.assertIn("next-minor candidate", _release_notes_error(invalid, "0.22.0"))
+                self.assertIn("next-minor candidate", _release_notes_error(invalid, "0.23.0"))
 
 
 if __name__ == "__main__":

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -20,7 +20,7 @@ class RepositoryPolicyTests(unittest.TestCase):
             (ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
         )
         self.assertEqual(manifest["name"], "click")
-        self.assertEqual(manifest["version"], "0.22.0")
+        self.assertEqual(manifest["version"], "0.23.0")
         self.assertEqual(manifest["license"], "MIT")
         self.assertIn("always on", manifest["description"].lower())
         self.assertIn("manual", manifest["description"].lower())
@@ -251,7 +251,7 @@ class RepositoryPolicyTests(unittest.TestCase):
         self.assertEqual(marketplace["name"], "click")
         self.assertEqual(marketplace["plugins"][0]["name"], "click")
         self.assertEqual(
-            marketplace["plugins"][0]["source"]["ref"], "v0.22.0"
+            marketplace["plugins"][0]["source"]["ref"], "v0.23.0"
         )
 
     def test_ci_enforces_distribution_compilation_and_diff_validation(self) -> None:
@@ -266,19 +266,20 @@ class RepositoryPolicyTests(unittest.TestCase):
         self.assertIn("workflow_dispatch:", workflow)
         self.assertTrue((ROOT / "scripts" / "validate_distribution.py").is_file())
 
-    def test_release_documents_identify_v0220_and_preserve_release_history(self) -> None:
+    def test_release_documents_identify_v0230_and_preserve_release_history(self) -> None:
         for readme_name in README_NAMES:
             with self.subTest(readme=readme_name):
                 readme = (ROOT / readme_name).read_text(encoding="utf-8")
-                self.assertIn("v0.22.0", readme)
+                self.assertIn("v0.23.0", readme)
                 self.assertIn("v0.21.0", readme)
                 self.assertIn("version-18", readme)
         notes = (ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8")
+        self.assertIn("## v0.23.0", notes)
         self.assertIn("## v0.22.0", notes)
         self.assertIn("## v0.21.1", notes)
         self.assertIn("## v0.21.0", notes)
         self.assertIn("## v0.20.0", notes)
-        self.assertNotIn("Unreleased v0.21", notes)
+        self.assertNotIn("Unreleased v0.23", notes)
         self.assertIn(
             "## Evidence-bound completion in v0.21.0",
             (ROOT / "README.md").read_text(encoding="utf-8"),
@@ -422,13 +423,26 @@ class RepositoryPolicyTests(unittest.TestCase):
     def test_runtime_hook_has_no_external_python_dependency(self) -> None:
         sources = {
             name: (ROOT / "hooks" / name).read_text(encoding="utf-8")
-            for name in ("click_gate.py", "click_state.py")
+            for name in ("click_gate.py", "click_process.py", "click_state.py")
         }
         for name, source in sources.items():
             for forbidden in ("requests", "yaml", "pydantic", "openai"):
                 with self.subTest(name=name, forbidden=forbidden):
                     self.assertNotIn(f"import {forbidden}", source)
                     self.assertNotIn(f"from {forbidden}", source)
+
+    def test_process_mechanics_are_isolated_from_gate_policy(self) -> None:
+        gate = (ROOT / "hooks" / "click_gate.py").read_text(encoding="utf-8")
+        process = (ROOT / "hooks" / "click_process.py").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertNotIn("subprocess.run(", gate)
+        self.assertNotIn("subprocess.Popen(", gate)
+        for forbidden in ("click_gate", "click_state", "evidence"):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(f"import {forbidden}", process)
+                self.assertNotIn(f"from {forbidden}", process)
 
     def test_compact_contract_replaces_the_verbose_execution_fields(self) -> None:
         hook = (ROOT / "hooks" / "click_gate.py").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- extract shared shell-free process execution, spawning, isolation, termination, and bounded output copying into `click_process.py`
- keep executable trust, Git/SSH policy, runner claims, orchestration, budgets, snapshots, and evidence semantics in `click_gate.py`
- bundle the same process module in the Antigravity distribution and document v0.23.0 without changing contract or evidence protocol version 2

## Validation

- `python3 -m unittest discover -s tests -v` — 255 passed, 1 Windows-only skip on Linux
- `python3 scripts/validate_distribution.py`
- Plugin validator and Click/Fix Skill validators
- Python compilation and `git diff --check`
- source and generated Antigravity process/gate files are byte-identical

## Scope

Evidence-ledger modularization is intentionally excluded and will be handled separately after this release is fixed.
