### PR TITLE
Release Click v0.24.5 Windows runner shell compatibility

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/grapefruit0205/click.git",
-        "ref": "v0.24.4"
+        "ref": "v0.24.5"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "click",
-  "version": "0.24.4",
+  "version": "0.24.5",
   "description": "Choose Always ON or @Click Manual. Click turns a software change into one compact plain-language execution contract, waits for approval, then keeps Codex inside that boundary with structured commands and only the primary evidence needed for completion—without repeated planning or repository-wide rescans.",
   "author": {
     "name": "Junseok Pak",

--- a/README.ko.md
+++ b/README.ko.md
@@ -222,9 +222,9 @@ Antigravity IDE에서는 `dist/antigravity`를 워크스페이스의 `.agents/pl
 
 Antigravity의 Hook contract는 Codex와 다릅니다. native file/search와 별도 MCP·Skill 도구는 계속 사용할 수 있지만 cross-tool 중복 제거와 Browser evidence는 아직 지원하지 않습니다. 정확한 제한은 [`platforms/antigravity/README.md`](platforms/antigravity/README.md)를 확인하세요.
 
-## 기존 설치 업데이트 — v0.24.4
+## 기존 설치 업데이트 — v0.24.5
 
-현재 릴리스는 **v0.24.4**입니다.
+현재 릴리스는 **v0.24.5**입니다.
 
 ```bash
 codex plugin marketplace upgrade click

--- a/README.md
+++ b/README.md
@@ -222,9 +222,9 @@ Antigravity IDE users may also copy `dist/antigravity` into `.agents/plugins/cli
 
 Antigravity's Hook contract differs from Codex. Native file/search and unrelated MCP or Skill tools remain available, but cross-tool deduplication and Browser evidence are not currently supported. See [`platforms/antigravity/README.md`](platforms/antigravity/README.md) for the exact limits.
 
-## Update an existing installation — v0.24.4
+## Update an existing installation — v0.24.5
 
-The current release is **v0.24.4**.
+The current release is **v0.24.5**.
 
 ```bash
 codex plugin marketplace upgrade click

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -222,9 +222,9 @@ Antigravity IDE 用户也可以把 `dist/antigravity` 复制到工作区的 `.ag
 
 Antigravity 的 Hook contract 与 Codex 不同。native file/search 和其他 MCP、Skill 工具仍可使用，但目前还不支持 cross-tool 去重和 Browser evidence。准确限制请参阅 [`platforms/antigravity/README.md`](platforms/antigravity/README.md)。
 
-## 更新现有安装 — v0.24.4
+## 更新现有安装 — v0.24.5
 
-当前版本是 **v0.24.4**。
+当前版本是 **v0.24.5**。
 
 ```bash
 codex plugin marketplace upgrade click

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,45 @@
 # Release notes
 
+## v0.24.5 — 2026-08-31
+
+Click v0.24.5 is a focused Windows internal-runner shell compatibility
+release. Contract shape, evidence transport, approval behavior, and
+non-Windows runner rendering remain unchanged from v0.24.4.
+
+### Cross-shell Windows runner launch
+
+- Rewritten `inspect`, observation, mutation, service, and verification
+  runners now reuse the bare `py -3` launcher already required by the Windows
+  lifecycle hooks.
+- The generated command no longer places a quoted absolute `sys.executable`
+  path in command position, where PowerShell treats it as a string expression
+  unless an incompatible shell-specific call operator is added.
+- The resolved Click script path remains quoted, while every action, state
+  path, token, and request stays inside the bounded encoded-runner transport.
+
+### End-to-end Windows regression
+
+- The Windows integration suite now asks the real PreToolUse hook to rewrite
+  a structured `click-gate inspect` request, then executes the returned
+  command through both PowerShell and `cmd.exe`.
+- Normal and space-containing plugin roots are covered, and the runner must
+  return the inspected file contents successfully from both shells.
+- Platform-independent tests pin the bare `py -3` prefix, exclude the
+  interpreter's absolute path from the emitted command, and retain expansion-
+  token hiding, launcher-path rejection, payload bounds, and decode fidelity.
+
+### Compatibility and release gate
+
+- POSIX rendering still uses `shlex.join`; Windows command-length limits and
+  fail-closed launcher-path checks are unchanged.
+- The shared source hook and generated Antigravity distribution remain byte-
+  equivalent. On Windows, the Antigravity adapter translates the portable
+  launcher back to its active interpreter argv before direct shell-free
+  execution, avoiding a new launcher dependency or behavior change.
+- The exact merged-main commit must pass the deterministic suite on Linux,
+  macOS, and Windows plus Plugin Security Scan before the immutable `v0.24.5`
+  tag and GitHub Release are published and reinstalled.
+
 ## v0.24.4 — 2026-08-31
 
 Click v0.24.4 is a focused contract-boundary extraction and verification

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,10 +20,11 @@ non-Windows runner rendering remain unchanged from v0.24.4.
 ### End-to-end Windows regression
 
 - The Windows integration suite now asks the real PreToolUse hook to rewrite
-  a structured `click-gate inspect` request, then executes the returned
-  command through both PowerShell and `cmd.exe`.
-- Normal and space-containing plugin roots are covered, and the runner must
-  return the inspected file contents successfully from both shells.
+  structured `click-gate inspect` requests, then executes the returned
+  commands through both PowerShell and `cmd.exe`.
+- Normal and space-containing plugin roots are covered. Stateless inspection
+  and separately authorized stateful review runners must both return the
+  inspected file contents successfully from both shells.
 - Platform-independent tests pin the bare `py -3` prefix, exclude the
   interpreter's absolute path from the emitted command, and retain expansion-
   token hiding, launcher-path rejection, payload bounds, and decode fidelity.
@@ -32,6 +33,9 @@ non-Windows runner rendering remain unchanged from v0.24.4.
 
 - POSIX rendering still uses `shlex.join`; Windows command-length limits and
   fail-closed launcher-path checks are unchanged.
+- Fail-closed state-root validation is also unchanged: this release verifies
+  reachable state bindings cross-shell but does not recreate a missing or
+  inaccessible approval state.
 - The shared source hook and generated Antigravity distribution remain byte-
   equivalent. On Windows, the Antigravity adapter translates the portable
   launcher back to its active interpreter argv before direct shell-free

--- a/dist/antigravity/hooks/antigravity_gate.py
+++ b/dist/antigravity/hooks/antigravity_gate.py
@@ -316,6 +316,16 @@ def _command_argv(command: str) -> list[str]:
     return _windows_command_argv(command) if os.name == "nt" else shlex.split(command)
 
 
+def _runner_command_argv(command: str) -> list[str]:
+    argv = _command_argv(command)
+    if os.name == "nt" and argv[:2] == ["py", "-3"]:
+        # Codex needs a shell-portable bare launcher, while Antigravity runs
+        # the returned command directly without a shell. Preserve its active
+        # interpreter instead of adding a separate py-launcher dependency.
+        return [str(Path(sys.executable).resolve(strict=True)), *argv[2:]]
+    return argv
+
+
 def _antigravity_bash_tokens(command: str) -> list[str] | None:
     """Parse one expansion-free Antigravity Bash command.
 
@@ -507,8 +517,8 @@ def _control(arguments: list[str]) -> int:
     if not isinstance(command, str) or not command:
         return 0
     try:
-        argv = _command_argv(command)
-    except ValueError as exc:
+        argv = _runner_command_argv(command)
+    except (OSError, ValueError) as exc:
         sys.stderr.write(f"Click produced an invalid runner command: {exc}\n")
         return 2
     try:

--- a/dist/antigravity/hooks/click_gate.py
+++ b/dist/antigravity/hooks/click_gate.py
@@ -2281,12 +2281,15 @@ def _runner_shell_command(arguments: list[str]) -> str:
         ):
             return "exit 2"
         transported = [
-            arguments[0],
             arguments[1],
             "--encoded-runner",
             _encode_runner_transport(arguments[2:]),
         ]
-        command = " ".join(
+        # hooks.json already requires the Windows py launcher. Reuse its bare
+        # command form here so the rewritten runner is valid in both cmd.exe
+        # and PowerShell; a quoted executable path in command position is only
+        # an expression in PowerShell unless prefixed with its call operator.
+        command = "py -3 " + " ".join(
             _windows_shell_quote(argument) for argument in transported
         )
         if len(command) > WINDOWS_COMMAND_LINE_LIMIT:

--- a/hooks/antigravity_gate.py
+++ b/hooks/antigravity_gate.py
@@ -316,6 +316,16 @@ def _command_argv(command: str) -> list[str]:
     return _windows_command_argv(command) if os.name == "nt" else shlex.split(command)
 
 
+def _runner_command_argv(command: str) -> list[str]:
+    argv = _command_argv(command)
+    if os.name == "nt" and argv[:2] == ["py", "-3"]:
+        # Codex needs a shell-portable bare launcher, while Antigravity runs
+        # the returned command directly without a shell. Preserve its active
+        # interpreter instead of adding a separate py-launcher dependency.
+        return [str(Path(sys.executable).resolve(strict=True)), *argv[2:]]
+    return argv
+
+
 def _antigravity_bash_tokens(command: str) -> list[str] | None:
     """Parse one expansion-free Antigravity Bash command.
 
@@ -507,8 +517,8 @@ def _control(arguments: list[str]) -> int:
     if not isinstance(command, str) or not command:
         return 0
     try:
-        argv = _command_argv(command)
-    except ValueError as exc:
+        argv = _runner_command_argv(command)
+    except (OSError, ValueError) as exc:
         sys.stderr.write(f"Click produced an invalid runner command: {exc}\n")
         return 2
     try:

--- a/hooks/click_gate.py
+++ b/hooks/click_gate.py
@@ -2281,12 +2281,15 @@ def _runner_shell_command(arguments: list[str]) -> str:
         ):
             return "exit 2"
         transported = [
-            arguments[0],
             arguments[1],
             "--encoded-runner",
             _encode_runner_transport(arguments[2:]),
         ]
-        command = " ".join(
+        # hooks.json already requires the Windows py launcher. Reuse its bare
+        # command form here so the rewritten runner is valid in both cmd.exe
+        # and PowerShell; a quoted executable path in command position is only
+        # an expression in PowerShell unless prefixed with its call operator.
+        command = "py -3 " + " ".join(
             _windows_shell_quote(argument) for argument in transported
         )
         if len(command) > WINDOWS_COMMAND_LINE_LIMIT:

--- a/tests/repository_policy_core.py
+++ b/tests/repository_policy_core.py
@@ -20,7 +20,7 @@ class RepositoryPolicyTests(unittest.TestCase):
             (ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
         )
         self.assertEqual(manifest["name"], "click")
-        self.assertEqual(manifest["version"], "0.24.4")
+        self.assertEqual(manifest["version"], "0.24.5")
         self.assertEqual(manifest["license"], "MIT")
         self.assertIn("always on", manifest["description"].lower())
         self.assertIn("manual", manifest["description"].lower())
@@ -256,7 +256,7 @@ class RepositoryPolicyTests(unittest.TestCase):
         self.assertEqual(marketplace["name"], "click")
         self.assertEqual(marketplace["plugins"][0]["name"], "click")
         self.assertEqual(
-            marketplace["plugins"][0]["source"]["ref"], "v0.24.4"
+            marketplace["plugins"][0]["source"]["ref"], "v0.24.5"
         )
 
     def test_ci_enforces_distribution_compilation_and_diff_validation(self) -> None:
@@ -271,10 +271,11 @@ class RepositoryPolicyTests(unittest.TestCase):
         self.assertIn("workflow_dispatch:", workflow)
         self.assertTrue((ROOT / "scripts" / "validate_distribution.py").is_file())
 
-    def test_release_documents_identify_v0244_and_preserve_release_history(self) -> None:
+    def test_release_documents_identify_v0245_and_preserve_release_history(self) -> None:
         for readme_name in README_NAMES:
             with self.subTest(readme=readme_name):
                 readme = (ROOT / readme_name).read_text(encoding="utf-8")
+                self.assertIn("v0.24.5", readme)
                 self.assertIn("v0.24.4", readme)
                 self.assertIn("v0.24.3", readme)
                 self.assertIn("v0.24.1", readme)
@@ -283,6 +284,7 @@ class RepositoryPolicyTests(unittest.TestCase):
                 self.assertIn("v0.21.0", readme)
                 self.assertIn("version-18", readme)
         notes = (ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8")
+        self.assertIn("## v0.24.5", notes)
         self.assertIn("## v0.24.4", notes)
         self.assertIn("## v0.24.3", notes)
         self.assertIn("## v0.24.1", notes)

--- a/tests/test_antigravity_adapter.py
+++ b/tests/test_antigravity_adapter.py
@@ -331,9 +331,16 @@ class AntigravityAdapterTests(unittest.TestCase):
         ]
         command = click_gate._runner_shell_command(arguments)
         parsed = antigravity_gate._command_argv(command)
-        self.assertEqual(parsed[:2], arguments[:2])
-        self.assertEqual(parsed[2], "--encoded-runner")
-        decoded, error = click_gate._decode_runner_transport(parsed[3])
+        self.assertEqual(parsed[:3], ["py", "-3", arguments[1]])
+        self.assertEqual(parsed[3], "--encoded-runner")
+        decoded, error = click_gate._decode_runner_transport(parsed[4])
+        self.assertEqual(error, "")
+        self.assertEqual(decoded, arguments[2:])
+
+        direct = antigravity_gate._runner_command_argv(command)
+        self.assertEqual(direct[:2], arguments[:2])
+        self.assertEqual(direct[2], "--encoded-runner")
+        decoded, error = click_gate._decode_runner_transport(direct[3])
         self.assertEqual(error, "")
         self.assertEqual(decoded, arguments[2:])
 

--- a/tests/test_click_gate.py
+++ b/tests/test_click_gate.py
@@ -759,6 +759,8 @@ class ClickGateTests(unittest.TestCase):
         ]
         with mock.patch.object(CLICK_GATE.os, "name", "nt"):
             command = CLICK_GATE._runner_shell_command(arguments)
+        self.assertTrue(command.startswith('py -3 "C:\\Users\\safe user'))
+        self.assertNotIn(arguments[0], command)
         self.assertIn('"--encoded-runner"', command)
         self.assertNotIn("%PATH%", command)
         self.assertNotIn("!CLICK!", command)

--- a/tests/test_click_gate.py
+++ b/tests/test_click_gate.py
@@ -441,14 +441,29 @@ class ClickGateTests(unittest.TestCase):
         self.assertIsNotNone(payload)
         return payload
 
-    def run_rewritten(self, payload: dict) -> subprocess.CompletedProcess[str]:
+    def run_rewritten(
+        self,
+        payload: dict,
+        environment_updates: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
         command = payload["hookSpecificOutput"]["updatedInput"]["command"]
         environment = os.environ.copy()
         environment["PLUGIN_DATA"] = str(self.plugin_data)
         environment["CLICK_CONFIG_HOME"] = str(self.plugin_data)
+        if environment_updates:
+            environment.update(environment_updates)
+        invocation: str | list[str] = command
+        use_shell = True
+        if os.name == "nt" and command.startswith("py -3 "):
+            # Runner shell compatibility has dedicated PowerShell/cmd.exe
+            # integration coverage. Keep semantic unit tests on the same
+            # interpreter that prepared their environment fingerprints.
+            invocation = split_runner_command(command)
+            invocation[0] = sys.executable
+            use_shell = False
         return subprocess.run(
-            command,
-            shell=True,
+            invocation,
+            shell=use_shell,
             cwd=self.workspace,
             env=environment,
             capture_output=True,
@@ -3025,19 +3040,9 @@ class ClickGateTests(unittest.TestCase):
             "running_environment_digests"
         ][source_key]
 
-        rewritten = first["hookSpecificOutput"]["updatedInput"]["command"]
-        environment = os.environ.copy()
-        environment["PLUGIN_DATA"] = str(self.plugin_data)
-        environment["CLICK_CONFIG_HOME"] = str(self.plugin_data)
-        environment["CLICK_RUNNER_ONLY_NOISE"] = "launcher-added"
-        completed = subprocess.run(
-            rewritten,
-            shell=True,
-            cwd=self.workspace,
-            env=environment,
-            capture_output=True,
-            text=True,
-            check=False,
+        completed = self.run_rewritten(
+            first,
+            {"CLICK_RUNNER_ONLY_NOISE": "launcher-added"},
         )
         self.assertEqual(completed.returncode, 0, completed.stderr)
         recorded = json.loads(state_path.read_text(encoding="utf-8"))

--- a/tests/test_click_gate.py
+++ b/tests/test_click_gate.py
@@ -68,11 +68,18 @@ def split_runner_command(command: str) -> list[str]:
         kernel32.LocalFree.argtypes = [ctypes.c_void_p]
         kernel32.LocalFree.restype = ctypes.c_void_p
         kernel32.LocalFree(ctypes.cast(argv, ctypes.c_void_p))
-    if len(parsed) == 4 and parsed[2] == "--encoded-runner":
-        decoded, error = CLICK_GATE._decode_runner_transport(parsed[3])
+    encoded_index = 3 if parsed[:2] == ["py", "-3"] else 2
+    if (
+        len(parsed) == encoded_index + 2
+        and parsed[encoded_index] == "--encoded-runner"
+    ):
+        decoded, error = CLICK_GATE._decode_runner_transport(
+            parsed[encoded_index + 1]
+        )
         if error or decoded is None:
             raise ValueError(error or "invalid runner transport")
-        return [*parsed[:2], *decoded]
+        script_index = encoded_index - 1
+        return [parsed[0], parsed[script_index], *decoded]
     return parsed
 
 

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -126,14 +126,23 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
         for marker in ("shell=False", "process group", "process-control", "pkill"):
             self.assertIn(marker, protocol)
 
-    def test_release_documents_identify_v0244_and_preserve_release_history(self) -> None:
+    def test_release_documents_identify_v0245_and_preserve_release_history(self) -> None:
         for readme in _readmes().values():
+            self.assertIn("v0.24.5", readme)
             self.assertIn("codex plugin marketplace upgrade click", readme)
             self.assertIn("codex plugin add click@click", readme)
         notes = (ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8")
         for marker in (
-            "## v0.24.4", "## v0.24.3", "## v0.24.1", "## v0.24.0",
-            "## v0.23.0", "## v0.22.0", "## v0.21.1", "## v0.21.0", "## v0.20.0",
+            "## v0.24.5",
+            "## v0.24.4",
+            "## v0.24.3",
+            "## v0.24.1",
+            "## v0.24.0",
+            "## v0.23.0",
+            "## v0.22.0",
+            "## v0.21.1",
+            "## v0.21.0",
+            "## v0.20.0",
         ):
             self.assertIn(marker, notes)
         self.assertNotIn("Unreleased v0.24", notes)

--- a/tests/test_windows_hook_commands.py
+++ b/tests/test_windows_hook_commands.py
@@ -102,6 +102,34 @@ class WindowsHookCommandTests(unittest.TestCase):
                         }
                     )
 
+                    def run_runner(
+                        shell_name: str, runner: str
+                    ) -> subprocess.CompletedProcess[str]:
+                        if shell_name == "PowerShell":
+                            invocation: str | list[str] = [
+                                powershell,
+                                "-NoProfile",
+                                "-NonInteractive",
+                                "-Command",
+                                runner,
+                            ]
+                            shell_options: dict[str, object] = {}
+                        else:
+                            invocation = runner
+                            shell_options = {
+                                "shell": True,
+                                "executable": command_prompt,
+                            }
+                        return subprocess.run(
+                            invocation,
+                            capture_output=True,
+                            text=True,
+                            cwd=workspace,
+                            env=environment,
+                            check=False,
+                            **shell_options,
+                        )
+
                     for event_name, mode in WINDOWS_MODES.items():
                         with self.subTest(plugin_root=root_name, event=event_name):
                             rendered = commands[event_name].replace(
@@ -183,26 +211,9 @@ class WindowsHookCommandTests(unittest.TestCase):
                     runner = payload["hookSpecificOutput"]["updatedInput"]["command"]
                     self.assertTrue(runner.startswith("py -3 "), runner)
 
-                    shells = {
-                        "PowerShell": [
-                            powershell,
-                            "-NoProfile",
-                            "-NonInteractive",
-                            "-Command",
-                            runner,
-                        ],
-                        "cmd.exe": [command_prompt, "/d", "/s", "/c", runner],
-                    }
-                    for shell_name, invocation in shells.items():
+                    for shell_name in ("PowerShell", "cmd.exe"):
                         with self.subTest(plugin_root=root_name, shell=shell_name):
-                            runner_result = subprocess.run(
-                                invocation,
-                                capture_output=True,
-                                text=True,
-                                cwd=workspace,
-                                env=environment,
-                                check=False,
-                            )
+                            runner_result = run_runner(shell_name, runner)
                             self.assertEqual(
                                 runner_result.returncode,
                                 0,
@@ -211,6 +222,88 @@ class WindowsHookCommandTests(unittest.TestCase):
                             )
                             self.assertEqual(
                                 runner_result.stdout, "portable Windows runner\n"
+                            )
+
+                    for shell_name in ("PowerShell", "cmd.exe"):
+                        suffix = (
+                            f"{root_name}-{shell_name}-stateful".replace(" ", "-")
+                        )
+                        review_event = synthetic_event(
+                            "PreToolUse", workspace, suffix
+                        )
+                        review_event["tool_input"] = {"command": "click-gate review"}
+                        review_result = subprocess.run(
+                            [
+                                powershell,
+                                "-NoProfile",
+                                "-NonInteractive",
+                                "-Command",
+                                rendered_hook,
+                            ],
+                            input=json.dumps(review_event) + "\n",
+                            capture_output=True,
+                            text=True,
+                            cwd=workspace,
+                            env=environment,
+                            check=False,
+                        )
+                        self.assertEqual(
+                            review_result.returncode,
+                            0,
+                            f"review hook failed:\n"
+                            f"{review_result.stderr}\n{review_result.stdout}",
+                        )
+
+                        stateful_event = synthetic_event(
+                            "PreToolUse", workspace, suffix
+                        )
+                        stateful_event["tool_input"] = inspect_event["tool_input"]
+                        stateful_result = subprocess.run(
+                            [
+                                powershell,
+                                "-NoProfile",
+                                "-NonInteractive",
+                                "-Command",
+                                rendered_hook,
+                            ],
+                            input=json.dumps(stateful_event) + "\n",
+                            capture_output=True,
+                            text=True,
+                            cwd=workspace,
+                            env=environment,
+                            check=False,
+                        )
+                        self.assertEqual(
+                            stateful_result.returncode,
+                            0,
+                            f"stateful inspect hook failed:\n"
+                            f"{stateful_result.stderr}\n{stateful_result.stdout}",
+                        )
+                        stateful_payload = json.loads(stateful_result.stdout)
+                        stateful_runner = stateful_payload["hookSpecificOutput"][
+                            "updatedInput"
+                        ]["command"]
+                        self.assertTrue(
+                            stateful_runner.startswith("py -3 "), stateful_runner
+                        )
+
+                        with self.subTest(
+                            plugin_root=root_name,
+                            shell=shell_name,
+                            runner="stateful",
+                        ):
+                            executed = run_runner(shell_name, stateful_runner)
+                            self.assertEqual(
+                                executed.returncode,
+                                0,
+                                f"{shell_name} stateful runner failed:\n"
+                                f"{executed.stderr}\n{executed.stdout}",
+                            )
+                            self.assertNotIn(
+                                "state-root binding", executed.stderr.lower()
+                            )
+                            self.assertEqual(
+                                executed.stdout, "portable Windows runner\n"
                             )
 
 

--- a/tests/test_windows_hook_commands.py
+++ b/tests/test_windows_hook_commands.py
@@ -76,6 +76,8 @@ class WindowsHookCommandTests(unittest.TestCase):
     def test_commands_execute_in_powershell_from_normal_and_spaced_roots(self) -> None:
         powershell = shutil.which("pwsh")
         self.assertIsNotNone(powershell, "pwsh is required on the Windows CI runner")
+        command_prompt = shutil.which("cmd.exe")
+        self.assertIsNotNone(command_prompt, "cmd.exe is required on Windows")
         commands = windows_commands()
 
         with tempfile.TemporaryDirectory() as temporary:
@@ -135,6 +137,81 @@ class WindowsHookCommandTests(unittest.TestCase):
                                 payload = json.loads(result.stdout)
                                 updated = payload["hookSpecificOutput"]["updatedInput"]
                                 self.assertIn("Click default mode:", updated["command"])
+
+                    probe = workspace / "runner probe.txt"
+                    probe.write_text("portable Windows runner\n", encoding="utf-8")
+                    request = {
+                        "version": 1,
+                        "commands": [["Get-Content", "-Raw", probe.name]],
+                    }
+                    inspect_event = synthetic_event(
+                        "PreToolUse",
+                        workspace,
+                        f"{root_name}-inspect".replace(" ", "-"),
+                    )
+                    inspect_event["tool_input"] = {
+                        "command": (
+                            "click-gate inspect '"
+                            + json.dumps(request, separators=(",", ":"))
+                            + "'"
+                        )
+                    }
+                    rendered_hook = commands["PreToolUse"].replace(
+                        "${PLUGIN_ROOT}", str(plugin_root)
+                    )
+                    hook_result = subprocess.run(
+                        [
+                            powershell,
+                            "-NoProfile",
+                            "-NonInteractive",
+                            "-Command",
+                            rendered_hook,
+                        ],
+                        input=json.dumps(inspect_event) + "\n",
+                        capture_output=True,
+                        text=True,
+                        cwd=workspace,
+                        env=environment,
+                        check=False,
+                    )
+                    self.assertEqual(
+                        hook_result.returncode,
+                        0,
+                        f"inspect hook failed:\n{hook_result.stderr}\n{hook_result.stdout}",
+                    )
+                    payload = json.loads(hook_result.stdout)
+                    runner = payload["hookSpecificOutput"]["updatedInput"]["command"]
+                    self.assertTrue(runner.startswith("py -3 "), runner)
+
+                    shells = {
+                        "PowerShell": [
+                            powershell,
+                            "-NoProfile",
+                            "-NonInteractive",
+                            "-Command",
+                            runner,
+                        ],
+                        "cmd.exe": [command_prompt, "/d", "/s", "/c", runner],
+                    }
+                    for shell_name, invocation in shells.items():
+                        with self.subTest(plugin_root=root_name, shell=shell_name):
+                            runner_result = subprocess.run(
+                                invocation,
+                                capture_output=True,
+                                text=True,
+                                cwd=workspace,
+                                env=environment,
+                                check=False,
+                            )
+                            self.assertEqual(
+                                runner_result.returncode,
+                                0,
+                                f"{shell_name} runner failed:\n"
+                                f"{runner_result.stderr}\n{runner_result.stdout}",
+                            )
+                            self.assertEqual(
+                                runner_result.stdout, "portable Windows runner\n"
+                            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- render Windows internal runners with a shell-portable bare py -3 launcher
- execute rewritten inspect runners in both PowerShell and cmd.exe from normal and spaced roots
- preserve Antigravity direct shell-free execution by normalizing back to the active interpreter
- publish v0.24.5 metadata, documentation, and generated distribution

## Validation
- python3 -m unittest discover -s tests: 298 passed, 2 platform skips locally
- python3 scripts/validate_distribution.py
- plugin manifest validator
- compileall and git diff --check