### PR TITLE
Release Click v0.24.1 SessionEnd timeout compatibility

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/grapefruit0205/click.git",
-        "ref": "v0.24.0"
+        "ref": "v0.24.1"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "click",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Choose Always ON or @Click Manual. Click turns a software change into one compact plain-language execution contract, waits for approval, then keeps Codex inside that boundary with structured commands and only the primary evidence needed for completion—without repeated planning or repository-wide rescans.",
   "author": {
     "name": "Junseok Pak",

--- a/README.ko.md
+++ b/README.ko.md
@@ -60,7 +60,7 @@ launcher를 사용합니다. launcher는 확장 없는 단일 Bash 명령만 허
 가정하지 말고 정확한 제한은
 [`platforms/antigravity/README.md`](platforms/antigravity/README.md)를 확인하세요.
 
-## v0.24.0으로 업데이트
+## v0.24.1로 업데이트
 
 Click을 이미 설치했다면 Git 마켓플레이스 스냅샷을 명시적으로 갱신하고 플러그인을 다시 설치해야 이번 버전이 적용됩니다.
 
@@ -69,7 +69,7 @@ codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-ChatGPT 데스크톱 앱을 다시 시작하고 갱신된 Click Hook을 검토해 신뢰한 뒤 새 작업을 시작합니다. 기존 모드 설정은 대상 저장소 밖에 그대로 유지됩니다. v0.24.0은 v0.23.0에서 도입한 공통 `click_process.py` 경계 위에 내용 비저장 evidence registry·ledger 동작을 `click_evidence.py`로 분리하고 Codex와 생성된 Antigravity 배포본에 함께 적용합니다. 일반 anti-loop 허용 여부도 현재 revision의 증거를 따릅니다. 필요한 첫 전체 inventory 한 번은 허용하고, evidence별 정확한 argv check 묶음을 하나의 누적 예산에 예약하며, active 계약·revision·보호된 Git tree·check·환경·실행 파일 지문이 모두 같은 성공 receipt만 재사용하고, 정규화된 Browser 입력의 중복을 막습니다. `click-gate`를 직접 호출한다면 계속 verify 프로토콜 버전 `2`를 사용하고 모든 check에 승인된 argv `evidence_id`를 넣으며, `pass`에는 발급된 `contract_id`만 전달하고 `done_when`은 구조화된 증거 참조를 사용합니다. 예전 설치가 만든 실행 대기 중 runner 명령은 재사용하지 말고, 갱신된 Hook이 새 명령을 발급하게 합니다.
+ChatGPT 데스크톱 앱을 다시 시작하고 갱신된 Click Hook을 검토해 신뢰한 뒤 새 작업을 시작합니다. 기존 모드 설정은 대상 저장소 밖에 그대로 유지됩니다. v0.24.1은 SessionEnd lifecycle 명령만 호스트가 지원하는 최대 3초로 제한해 clamping 경고를 제거합니다. UserPromptSubmit, PreToolUse, PostToolUse는 계속 7초이며 hook 명령, 계약 형식, 검증 프로토콜, 모드, 승인 동작은 v0.24.0과 같습니다. 예전 설치가 만든 실행 대기 중 runner 명령은 재사용하지 말고, 갱신된 Hook이 새 명령을 발급하게 합니다.
 
 나중에 “Click을 Always ON으로 설정해줘” 또는 “Click을 Manual로 설정해줘”라고 바꿀 수 있고, 이 설정은 대상 저장소 밖에 유지됩니다. 정확히 한 turn만 우회하려면 사용자 프롬프트 첫 줄에 `@Click bypass` 또는 자동완성 형식인 `[@Click](plugin://click@click) bypass`를 씁니다. Hook은 같은 turn의 `click-gate bypass` 한 번만 승인하고 active 계약은 그대로 보존합니다. active 계약을 버릴 때는 같은 형식의 `cancel` 명령으로 `click-gate cancel` 한 번을 승인합니다. `@Click` 이름과 명령의 대소문자는 구분하지 않지만 plugin URI는 정확히 일치해야 하며, 명령 줄에 다른 문구를 붙일 수 없습니다. 실제 작업 내용은 둘째 줄부터 이어서 쓸 수 있습니다. 두 권한은 재사용하거나 다음 turn으로 가져갈 수 없습니다. Click은 프로젝트 안에 설정이나 계약 파일을 만들지 않습니다.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ deduplicated. Browser evidence is not currently supported. See
 [`platforms/antigravity/README.md`](platforms/antigravity/README.md) for the
 exact limits instead of assuming full host parity.
 
-## Update to v0.24.0
+## Update to v0.24.1
 
 If Click is already installed, explicitly refresh its Git marketplace snapshot and reinstall the plugin to load this release:
 
@@ -74,7 +74,7 @@ codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-Restart the ChatGPT desktop app, review and trust the updated Click Hook, and start a new task. Existing mode preferences remain outside the target repository. Building on the shared `click_process.py` boundary introduced in v0.23.0, v0.24.0 extracts the content-free evidence registry and ledger mechanics into `click_evidence.py` for both Codex and the generated Antigravity distribution. Normal anti-loop admission now follows current-revision evidence: Click permits one necessary broad inventory, reserves exact per-source argv check groups against one cumulative budget, reuses an exact successful receipt only when the active contract, revision, protected Git tree, check, environment, and executable fingerprint still match, and deduplicates normalized Browser inputs. Direct `click-gate` callers continue to use verification protocol version `2`, include an approved argv `evidence_id` on every check, pass only the emitted `contract_id`, and use structured `done_when` evidence references. Do not reuse a pending runner command created by an older installation; let the updated Hook issue a fresh rewritten command.
+Restart the ChatGPT desktop app, review and trust the updated Click Hook, and start a new task. Existing mode preferences remain outside the target repository. v0.24.1 caps only the SessionEnd lifecycle command at the host-supported three-second maximum, removing the clamping warning. UserPromptSubmit, PreToolUse, and PostToolUse remain at seven seconds; hook commands, contract shape, verification protocol, modes, and authorization behavior are unchanged from v0.24.0. Do not reuse a pending runner command created by an older installation; let the updated Hook issue a fresh rewritten command.
 
 You can later say “Set Click to Always ON” or “Set Click to Manual.” Those preferences persist outside the target repository. To bypass Click for exactly one turn, make the first line of that user prompt either `@Click bypass` or the autocomplete form `[@Click](plugin://click@click) bypass`; the Hook authorizes one same-turn `click-gate bypass` and keeps any active contract intact. Use the corresponding `cancel` form to authorize one same-turn `click-gate cancel` and discard the active contract. The `@Click` label and action are case-insensitive, but the plugin URI must match exactly and the directive line cannot contain extra text. The task may continue on later lines. Neither authorization is reusable or carries across turns. Click does not place preference or contract files in your project.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -60,7 +60,7 @@ launcher 只接受一条不含展开的 Bash 命令；命令串联、重定向�
 [`platforms/antigravity/README.md`](platforms/antigravity/README.md)了解准确
 限制，不要假设宿主功能完全等价。
 
-## 更新到 v0.24.0
+## 更新到 v0.24.1
 
 如果已经安装 Click，需要明确刷新 Git marketplace 快照并重新安装插件，才能加载本版本。
 
@@ -69,7 +69,7 @@ codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-重新启动 ChatGPT 桌面应用，检查并信任更新后的 Click Hook，然后开始一个新任务。现有模式偏好仍保存在目标仓库之外。v0.24.0 在 v0.23.0 引入的共享 `click_process.py` 边界之上，把不保存内容的 evidence registry 与 ledger 机制提取到 `click_evidence.py`，并同时用于 Codex 与生成的 Antigravity 分发包。常规防循环许可也改为依据当前 revision 的证据：允许一次必要的全仓库清单读取；将每个 evidence 的准确 argv 检查组预约到同一累计预算；仅当活动契约、revision、受保护 Git tree、检查、环境和可执行文件指纹全部一致时复用成功 receipt；并去重规范化后的 Browser 输入。直接调用 `click-gate` 时，继续使用 verify 协议版本 `2`，为每项检查提供已批准的 argv `evidence_id`，让 `pass` 只传递已签发的 `contract_id`，并使用结构化 `done_when` 证据引用。不要重复使用旧安装留下的待执行 runner 命令；应让更新后的 Hook 签发一条新命令。
+重新启动 ChatGPT 桌面应用，检查并信任更新后的 Click Hook，然后开始一个新任务。现有模式偏好仍保存在目标仓库之外。v0.24.1 仅把 SessionEnd lifecycle 命令限制为宿主支持的三秒上限，从而消除 clamping 警告。UserPromptSubmit、PreToolUse 和 PostToolUse 仍保持七秒；Hook 命令、契约格式、验证协议、模式和授权行为与 v0.24.0 相同。不要重复使用旧安装留下的待执行 runner 命令；应让更新后的 Hook 签发一条新命令。
 
 之后你可以说“Set Click to Always ON”或“Set Click to Manual”，这些偏好会持久保存在目标仓库之外。若只想绕过一个 turn，请把用户提示的第一行写成 `@Click bypass`，或使用自动补全形式 `[@Click](plugin://click@click) bypass`；Hook 只授权同一 turn 的一次 `click-gate bypass`，并保留活动契约。要丢弃活动契约，请使用对应的 `cancel` 形式来授权一次 `click-gate cancel`。`@Click` 标签和动作不区分大小写，但 plugin URI 必须完全匹配，指令行不能包含其他文字；实际任务可以从第二行继续。两种授权都不能重复使用或带到下一个 turn。Click 不会把偏好或契约文件放进你的项目。
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,30 @@
 # Release notes
 
+## v0.24.1 — 2026-08-30
+
+Click v0.24.1 is a focused host-compatibility patch for the SessionEnd
+lifecycle hook. Contract shape, evidence protocol, mode behavior, and all
+runtime authorization rules remain unchanged from v0.24.0.
+
+### SessionEnd timeout compatibility
+
+- `hooks/hooks.json` now declares the SessionEnd command timeout as three
+  seconds, matching the host's supported maximum and removing the startup
+  clamping warning.
+- UserPromptSubmit, PreToolUse, and PostToolUse retain their seven-second
+  timeouts, and every hook command and matcher remains unchanged.
+- The deterministic hook-configuration regression test now pins all four
+  timeout values to prevent this compatibility setting from drifting.
+
+### Compatibility and release gate
+
+- Existing Always ON or Manual preferences and active-state formats require no
+  migration. Users refresh the `click` marketplace, reinstall `click@click`,
+  restart the desktop app, review the updated Hook, and begin a new task.
+- The exact release commit must pass the full deterministic suite on Linux,
+  macOS, and Windows, the repository distribution checks, and Plugin Security
+  Scan before the immutable `v0.24.1` tag and GitHub Release are published.
+
 ## v0.24.0 — 2026-08-30
 
 Click v0.24.0 changes normal anti-loop decisions from raw call counts to

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -47,7 +47,7 @@
             "type": "command",
             "command": "python3 \"${PLUGIN_ROOT}/hooks/click_gate.py\" session-end",
             "commandWindows": "py -3 \"%PLUGIN_ROOT%\\hooks\\click_gate.py\" session-end",
-            "timeout": 7
+            "timeout": 3
           }
         ]
       }

--- a/tests/test_click_gate.py
+++ b/tests/test_click_gate.py
@@ -531,16 +531,16 @@ class ClickGateTests(unittest.TestCase):
         self.assertEqual(
             hooks["PostToolUse"][0]["matcher"], "^mcp__node_repl__js$"
         )
+        post_tool_handler = hooks["PostToolUse"][0]["hooks"][0]
         self.assertTrue(
-            hooks["PostToolUse"][0]["hooks"][0]["command"].endswith(
-                'click_gate.py" post-tool'
-            )
+            post_tool_handler["command"].endswith('click_gate.py" post-tool')
         )
+        self.assertEqual(post_tool_handler["timeout"], 7)
+        session_end_handler = hooks["SessionEnd"][0]["hooks"][0]
         self.assertTrue(
-            hooks["SessionEnd"][0]["hooks"][0]["command"].endswith(
-                'click_gate.py" session-end'
-            )
+            session_end_handler["command"].endswith('click_gate.py" session-end')
         )
+        self.assertEqual(session_end_handler["timeout"], 3)
 
     def test_uninvoked_hook_starts_without_state(self) -> None:
         self.assertFalse((self.plugin_data / "gate-state").exists())

--- a/tests/test_distribution_validation.py
+++ b/tests/test_distribution_validation.py
@@ -59,17 +59,17 @@ class DistributionValidationTests(unittest.TestCase):
                     self.assertIsInstance(json.loads(result.stdout), dict)
 
     def test_release_notes_allow_only_the_explicit_next_minor_candidate(self) -> None:
-        stable = "## v0.24.0 — 2026-08-30\n"
-        self.assertEqual(_release_notes_error(stable, "0.24.0"), "")
-        current = "## Unreleased v0.25 candidate — evidence\n\n## v0.24.0\n"
-        self.assertEqual(_release_notes_error(current, "0.24.0"), "")
+        stable = "## v0.24.1 — 2026-08-30\n"
+        self.assertEqual(_release_notes_error(stable, "0.24.1"), "")
+        current = "## Unreleased v0.25 candidate — evidence\n\n## v0.24.1\n"
+        self.assertEqual(_release_notes_error(current, "0.24.1"), "")
         for invalid in (
-            "## Unreleased — evidence\n\n## v0.24.0\n",
-            "## Unreleased v0.26 candidate\n\n## v0.24.0\n",
-            "## Unreleased v0.25 candidate\n## Unreleased v0.25 candidate — two\n## v0.24.0\n",
+            "## Unreleased — evidence\n\n## v0.24.1\n",
+            "## Unreleased v0.26 candidate\n\n## v0.24.1\n",
+            "## Unreleased v0.25 candidate\n## Unreleased v0.25 candidate — two\n## v0.24.1\n",
         ):
             with self.subTest(invalid=invalid):
-                self.assertIn("next-minor candidate", _release_notes_error(invalid, "0.24.0"))
+                self.assertIn("next-minor candidate", _release_notes_error(invalid, "0.24.1"))
 
 
 if __name__ == "__main__":

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -20,7 +20,7 @@ class RepositoryPolicyTests(unittest.TestCase):
             (ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
         )
         self.assertEqual(manifest["name"], "click")
-        self.assertEqual(manifest["version"], "0.24.0")
+        self.assertEqual(manifest["version"], "0.24.1")
         self.assertEqual(manifest["license"], "MIT")
         self.assertIn("always on", manifest["description"].lower())
         self.assertIn("manual", manifest["description"].lower())
@@ -254,7 +254,7 @@ class RepositoryPolicyTests(unittest.TestCase):
         self.assertEqual(marketplace["name"], "click")
         self.assertEqual(marketplace["plugins"][0]["name"], "click")
         self.assertEqual(
-            marketplace["plugins"][0]["source"]["ref"], "v0.24.0"
+            marketplace["plugins"][0]["source"]["ref"], "v0.24.1"
         )
 
     def test_ci_enforces_distribution_compilation_and_diff_validation(self) -> None:
@@ -269,15 +269,17 @@ class RepositoryPolicyTests(unittest.TestCase):
         self.assertIn("workflow_dispatch:", workflow)
         self.assertTrue((ROOT / "scripts" / "validate_distribution.py").is_file())
 
-    def test_release_documents_identify_v0240_and_preserve_release_history(self) -> None:
+    def test_release_documents_identify_v0241_and_preserve_release_history(self) -> None:
         for readme_name in README_NAMES:
             with self.subTest(readme=readme_name):
                 readme = (ROOT / readme_name).read_text(encoding="utf-8")
+                self.assertIn("v0.24.1", readme)
                 self.assertIn("v0.24.0", readme)
                 self.assertIn("v0.23.0", readme)
                 self.assertIn("v0.21.0", readme)
                 self.assertIn("version-18", readme)
         notes = (ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8")
+        self.assertIn("## v0.24.1", notes)
         self.assertIn("## v0.24.0", notes)
         self.assertIn("## v0.23.0", notes)
         self.assertIn("## v0.22.0", notes)


### PR DESCRIPTION
## Summary
- cap the SessionEnd lifecycle hook timeout at the host-supported 3 seconds
- publish Click v0.24.1 metadata and immutable marketplace ref
- pin all four hook timeout values in the deterministic regression test

## Local release gate
- python3 scripts/validate_distribution.py
- python3 -m compileall -q hooks evals scripts tests
- python3 -m unittest discover -s tests -v: 279 tests passed, 1 skipped
- git diff --check