### PR TITLE
Release Click v0.24.2 Windows plugin-root compatibility

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/grapefruit0205/click.git",
-        "ref": "v0.24.1"
+        "ref": "v0.24.2"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "click",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Choose Always ON or @Click Manual. Click turns a software change into one compact plain-language execution contract, waits for approval, then keeps Codex inside that boundary with structured commands and only the primary evidence needed for completion—without repeated planning or repository-wide rescans.",
   "author": {
     "name": "Junseok Pak",

--- a/README.ko.md
+++ b/README.ko.md
@@ -60,7 +60,7 @@ launcher를 사용합니다. launcher는 확장 없는 단일 Bash 명령만 허
 가정하지 말고 정확한 제한은
 [`platforms/antigravity/README.md`](platforms/antigravity/README.md)를 확인하세요.
 
-## v0.24.1로 업데이트
+## v0.24.2로 업데이트
 
 Click을 이미 설치했다면 Git 마켓플레이스 스냅샷을 명시적으로 갱신하고 플러그인을 다시 설치해야 이번 버전이 적용됩니다.
 
@@ -69,7 +69,7 @@ codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-ChatGPT 데스크톱 앱을 다시 시작하고 갱신된 Click Hook을 검토해 신뢰한 뒤 새 작업을 시작합니다. 기존 모드 설정은 대상 저장소 밖에 그대로 유지됩니다. v0.24.1은 SessionEnd lifecycle 명령만 호스트가 지원하는 최대 3초로 제한해 clamping 경고를 제거합니다. UserPromptSubmit, PreToolUse, PostToolUse는 계속 7초이며 hook 명령, 계약 형식, 검증 프로토콜, 모드, 승인 동작은 v0.24.0과 같습니다. 예전 설치가 만든 실행 대기 중 runner 명령은 재사용하지 말고, 갱신된 Hook이 새 명령을 발급하게 합니다.
+ChatGPT 데스크톱 앱을 다시 시작하고 갱신된 Click Hook을 검토해 신뢰한 뒤 새 작업을 시작합니다. 기존 모드 설정은 대상 저장소 밖에 그대로 유지됩니다. v0.24.2는 Windows lifecycle hook 명령에서 cmd 스타일 `%PLUGIN_ROOT%` 대신 Codex의 `${PLUGIN_ROOT}` 템플릿을 사용하고, 일반 경로와 공백이 포함된 plugin root 모두를 PowerShell에서 실제 실행하는 Windows 회귀 테스트를 추가합니다. SessionEnd의 호스트 지원 최대 3초 제한은 v0.24.1 그대로이며 계약 형식, evidence 프로토콜, 모드, runtime 권한 규칙도 바뀌지 않습니다. 호스트가 해당 PreToolUse 이벤트 자체를 전달하지 않는 경로까지 해결했다고 주장하지 않습니다. 예전 설치가 만든 실행 대기 중 runner 명령은 재사용하지 말고, 갱신된 Hook이 새 명령을 발급하게 합니다.
 
 나중에 “Click을 Always ON으로 설정해줘” 또는 “Click을 Manual로 설정해줘”라고 바꿀 수 있고, 이 설정은 대상 저장소 밖에 유지됩니다. 정확히 한 turn만 우회하려면 사용자 프롬프트 첫 줄에 `@Click bypass` 또는 자동완성 형식인 `[@Click](plugin://click@click) bypass`를 씁니다. Hook은 같은 turn의 `click-gate bypass` 한 번만 승인하고 active 계약은 그대로 보존합니다. active 계약을 버릴 때는 같은 형식의 `cancel` 명령으로 `click-gate cancel` 한 번을 승인합니다. `@Click` 이름과 명령의 대소문자는 구분하지 않지만 plugin URI는 정확히 일치해야 하며, 명령 줄에 다른 문구를 붙일 수 없습니다. 실제 작업 내용은 둘째 줄부터 이어서 쓸 수 있습니다. 두 권한은 재사용하거나 다음 turn으로 가져갈 수 없습니다. Click은 프로젝트 안에 설정이나 계약 파일을 만들지 않습니다.
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ deduplicated. Browser evidence is not currently supported. See
 [`platforms/antigravity/README.md`](platforms/antigravity/README.md) for the
 exact limits instead of assuming full host parity.
 
-## Update to v0.24.1
+## Update to v0.24.2
 
 If Click is already installed, explicitly refresh its Git marketplace snapshot and reinstall the plugin to load this release:
 
@@ -74,7 +74,7 @@ codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-Restart the ChatGPT desktop app, review and trust the updated Click Hook, and start a new task. Existing mode preferences remain outside the target repository. v0.24.1 caps only the SessionEnd lifecycle command at the host-supported three-second maximum, removing the clamping warning. UserPromptSubmit, PreToolUse, and PostToolUse remain at seven seconds; hook commands, contract shape, verification protocol, modes, and authorization behavior are unchanged from v0.24.0. Do not reuse a pending runner command created by an older installation; let the updated Hook issue a fresh rewritten command.
+Restart the ChatGPT desktop app, review and trust the updated Click Hook, and start a new task. Existing mode preferences remain outside the target repository. v0.24.2 changes the Windows lifecycle hook commands to use Codex's `${PLUGIN_ROOT}` template instead of the cmd-style `%PLUGIN_ROOT%` form and adds Windows PowerShell regressions for ordinary plugin roots and roots containing spaces. SessionEnd remains capped at the host-supported three seconds from v0.24.1; contract shape, evidence protocol, modes, and runtime authorization behavior remain unchanged. This patch does not claim to repair a host path that fails to dispatch the matching PreToolUse event at all. Do not reuse a pending runner command created by an older installation; let the updated Hook issue a fresh rewritten command.
 
 You can later say “Set Click to Always ON” or “Set Click to Manual.” Those preferences persist outside the target repository. To bypass Click for exactly one turn, make the first line of that user prompt either `@Click bypass` or the autocomplete form `[@Click](plugin://click@click) bypass`; the Hook authorizes one same-turn `click-gate bypass` and keeps any active contract intact. Use the corresponding `cancel` form to authorize one same-turn `click-gate cancel` and discard the active contract. The `@Click` label and action are case-insensitive, but the plugin URI must match exactly and the directive line cannot contain extra text. The task may continue on later lines. Neither authorization is reusable or carries across turns. Click does not place preference or contract files in your project.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -60,7 +60,7 @@ launcher 只接受一条不含展开的 Bash 命令；命令串联、重定向�
 [`platforms/antigravity/README.md`](platforms/antigravity/README.md)了解准确
 限制，不要假设宿主功能完全等价。
 
-## 更新到 v0.24.1
+## 更新到 v0.24.2
 
 如果已经安装 Click，需要明确刷新 Git marketplace 快照并重新安装插件，才能加载本版本。
 
@@ -69,7 +69,7 @@ codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-重新启动 ChatGPT 桌面应用，检查并信任更新后的 Click Hook，然后开始一个新任务。现有模式偏好仍保存在目标仓库之外。v0.24.1 仅把 SessionEnd lifecycle 命令限制为宿主支持的三秒上限，从而消除 clamping 警告。UserPromptSubmit、PreToolUse 和 PostToolUse 仍保持七秒；Hook 命令、契约格式、验证协议、模式和授权行为与 v0.24.0 相同。不要重复使用旧安装留下的待执行 runner 命令；应让更新后的 Hook 签发一条新命令。
+重新启动 ChatGPT 桌面应用，检查并信任更新后的 Click Hook，然后开始一个新任务。现有模式偏好仍保存在目标仓库之外。v0.24.2 将 Windows lifecycle hook 命令从 cmd 风格的 `%PLUGIN_ROOT%` 改为 Codex 的 `${PLUGIN_ROOT}` 模板，并增加 Windows PowerShell 回归测试，覆盖普通 plugin root 和包含空格的 plugin root。SessionEnd 继续沿用 v0.24.1 的宿主支持三秒上限；契约格式、evidence 协议、模式和 runtime 授权规则均未改变。该补丁不声称修复宿主根本没有分发对应 PreToolUse 事件的调用路径。不要重复使用旧安装留下的待执行 runner 命令；应让更新后的 Hook 签发一条新命令。
 
 之后你可以说“Set Click to Always ON”或“Set Click to Manual”，这些偏好会持久保存在目标仓库之外。若只想绕过一个 turn，请把用户提示的第一行写成 `@Click bypass`，或使用自动补全形式 `[@Click](plugin://click@click) bypass`；Hook 只授权同一 turn 的一次 `click-gate bypass`，并保留活动契约。要丢弃活动契约，请使用对应的 `cancel` 形式来授权一次 `click-gate cancel`。`@Click` 标签和动作不区分大小写，但 plugin URI 必须完全匹配，指令行不能包含其他文字；实际任务可以从第二行继续。两种授权都不能重复使用或带到下一个 turn。Click 不会把偏好或契约文件放进你的项目。
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,36 @@
 # Release notes
 
+## v0.24.2 — 2026-08-30
+
+Click v0.24.2 is a focused Windows Codex hook-launch compatibility patch.
+Contract shape, evidence protocol, mode behavior, and runtime authorization
+rules remain unchanged from v0.24.1.
+
+### Windows plugin-root template compatibility
+
+- `hooks/hooks.json` now uses Codex's `${PLUGIN_ROOT}` template in every
+  `commandWindows` hook command instead of the cmd-style `%PLUGIN_ROOT%` form.
+  The path remains quoted and uses Windows separators after host rendering.
+- A Windows regression suite pins all four lifecycle commands and, on the
+  Windows CI runner, executes them through PowerShell from both an ordinary
+  plugin root and a plugin root containing spaces.
+- The patch covers UserPromptSubmit, PreToolUse, PostToolUse, and SessionEnd
+  launcher rendering without changing their Click modes or authorization
+  semantics. SessionEnd remains capped at the host-supported three seconds.
+
+### Scope and release gate
+
+- This patch does not claim to fix host-side hook dispatch paths that do not
+  invoke Click's PreToolUse hook. The separately reported Windows Codex Desktop
+  unified-exec dispatch issue remains an upstream/host compatibility boundary
+  unless the host begins delivering the matching hook event.
+- Existing Always ON or Manual preferences and active-state formats require no
+  migration. Users refresh the `click` marketplace, reinstall `click@click`,
+  restart the desktop app, review the updated Hook, and begin a new task.
+- The exact release commit must pass the deterministic suite on Linux, macOS,
+  and Windows, repository distribution checks, and Plugin Security Scan before
+  the immutable `v0.24.2` tag and GitHub Release are published.
+
 ## v0.24.1 — 2026-08-30
 
 Click v0.24.1 is a focused host-compatibility patch for the SessionEnd

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -20,7 +20,7 @@ class RepositoryPolicyTests(unittest.TestCase):
             (ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
         )
         self.assertEqual(manifest["name"], "click")
-        self.assertEqual(manifest["version"], "0.24.1")
+        self.assertEqual(manifest["version"], "0.24.2")
         self.assertEqual(manifest["license"], "MIT")
         self.assertIn("always on", manifest["description"].lower())
         self.assertIn("manual", manifest["description"].lower())
@@ -163,11 +163,7 @@ class RepositoryPolicyTests(unittest.TestCase):
                 / "translation-guide.md"
             ).read_text(encoding="utf-8"),
             (
-                ROOT
-                / "skills"
-                / "click"
-                / "references"
-                / "directive-format.md"
+                ROOT / "skills" / "click" / "references" / "directive-format.md"
             ).read_text(encoding="utf-8"),
             (ROOT / "evals" / "SEMANTIC_GRADER.md").read_text(encoding="utf-8"),
             (ROOT / "evals" / "golden-prompts.yaml").read_text(encoding="utf-8"),
@@ -254,7 +250,7 @@ class RepositoryPolicyTests(unittest.TestCase):
         self.assertEqual(marketplace["name"], "click")
         self.assertEqual(marketplace["plugins"][0]["name"], "click")
         self.assertEqual(
-            marketplace["plugins"][0]["source"]["ref"], "v0.24.1"
+            marketplace["plugins"][0]["source"]["ref"], "v0.24.2"
         )
 
     def test_ci_enforces_distribution_compilation_and_diff_validation(self) -> None:
@@ -269,16 +265,18 @@ class RepositoryPolicyTests(unittest.TestCase):
         self.assertIn("workflow_dispatch:", workflow)
         self.assertTrue((ROOT / "scripts" / "validate_distribution.py").is_file())
 
-    def test_release_documents_identify_v0241_and_preserve_release_history(self) -> None:
+    def test_release_documents_identify_v0242_and_preserve_release_history(self) -> None:
         for readme_name in README_NAMES:
             with self.subTest(readme=readme_name):
                 readme = (ROOT / readme_name).read_text(encoding="utf-8")
+                self.assertIn("v0.24.2", readme)
                 self.assertIn("v0.24.1", readme)
                 self.assertIn("v0.24.0", readme)
                 self.assertIn("v0.23.0", readme)
                 self.assertIn("v0.21.0", readme)
                 self.assertIn("version-18", readme)
         notes = (ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8")
+        self.assertIn("## v0.24.2", notes)
         self.assertIn("## v0.24.1", notes)
         self.assertIn("## v0.24.0", notes)
         self.assertIn("## v0.23.0", notes)


### PR DESCRIPTION
## Summary
- release Click v0.24.2 from the current main that includes #28
- use Codex's `${PLUGIN_ROOT}` template for Windows lifecycle hook commands
- document the Windows PowerShell regression coverage for normal and spaced plugin roots
- keep contract shape, evidence protocol, modes, runtime authorization, and the v0.24.1 SessionEnd timeout behavior unchanged
- keep the separate Windows Codex Desktop unified-exec PreToolUse dispatch issue explicitly outside this patch's claim

## Release metadata
- bump `.codex-plugin/plugin.json` to `0.24.2`
- pin the marketplace to immutable `v0.24.2`
- update English, Korean, and Simplified Chinese upgrade docs
- add v0.24.2 release notes and align repository-policy regressions

## Required gate
- deterministic tests on Ubuntu, macOS, and Windows
- distribution validation, Python compilation, and `git diff --check`
- Plugin Security Scan

Publish the immutable `v0.24.2` tag and GitHub Release only after the exact merged-main commit passes the required checks.