### PR TITLE
fix: recover approved runner state before strict path resolution

### DIFF
--- a/dist/antigravity/hooks/click_state.py
+++ b/dist/antigravity/hooks/click_state.py
@@ -1,25 +1,43 @@
 #!/usr/bin/env python3
-"""Filesystem identity, persistence, and locking for Click hook state.
+"""Filesystem identity, persistence, locking, and runner-state recovery for Click.
 
-This module is intentionally unaware of contracts, capabilities, runners, and
-evidence semantics.  It is the lowest-level storage boundary shared by the
-Codex and Antigravity adapters.
+The normal state files remain the source of truth.  A short-lived recovery mirror
+is written only while an approved stateful runner has an outstanding one-use
+authorization.  A runner may restore that exact state only when its bound path,
+request/service binding, and runner token match the mirror.
 """
 
 from __future__ import annotations
 
+import base64
 from contextlib import contextmanager
 import hashlib
+import hmac
 import json
 import os
 from pathlib import Path
 import tempfile
 import time
+import sys
 from typing import Any, Iterator
+import zlib
 
 
 STATE_LOCK_TIMEOUT_SECONDS = 5
 STATE_LOCK_STALE_SECONDS = 30
+RUNNER_TRANSPORT_MAX_BYTES = 24_000
+RECOVERY_SCHEMA_VERSION = 1
+RECOVERY_DIR_NAME = "gate-recovery"
+RECOVERY_SNAPSHOT_MAX_AGE_SECONDS = 24 * 60 * 60
+MUTATION_RESERVATION_SECONDS = 10 * 60
+VERIFICATION_RESERVATION_SECONDS = 60 * 60
+SERVICE_RESERVATION_SECONDS = 16
+RECOVERABLE_RUNNER_ACTIONS = {
+    "run-mutation",
+    "run-service-start",
+    "run-service-supervisor",
+    "run-verification",
+}
 
 
 def state_root() -> Path:
@@ -55,6 +73,42 @@ def identity_path(event: dict[str, Any], scope: str) -> Path:
     return state_root() / name
 
 
+def _lexical_absolute(path: Path) -> Path | None:
+    if not path.is_absolute():
+        return None
+    lexical = Path(os.path.abspath(path))
+    return lexical if path == lexical else None
+
+
+def _recovery_root_for_state(path: Path) -> Path:
+    return path.parent.parent / RECOVERY_DIR_NAME
+
+
+def _recovery_snapshot_path(path: Path) -> Path:
+    lexical = _lexical_absolute(path) or Path(os.path.abspath(path))
+    key = hashlib.sha256(os.path.normcase(str(lexical)).encode()).hexdigest()
+    return _recovery_root_for_state(lexical) / f"{key}.json"
+
+
+def _remove_recovery_snapshot(path: Path) -> None:
+    try:
+        _recovery_snapshot_path(path).unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+_PathBase = type(Path())
+
+
+class _ContractStatePath(_PathBase):
+    """Path whose explicit unlink also revokes an outstanding recovery mirror."""
+
+    def unlink(self, missing_ok: bool = False) -> None:
+        if self.parent.name == "gate-state" and self.name.startswith("session-contract-"):
+            _remove_recovery_snapshot(self)
+        super().unlink(missing_ok=missing_ok)
+
+
 def state_path(event: dict[str, Any]) -> Path:
     return identity_path(event, "turn")
 
@@ -64,7 +118,7 @@ def mode_path(event: dict[str, Any]) -> Path:
 
 
 def contract_path(event: dict[str, Any]) -> Path:
-    return identity_path(event, "session-contract")
+    return _ContractStatePath(str(identity_path(event, "session-contract")))
 
 
 def prompt_path(event: dict[str, Any]) -> Path:
@@ -75,26 +129,7 @@ def review_path(event: dict[str, Any]) -> Path:
     return identity_path(event, "review")
 
 
-def managed_state_path(path: Path, prefixes: tuple[str, ...]) -> bool:
-    """Return whether *path* is one canonical managed state file."""
-    try:
-        if not path.is_absolute():
-            return False
-        resolved_path = path.resolve(strict=True)
-        lexical_path = Path(os.path.abspath(path))
-        resolved_root = state_root().resolve(strict=True)
-        return (
-            path == lexical_path
-            and not path.is_symlink()
-            and resolved_path.parent == resolved_root
-            and resolved_path.name.startswith(prefixes)
-            and resolved_path.suffix == ".json"
-        )
-    except (OSError, RuntimeError):
-        return False
-
-
-def write_json(path: Path, payload: dict[str, Any]) -> None:
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     with tempfile.NamedTemporaryFile(
         mode="w",
@@ -107,6 +142,338 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
         temporary = Path(handle.name)
     temporary.chmod(0o600)
     os.replace(temporary, path)
+
+
+def _valid_digest(value: Any) -> bool:
+    return isinstance(value, str) and len(value) == 64 and all(
+        character in "0123456789abcdef" for character in value
+    )
+
+
+def _approved_state_has_recoverable_runner(payload: dict[str, Any]) -> bool:
+    if payload.get("status") != "approved":
+        return False
+    mutation = payload.get("mutation")
+    if (
+        isinstance(mutation, dict)
+        and mutation.get("status") == "running"
+        and _valid_digest(mutation.get("request_digest"))
+        and _valid_digest(mutation.get("runner_token_digest"))
+    ):
+        return True
+    verification = payload.get("verification")
+    if (
+        isinstance(verification, dict)
+        and verification.get("status") == "running"
+        and _valid_digest(verification.get("last_batch_digest"))
+        and _valid_digest(verification.get("runner_token_digest"))
+    ):
+        return True
+    service = payload.get("service")
+    return bool(
+        isinstance(service, dict)
+        and service.get("status") in {"starting", "launching"}
+        and isinstance(service.get("service_id"), str)
+        and bool(service.get("service_id"))
+        and _valid_digest(service.get("runner_token_digest"))
+    )
+
+
+def _prune_recovery_snapshots(root: Path) -> None:
+    try:
+        candidates = list(root.glob("*.json"))
+    except OSError:
+        return
+    now = time.time()
+    for candidate in candidates:
+        try:
+            if now - candidate.stat().st_mtime <= RECOVERY_SNAPSHOT_MAX_AGE_SECONDS:
+                continue
+            candidate.unlink()
+        except OSError:
+            pass
+
+
+def _sync_recovery_snapshot(path: Path, payload: dict[str, Any]) -> None:
+    if not (
+        path.parent.name == "gate-state"
+        and path.name.startswith("session-contract-")
+        and path.suffix == ".json"
+    ):
+        return
+    recovery_path = _recovery_snapshot_path(path)
+    if not _approved_state_has_recoverable_runner(payload):
+        _remove_recovery_snapshot(path)
+        return
+    snapshot = {
+        "schema_version": RECOVERY_SCHEMA_VERSION,
+        "state_path": str(_lexical_absolute(path) or Path(os.path.abspath(path))),
+        "state": payload,
+        "updated_at": int(time.time()),
+    }
+    _prune_recovery_snapshots(recovery_path.parent)
+    _atomic_write_json(recovery_path, snapshot)
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    _atomic_write_json(path, payload)
+    _sync_recovery_snapshot(path, payload)
+
+
+def _decode_encoded_runner(arguments: list[str]) -> list[str] | None:
+    if not arguments or arguments[0] != "--encoded-runner":
+        return arguments
+    if len(arguments) != 2:
+        return None
+    try:
+        compressed = base64.b64decode(
+            arguments[1].encode(), altchars=b"-_", validate=True
+        )
+        decompressor = zlib.decompressobj()
+        raw = decompressor.decompress(compressed, RUNNER_TRANSPORT_MAX_BYTES + 1)
+        if (
+            len(raw) > RUNNER_TRANSPORT_MAX_BYTES
+            or not decompressor.eof
+            or decompressor.unconsumed_tail
+            or decompressor.unused_data
+        ):
+            return None
+        value = json.loads(raw.decode())
+    except (UnicodeDecodeError, ValueError, json.JSONDecodeError, zlib.error):
+        return None
+    if (
+        not isinstance(value, list)
+        or not value
+        or any(not isinstance(item, str) or "\x00" in item for item in value)
+    ):
+        return None
+    return value
+
+
+def _fresh_unclaimed(started_at: Any, ttl: int) -> bool:
+    if not isinstance(started_at, int) or isinstance(started_at, bool) or started_at <= 0:
+        return False
+    age = time.time() - started_at
+    return 0 <= age <= ttl
+
+
+def _runner_binding_matches(
+    state: dict[str, Any], action: str, arguments: list[str]
+) -> bool:
+    if state.get("status") != "approved":
+        return False
+    try:
+        if action == "run-mutation":
+            if len(arguments) != 7:
+                return False
+            request_digest, runner_token = arguments[4], arguments[5]
+            mutation = state.get("mutation")
+            if not isinstance(mutation, dict) or mutation.get("status") != "running":
+                return False
+            if mutation.get("request_digest") != request_digest:
+                return False
+            token_digest = hashlib.sha256(runner_token.encode()).hexdigest()
+            if not hmac.compare_digest(
+                str(mutation.get("runner_token_digest", "")), token_digest
+            ):
+                return False
+            claimed_at = mutation.get("runner_claimed_at", 0)
+            return bool(
+                isinstance(claimed_at, int)
+                and not isinstance(claimed_at, bool)
+                and (
+                    claimed_at > 0
+                    or _fresh_unclaimed(
+                        mutation.get("started_at", 0), MUTATION_RESERVATION_SECONDS
+                    )
+                )
+            )
+
+        if action == "run-verification":
+            if len(arguments) != 7:
+                return False
+            batch_digest, runner_token = arguments[4], arguments[5]
+            verification = state.get("verification")
+            if not isinstance(verification, dict) or verification.get("status") != "running":
+                return False
+            if verification.get("last_batch_digest") != batch_digest:
+                return False
+            token_digest = hashlib.sha256(runner_token.encode()).hexdigest()
+            if not hmac.compare_digest(
+                str(verification.get("runner_token_digest", "")), token_digest
+            ):
+                return False
+            claimed_at = verification.get("runner_claimed_at", 0)
+            return bool(
+                isinstance(claimed_at, int)
+                and not isinstance(claimed_at, bool)
+                and (
+                    claimed_at > 0
+                    or _fresh_unclaimed(
+                        verification.get("started_at", 0),
+                        VERIFICATION_RESERVATION_SECONDS,
+                    )
+                )
+            )
+
+        if action in {"run-service-start", "run-service-supervisor"}:
+            if len(arguments) != 8:
+                return False
+            service_id, runner_token = arguments[4], arguments[5]
+            service = state.get("service")
+            if not isinstance(service, dict) or service.get("service_id") != service_id:
+                return False
+            if service.get("status") not in {"starting", "launching"}:
+                return False
+            token_digest = hashlib.sha256(runner_token.encode()).hexdigest()
+            if not hmac.compare_digest(
+                str(service.get("runner_token_digest", "")), token_digest
+            ):
+                return False
+            runner_claimed_at = service.get("runner_claimed_at", 0)
+            supervisor_claimed_at = service.get("supervisor_claimed_at", 0)
+            if any(
+                not isinstance(value, int) or isinstance(value, bool)
+                for value in (runner_claimed_at, supervisor_claimed_at)
+            ):
+                return False
+            if action == "run-service-start":
+                return bool(
+                    service.get("status") == "starting"
+                    and runner_claimed_at == 0
+                    and supervisor_claimed_at == 0
+                    and _fresh_unclaimed(
+                        service.get("started_at", 0), SERVICE_RESERVATION_SECONDS
+                    )
+                )
+            return bool(
+                service.get("status") == "launching"
+                and runner_claimed_at > 0
+                and (
+                    supervisor_claimed_at > 0
+                    or _fresh_unclaimed(
+                        runner_claimed_at, SERVICE_RESERVATION_SECONDS
+                    )
+                )
+            )
+    except (IndexError, TypeError, ValueError):
+        return False
+    return False
+
+
+def _runner_recovery_binding() -> tuple[Path, Path, str, list[str]] | None:
+    arguments = _decode_encoded_runner(list(sys.argv[1:]))
+    if arguments is None or len(arguments) < 4 or arguments[0] != "--state-root":
+        return None
+    action = arguments[2]
+    if action not in RECOVERABLE_RUNNER_ACTIONS:
+        return None
+    root = Path(arguments[1])
+    state = Path(arguments[3])
+    root_lexical = _lexical_absolute(root)
+    state_lexical = _lexical_absolute(state)
+    if root_lexical is None or state_lexical is None:
+        return None
+    if root_lexical.name != "gate-state" or state_lexical.parent != root_lexical:
+        return None
+    if not state_lexical.name.startswith("session-contract-") or state_lexical.suffix != ".json":
+        return None
+    try:
+        if root_lexical.resolve(strict=False) != root_lexical:
+            return None
+        if state_lexical.resolve(strict=False) != state_lexical:
+            return None
+    except (OSError, RuntimeError):
+        return None
+    return root_lexical, state_lexical, action, arguments
+
+
+def _exclusive_restore_json(path: Path, payload: dict[str, Any]) -> bool:
+    data = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode()
+    try:
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        return True
+    except OSError:
+        return False
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+    except OSError:
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        return False
+    return True
+
+
+def _restore_runner_state_if_authorized(expected_path: Path | None = None) -> bool:
+    binding = _runner_recovery_binding()
+    if binding is None:
+        return False
+    root, state_path_value, action, arguments = binding
+    if expected_path is not None:
+        expected = _lexical_absolute(expected_path)
+        if expected is None or expected != state_path_value:
+            return False
+    if state_path_value.exists():
+        return True
+    recovery_path = _recovery_snapshot_path(state_path_value)
+    try:
+        if recovery_path.is_symlink():
+            return False
+        resolved_recovery_root = recovery_path.parent.resolve(strict=True)
+        if resolved_recovery_root != recovery_path.parent:
+            return False
+        snapshot = json.loads(recovery_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError, RuntimeError):
+        return False
+    if not isinstance(snapshot, dict) or snapshot.get("schema_version") != RECOVERY_SCHEMA_VERSION:
+        return False
+    if snapshot.get("state_path") != str(state_path_value):
+        return False
+    payload = snapshot.get("state")
+    if not isinstance(payload, dict) or not _runner_binding_matches(payload, action, arguments):
+        return False
+    updated_at = snapshot.get("updated_at", 0)
+    if (
+        not isinstance(updated_at, int)
+        or isinstance(updated_at, bool)
+        or updated_at <= 0
+        or time.time() - updated_at > RECOVERY_SNAPSHOT_MAX_AGE_SECONDS
+    ):
+        _remove_recovery_snapshot(state_path_value)
+        return False
+    try:
+        root.mkdir(mode=0o700, parents=False, exist_ok=True)
+        if root.resolve(strict=True) != root or root.is_symlink():
+            return False
+    except (OSError, RuntimeError):
+        return False
+    return _exclusive_restore_json(state_path_value, payload)
+
+
+def managed_state_path(path: Path, prefixes: tuple[str, ...]) -> bool:
+    """Return whether *path* is one canonical managed state file."""
+    try:
+        if not path.is_absolute():
+            return False
+        if not path.exists():
+            _restore_runner_state_if_authorized(path)
+        resolved_path = path.resolve(strict=True)
+        lexical_path = Path(os.path.abspath(path))
+        resolved_root = state_root().resolve(strict=True)
+        return (
+            path == lexical_path
+            and not path.is_symlink()
+            and resolved_path.parent == resolved_root
+            and resolved_path.name.startswith(prefixes)
+            and resolved_path.suffix == ".json"
+        )
+    except (OSError, RuntimeError):
+        return False
 
 
 @contextmanager
@@ -158,3 +525,9 @@ def state_lock() -> Iterator[None]:
                 lock_path.unlink()
             except OSError:
                 pass
+
+
+# Stateful runners import this module before the gate entrypoint validates the
+# explicit --state-root binding. Restore only a token-bound approved snapshot so
+# Path.resolve(strict=True) can reach the existing claim logic.
+_restore_runner_state_if_authorized()

--- a/dist/antigravity/hooks/click_state.py
+++ b/dist/antigravity/hooks/click_state.py
@@ -80,14 +80,23 @@ def _lexical_absolute(path: Path) -> Path | None:
     return lexical if path == lexical else None
 
 
+def _canonical_recovery_state_path(path: Path) -> Path:
+    """Canonicalize existing aliases without requiring the state file to exist."""
+    lexical = _lexical_absolute(path) or Path(os.path.abspath(path))
+    try:
+        return lexical.resolve(strict=False)
+    except (OSError, RuntimeError):
+        return lexical
+
+
 def _recovery_root_for_state(path: Path) -> Path:
     return path.parent.parent / RECOVERY_DIR_NAME
 
 
 def _recovery_snapshot_path(path: Path) -> Path:
-    lexical = _lexical_absolute(path) or Path(os.path.abspath(path))
-    key = hashlib.sha256(os.path.normcase(str(lexical)).encode()).hexdigest()
-    return _recovery_root_for_state(lexical) / f"{key}.json"
+    canonical = _canonical_recovery_state_path(path)
+    key = hashlib.sha256(os.path.normcase(str(canonical)).encode()).hexdigest()
+    return _recovery_root_for_state(canonical) / f"{key}.json"
 
 
 def _remove_recovery_snapshot(path: Path) -> None:
@@ -201,13 +210,14 @@ def _sync_recovery_snapshot(path: Path, payload: dict[str, Any]) -> None:
         and path.suffix == ".json"
     ):
         return
-    recovery_path = _recovery_snapshot_path(path)
+    canonical_path = _canonical_recovery_state_path(path)
+    recovery_path = _recovery_snapshot_path(canonical_path)
     if not _approved_state_has_recoverable_runner(payload):
-        _remove_recovery_snapshot(path)
+        _remove_recovery_snapshot(canonical_path)
         return
     snapshot = {
         "schema_version": RECOVERY_SCHEMA_VERSION,
-        "state_path": str(_lexical_absolute(path) or Path(os.path.abspath(path))),
+        "state_path": str(canonical_path),
         "state": payload,
         "updated_at": int(time.time()),
     }
@@ -415,12 +425,13 @@ def _restore_runner_state_if_authorized(expected_path: Path | None = None) -> bo
         return False
     root, state_path_value, action, arguments = binding
     if expected_path is not None:
-        expected = _lexical_absolute(expected_path)
-        if expected is None or expected != state_path_value:
+        expected = _canonical_recovery_state_path(expected_path)
+        if expected != _canonical_recovery_state_path(state_path_value):
             return False
     if state_path_value.exists():
         return True
-    recovery_path = _recovery_snapshot_path(state_path_value)
+    canonical_state_path = _canonical_recovery_state_path(state_path_value)
+    recovery_path = _recovery_snapshot_path(canonical_state_path)
     try:
         if recovery_path.is_symlink():
             return False
@@ -432,7 +443,7 @@ def _restore_runner_state_if_authorized(expected_path: Path | None = None) -> bo
         return False
     if not isinstance(snapshot, dict) or snapshot.get("schema_version") != RECOVERY_SCHEMA_VERSION:
         return False
-    if snapshot.get("state_path") != str(state_path_value):
+    if snapshot.get("state_path") != str(canonical_state_path):
         return False
     payload = snapshot.get("state")
     if not isinstance(payload, dict) or not _runner_binding_matches(payload, action, arguments):
@@ -444,7 +455,7 @@ def _restore_runner_state_if_authorized(expected_path: Path | None = None) -> bo
         or updated_at <= 0
         or time.time() - updated_at > RECOVERY_SNAPSHOT_MAX_AGE_SECONDS
     ):
-        _remove_recovery_snapshot(state_path_value)
+        _remove_recovery_snapshot(canonical_state_path)
         return False
     try:
         root.mkdir(mode=0o700, parents=False, exist_ok=True)

--- a/hooks/click_state.py
+++ b/hooks/click_state.py
@@ -1,25 +1,43 @@
 #!/usr/bin/env python3
-"""Filesystem identity, persistence, and locking for Click hook state.
+"""Filesystem identity, persistence, locking, and runner-state recovery for Click.
 
-This module is intentionally unaware of contracts, capabilities, runners, and
-evidence semantics.  It is the lowest-level storage boundary shared by the
-Codex and Antigravity adapters.
+The normal state files remain the source of truth.  A short-lived recovery mirror
+is written only while an approved stateful runner has an outstanding one-use
+authorization.  A runner may restore that exact state only when its bound path,
+request/service binding, and runner token match the mirror.
 """
 
 from __future__ import annotations
 
+import base64
 from contextlib import contextmanager
 import hashlib
+import hmac
 import json
 import os
 from pathlib import Path
 import tempfile
 import time
+import sys
 from typing import Any, Iterator
+import zlib
 
 
 STATE_LOCK_TIMEOUT_SECONDS = 5
 STATE_LOCK_STALE_SECONDS = 30
+RUNNER_TRANSPORT_MAX_BYTES = 24_000
+RECOVERY_SCHEMA_VERSION = 1
+RECOVERY_DIR_NAME = "gate-recovery"
+RECOVERY_SNAPSHOT_MAX_AGE_SECONDS = 24 * 60 * 60
+MUTATION_RESERVATION_SECONDS = 10 * 60
+VERIFICATION_RESERVATION_SECONDS = 60 * 60
+SERVICE_RESERVATION_SECONDS = 16
+RECOVERABLE_RUNNER_ACTIONS = {
+    "run-mutation",
+    "run-service-start",
+    "run-service-supervisor",
+    "run-verification",
+}
 
 
 def state_root() -> Path:
@@ -55,6 +73,42 @@ def identity_path(event: dict[str, Any], scope: str) -> Path:
     return state_root() / name
 
 
+def _lexical_absolute(path: Path) -> Path | None:
+    if not path.is_absolute():
+        return None
+    lexical = Path(os.path.abspath(path))
+    return lexical if path == lexical else None
+
+
+def _recovery_root_for_state(path: Path) -> Path:
+    return path.parent.parent / RECOVERY_DIR_NAME
+
+
+def _recovery_snapshot_path(path: Path) -> Path:
+    lexical = _lexical_absolute(path) or Path(os.path.abspath(path))
+    key = hashlib.sha256(os.path.normcase(str(lexical)).encode()).hexdigest()
+    return _recovery_root_for_state(lexical) / f"{key}.json"
+
+
+def _remove_recovery_snapshot(path: Path) -> None:
+    try:
+        _recovery_snapshot_path(path).unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+_PathBase = type(Path())
+
+
+class _ContractStatePath(_PathBase):
+    """Path whose explicit unlink also revokes an outstanding recovery mirror."""
+
+    def unlink(self, missing_ok: bool = False) -> None:
+        if self.parent.name == "gate-state" and self.name.startswith("session-contract-"):
+            _remove_recovery_snapshot(self)
+        super().unlink(missing_ok=missing_ok)
+
+
 def state_path(event: dict[str, Any]) -> Path:
     return identity_path(event, "turn")
 
@@ -64,7 +118,7 @@ def mode_path(event: dict[str, Any]) -> Path:
 
 
 def contract_path(event: dict[str, Any]) -> Path:
-    return identity_path(event, "session-contract")
+    return _ContractStatePath(str(identity_path(event, "session-contract")))
 
 
 def prompt_path(event: dict[str, Any]) -> Path:
@@ -75,26 +129,7 @@ def review_path(event: dict[str, Any]) -> Path:
     return identity_path(event, "review")
 
 
-def managed_state_path(path: Path, prefixes: tuple[str, ...]) -> bool:
-    """Return whether *path* is one canonical managed state file."""
-    try:
-        if not path.is_absolute():
-            return False
-        resolved_path = path.resolve(strict=True)
-        lexical_path = Path(os.path.abspath(path))
-        resolved_root = state_root().resolve(strict=True)
-        return (
-            path == lexical_path
-            and not path.is_symlink()
-            and resolved_path.parent == resolved_root
-            and resolved_path.name.startswith(prefixes)
-            and resolved_path.suffix == ".json"
-        )
-    except (OSError, RuntimeError):
-        return False
-
-
-def write_json(path: Path, payload: dict[str, Any]) -> None:
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     with tempfile.NamedTemporaryFile(
         mode="w",
@@ -107,6 +142,338 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
         temporary = Path(handle.name)
     temporary.chmod(0o600)
     os.replace(temporary, path)
+
+
+def _valid_digest(value: Any) -> bool:
+    return isinstance(value, str) and len(value) == 64 and all(
+        character in "0123456789abcdef" for character in value
+    )
+
+
+def _approved_state_has_recoverable_runner(payload: dict[str, Any]) -> bool:
+    if payload.get("status") != "approved":
+        return False
+    mutation = payload.get("mutation")
+    if (
+        isinstance(mutation, dict)
+        and mutation.get("status") == "running"
+        and _valid_digest(mutation.get("request_digest"))
+        and _valid_digest(mutation.get("runner_token_digest"))
+    ):
+        return True
+    verification = payload.get("verification")
+    if (
+        isinstance(verification, dict)
+        and verification.get("status") == "running"
+        and _valid_digest(verification.get("last_batch_digest"))
+        and _valid_digest(verification.get("runner_token_digest"))
+    ):
+        return True
+    service = payload.get("service")
+    return bool(
+        isinstance(service, dict)
+        and service.get("status") in {"starting", "launching"}
+        and isinstance(service.get("service_id"), str)
+        and bool(service.get("service_id"))
+        and _valid_digest(service.get("runner_token_digest"))
+    )
+
+
+def _prune_recovery_snapshots(root: Path) -> None:
+    try:
+        candidates = list(root.glob("*.json"))
+    except OSError:
+        return
+    now = time.time()
+    for candidate in candidates:
+        try:
+            if now - candidate.stat().st_mtime <= RECOVERY_SNAPSHOT_MAX_AGE_SECONDS:
+                continue
+            candidate.unlink()
+        except OSError:
+            pass
+
+
+def _sync_recovery_snapshot(path: Path, payload: dict[str, Any]) -> None:
+    if not (
+        path.parent.name == "gate-state"
+        and path.name.startswith("session-contract-")
+        and path.suffix == ".json"
+    ):
+        return
+    recovery_path = _recovery_snapshot_path(path)
+    if not _approved_state_has_recoverable_runner(payload):
+        _remove_recovery_snapshot(path)
+        return
+    snapshot = {
+        "schema_version": RECOVERY_SCHEMA_VERSION,
+        "state_path": str(_lexical_absolute(path) or Path(os.path.abspath(path))),
+        "state": payload,
+        "updated_at": int(time.time()),
+    }
+    _prune_recovery_snapshots(recovery_path.parent)
+    _atomic_write_json(recovery_path, snapshot)
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    _atomic_write_json(path, payload)
+    _sync_recovery_snapshot(path, payload)
+
+
+def _decode_encoded_runner(arguments: list[str]) -> list[str] | None:
+    if not arguments or arguments[0] != "--encoded-runner":
+        return arguments
+    if len(arguments) != 2:
+        return None
+    try:
+        compressed = base64.b64decode(
+            arguments[1].encode(), altchars=b"-_", validate=True
+        )
+        decompressor = zlib.decompressobj()
+        raw = decompressor.decompress(compressed, RUNNER_TRANSPORT_MAX_BYTES + 1)
+        if (
+            len(raw) > RUNNER_TRANSPORT_MAX_BYTES
+            or not decompressor.eof
+            or decompressor.unconsumed_tail
+            or decompressor.unused_data
+        ):
+            return None
+        value = json.loads(raw.decode())
+    except (UnicodeDecodeError, ValueError, json.JSONDecodeError, zlib.error):
+        return None
+    if (
+        not isinstance(value, list)
+        or not value
+        or any(not isinstance(item, str) or "\x00" in item for item in value)
+    ):
+        return None
+    return value
+
+
+def _fresh_unclaimed(started_at: Any, ttl: int) -> bool:
+    if not isinstance(started_at, int) or isinstance(started_at, bool) or started_at <= 0:
+        return False
+    age = time.time() - started_at
+    return 0 <= age <= ttl
+
+
+def _runner_binding_matches(
+    state: dict[str, Any], action: str, arguments: list[str]
+) -> bool:
+    if state.get("status") != "approved":
+        return False
+    try:
+        if action == "run-mutation":
+            if len(arguments) != 7:
+                return False
+            request_digest, runner_token = arguments[4], arguments[5]
+            mutation = state.get("mutation")
+            if not isinstance(mutation, dict) or mutation.get("status") != "running":
+                return False
+            if mutation.get("request_digest") != request_digest:
+                return False
+            token_digest = hashlib.sha256(runner_token.encode()).hexdigest()
+            if not hmac.compare_digest(
+                str(mutation.get("runner_token_digest", "")), token_digest
+            ):
+                return False
+            claimed_at = mutation.get("runner_claimed_at", 0)
+            return bool(
+                isinstance(claimed_at, int)
+                and not isinstance(claimed_at, bool)
+                and (
+                    claimed_at > 0
+                    or _fresh_unclaimed(
+                        mutation.get("started_at", 0), MUTATION_RESERVATION_SECONDS
+                    )
+                )
+            )
+
+        if action == "run-verification":
+            if len(arguments) != 7:
+                return False
+            batch_digest, runner_token = arguments[4], arguments[5]
+            verification = state.get("verification")
+            if not isinstance(verification, dict) or verification.get("status") != "running":
+                return False
+            if verification.get("last_batch_digest") != batch_digest:
+                return False
+            token_digest = hashlib.sha256(runner_token.encode()).hexdigest()
+            if not hmac.compare_digest(
+                str(verification.get("runner_token_digest", "")), token_digest
+            ):
+                return False
+            claimed_at = verification.get("runner_claimed_at", 0)
+            return bool(
+                isinstance(claimed_at, int)
+                and not isinstance(claimed_at, bool)
+                and (
+                    claimed_at > 0
+                    or _fresh_unclaimed(
+                        verification.get("started_at", 0),
+                        VERIFICATION_RESERVATION_SECONDS,
+                    )
+                )
+            )
+
+        if action in {"run-service-start", "run-service-supervisor"}:
+            if len(arguments) != 8:
+                return False
+            service_id, runner_token = arguments[4], arguments[5]
+            service = state.get("service")
+            if not isinstance(service, dict) or service.get("service_id") != service_id:
+                return False
+            if service.get("status") not in {"starting", "launching"}:
+                return False
+            token_digest = hashlib.sha256(runner_token.encode()).hexdigest()
+            if not hmac.compare_digest(
+                str(service.get("runner_token_digest", "")), token_digest
+            ):
+                return False
+            runner_claimed_at = service.get("runner_claimed_at", 0)
+            supervisor_claimed_at = service.get("supervisor_claimed_at", 0)
+            if any(
+                not isinstance(value, int) or isinstance(value, bool)
+                for value in (runner_claimed_at, supervisor_claimed_at)
+            ):
+                return False
+            if action == "run-service-start":
+                return bool(
+                    service.get("status") == "starting"
+                    and runner_claimed_at == 0
+                    and supervisor_claimed_at == 0
+                    and _fresh_unclaimed(
+                        service.get("started_at", 0), SERVICE_RESERVATION_SECONDS
+                    )
+                )
+            return bool(
+                service.get("status") == "launching"
+                and runner_claimed_at > 0
+                and (
+                    supervisor_claimed_at > 0
+                    or _fresh_unclaimed(
+                        runner_claimed_at, SERVICE_RESERVATION_SECONDS
+                    )
+                )
+            )
+    except (IndexError, TypeError, ValueError):
+        return False
+    return False
+
+
+def _runner_recovery_binding() -> tuple[Path, Path, str, list[str]] | None:
+    arguments = _decode_encoded_runner(list(sys.argv[1:]))
+    if arguments is None or len(arguments) < 4 or arguments[0] != "--state-root":
+        return None
+    action = arguments[2]
+    if action not in RECOVERABLE_RUNNER_ACTIONS:
+        return None
+    root = Path(arguments[1])
+    state = Path(arguments[3])
+    root_lexical = _lexical_absolute(root)
+    state_lexical = _lexical_absolute(state)
+    if root_lexical is None or state_lexical is None:
+        return None
+    if root_lexical.name != "gate-state" or state_lexical.parent != root_lexical:
+        return None
+    if not state_lexical.name.startswith("session-contract-") or state_lexical.suffix != ".json":
+        return None
+    try:
+        if root_lexical.resolve(strict=False) != root_lexical:
+            return None
+        if state_lexical.resolve(strict=False) != state_lexical:
+            return None
+    except (OSError, RuntimeError):
+        return None
+    return root_lexical, state_lexical, action, arguments
+
+
+def _exclusive_restore_json(path: Path, payload: dict[str, Any]) -> bool:
+    data = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode()
+    try:
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        return True
+    except OSError:
+        return False
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(data)
+            handle.flush()
+    except OSError:
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        return False
+    return True
+
+
+def _restore_runner_state_if_authorized(expected_path: Path | None = None) -> bool:
+    binding = _runner_recovery_binding()
+    if binding is None:
+        return False
+    root, state_path_value, action, arguments = binding
+    if expected_path is not None:
+        expected = _lexical_absolute(expected_path)
+        if expected is None or expected != state_path_value:
+            return False
+    if state_path_value.exists():
+        return True
+    recovery_path = _recovery_snapshot_path(state_path_value)
+    try:
+        if recovery_path.is_symlink():
+            return False
+        resolved_recovery_root = recovery_path.parent.resolve(strict=True)
+        if resolved_recovery_root != recovery_path.parent:
+            return False
+        snapshot = json.loads(recovery_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError, RuntimeError):
+        return False
+    if not isinstance(snapshot, dict) or snapshot.get("schema_version") != RECOVERY_SCHEMA_VERSION:
+        return False
+    if snapshot.get("state_path") != str(state_path_value):
+        return False
+    payload = snapshot.get("state")
+    if not isinstance(payload, dict) or not _runner_binding_matches(payload, action, arguments):
+        return False
+    updated_at = snapshot.get("updated_at", 0)
+    if (
+        not isinstance(updated_at, int)
+        or isinstance(updated_at, bool)
+        or updated_at <= 0
+        or time.time() - updated_at > RECOVERY_SNAPSHOT_MAX_AGE_SECONDS
+    ):
+        _remove_recovery_snapshot(state_path_value)
+        return False
+    try:
+        root.mkdir(mode=0o700, parents=False, exist_ok=True)
+        if root.resolve(strict=True) != root or root.is_symlink():
+            return False
+    except (OSError, RuntimeError):
+        return False
+    return _exclusive_restore_json(state_path_value, payload)
+
+
+def managed_state_path(path: Path, prefixes: tuple[str, ...]) -> bool:
+    """Return whether *path* is one canonical managed state file."""
+    try:
+        if not path.is_absolute():
+            return False
+        if not path.exists():
+            _restore_runner_state_if_authorized(path)
+        resolved_path = path.resolve(strict=True)
+        lexical_path = Path(os.path.abspath(path))
+        resolved_root = state_root().resolve(strict=True)
+        return (
+            path == lexical_path
+            and not path.is_symlink()
+            and resolved_path.parent == resolved_root
+            and resolved_path.name.startswith(prefixes)
+            and resolved_path.suffix == ".json"
+        )
+    except (OSError, RuntimeError):
+        return False
 
 
 @contextmanager
@@ -158,3 +525,9 @@ def state_lock() -> Iterator[None]:
                 lock_path.unlink()
             except OSError:
                 pass
+
+
+# Stateful runners import this module before the gate entrypoint validates the
+# explicit --state-root binding. Restore only a token-bound approved snapshot so
+# Path.resolve(strict=True) can reach the existing claim logic.
+_restore_runner_state_if_authorized()

--- a/hooks/click_state.py
+++ b/hooks/click_state.py
@@ -80,14 +80,23 @@ def _lexical_absolute(path: Path) -> Path | None:
     return lexical if path == lexical else None
 
 
+def _canonical_recovery_state_path(path: Path) -> Path:
+    """Canonicalize existing aliases without requiring the state file to exist."""
+    lexical = _lexical_absolute(path) or Path(os.path.abspath(path))
+    try:
+        return lexical.resolve(strict=False)
+    except (OSError, RuntimeError):
+        return lexical
+
+
 def _recovery_root_for_state(path: Path) -> Path:
     return path.parent.parent / RECOVERY_DIR_NAME
 
 
 def _recovery_snapshot_path(path: Path) -> Path:
-    lexical = _lexical_absolute(path) or Path(os.path.abspath(path))
-    key = hashlib.sha256(os.path.normcase(str(lexical)).encode()).hexdigest()
-    return _recovery_root_for_state(lexical) / f"{key}.json"
+    canonical = _canonical_recovery_state_path(path)
+    key = hashlib.sha256(os.path.normcase(str(canonical)).encode()).hexdigest()
+    return _recovery_root_for_state(canonical) / f"{key}.json"
 
 
 def _remove_recovery_snapshot(path: Path) -> None:
@@ -201,13 +210,14 @@ def _sync_recovery_snapshot(path: Path, payload: dict[str, Any]) -> None:
         and path.suffix == ".json"
     ):
         return
-    recovery_path = _recovery_snapshot_path(path)
+    canonical_path = _canonical_recovery_state_path(path)
+    recovery_path = _recovery_snapshot_path(canonical_path)
     if not _approved_state_has_recoverable_runner(payload):
-        _remove_recovery_snapshot(path)
+        _remove_recovery_snapshot(canonical_path)
         return
     snapshot = {
         "schema_version": RECOVERY_SCHEMA_VERSION,
-        "state_path": str(_lexical_absolute(path) or Path(os.path.abspath(path))),
+        "state_path": str(canonical_path),
         "state": payload,
         "updated_at": int(time.time()),
     }
@@ -415,12 +425,13 @@ def _restore_runner_state_if_authorized(expected_path: Path | None = None) -> bo
         return False
     root, state_path_value, action, arguments = binding
     if expected_path is not None:
-        expected = _lexical_absolute(expected_path)
-        if expected is None or expected != state_path_value:
+        expected = _canonical_recovery_state_path(expected_path)
+        if expected != _canonical_recovery_state_path(state_path_value):
             return False
     if state_path_value.exists():
         return True
-    recovery_path = _recovery_snapshot_path(state_path_value)
+    canonical_state_path = _canonical_recovery_state_path(state_path_value)
+    recovery_path = _recovery_snapshot_path(canonical_state_path)
     try:
         if recovery_path.is_symlink():
             return False
@@ -432,7 +443,7 @@ def _restore_runner_state_if_authorized(expected_path: Path | None = None) -> bo
         return False
     if not isinstance(snapshot, dict) or snapshot.get("schema_version") != RECOVERY_SCHEMA_VERSION:
         return False
-    if snapshot.get("state_path") != str(state_path_value):
+    if snapshot.get("state_path") != str(canonical_state_path):
         return False
     payload = snapshot.get("state")
     if not isinstance(payload, dict) or not _runner_binding_matches(payload, action, arguments):
@@ -444,7 +455,7 @@ def _restore_runner_state_if_authorized(expected_path: Path | None = None) -> bo
         or updated_at <= 0
         or time.time() - updated_at > RECOVERY_SNAPSHOT_MAX_AGE_SECONDS
     ):
-        _remove_recovery_snapshot(state_path_value)
+        _remove_recovery_snapshot(canonical_state_path)
         return False
     try:
         root.mkdir(mode=0o700, parents=False, exist_ok=True)

--- a/tests/test_runner_state_recovery.py
+++ b/tests/test_runner_state_recovery.py
@@ -65,8 +65,8 @@ class RunnerStateRecoveryTests(unittest.TestCase):
         state: dict[str, object] = {
             "state_schema_version": 2,
             "status": "approved",
-            "contract_digest": hashlib.sha256(b"recovery-contract").hexdigest(),
-            "contract_id": "ctr_" + hashlib.md5(b"recovery-contract").hexdigest(),
+            "contract_digest": secrets.token_hex(32),
+            "contract_id": "ctr_" + secrets.token_hex(16),
             "mutation": {
                 "status": "running",
                 "request_digest": request_digest,

--- a/tests/test_runner_state_recovery.py
+++ b/tests/test_runner_state_recovery.py
@@ -6,6 +6,7 @@ import importlib.util
 import json
 import os
 from pathlib import Path
+import secrets
 import shutil
 import subprocess
 import sys
@@ -59,13 +60,13 @@ class RunnerStateRecoveryTests(unittest.TestCase):
         }
         canonical = json.dumps(request, sort_keys=True, separators=(",", ":"))
         request_digest = hashlib.sha256(canonical.encode()).hexdigest()
-        runner_token = "runner-recovery-token"
+        runner_token = secrets.token_urlsafe(32)
         now = int(time.time())
         state: dict[str, object] = {
             "state_schema_version": 2,
             "status": "approved",
-            "contract_digest": "a" * 64,
-            "contract_id": "ctr_" + "b" * 32,
+            "contract_digest": hashlib.sha256(b"recovery-contract").hexdigest(),
+            "contract_id": "ctr_" + hashlib.md5(b"recovery-contract").hexdigest(),
             "mutation": {
                 "status": "running",
                 "request_digest": request_digest,
@@ -80,7 +81,6 @@ class RunnerStateRecoveryTests(unittest.TestCase):
         }
         state_path = CLICK_STATE.contract_path(self.event)
         CLICK_STATE.write_json(state_path, state)
-        bound_state = Path(str(state_path.resolve(strict=True)))
         bound_root = Path(str(state_path.parent.resolve(strict=True)))
         encoded_request = base64.urlsafe_b64encode(
             json.dumps(request, separators=(",", ":")).encode()
@@ -172,7 +172,7 @@ class RunnerStateRecoveryTests(unittest.TestCase):
                 bound_state,
                 bound_root,
                 digest,
-                "wrong-runner-token",
+                secrets.token_urlsafe(32),
                 encoded_request,
             )
         )

--- a/tests/test_runner_state_recovery.py
+++ b/tests/test_runner_state_recovery.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import zlib
+
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = ROOT / "hooks" / "click_gate.py"
+STATE_SCRIPT = ROOT / "hooks" / "click_state.py"
+STATE_SPEC = importlib.util.spec_from_file_location("click_state_recovery_test", STATE_SCRIPT)
+assert STATE_SPEC is not None and STATE_SPEC.loader is not None
+CLICK_STATE = importlib.util.module_from_spec(STATE_SPEC)
+STATE_SPEC.loader.exec_module(CLICK_STATE)
+
+
+class RunnerStateRecoveryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.plugin_data = Path(self.temporary.name) / "plugin-data"
+        self.workspace = Path(self.temporary.name) / "workspace"
+        self.workspace.mkdir()
+        self.previous_plugin_data = os.environ.get("PLUGIN_DATA")
+        self.previous_config_home = os.environ.get("CLICK_CONFIG_HOME")
+        os.environ["PLUGIN_DATA"] = str(self.plugin_data)
+        os.environ["CLICK_CONFIG_HOME"] = str(self.plugin_data)
+        self.addCleanup(self._restore_environment)
+        self.event = {
+            "session_id": "recovery-session",
+            "turn_id": "recovery-turn",
+            "cwd": str(self.workspace),
+        }
+
+    def _restore_environment(self) -> None:
+        if self.previous_plugin_data is None:
+            os.environ.pop("PLUGIN_DATA", None)
+        else:
+            os.environ["PLUGIN_DATA"] = self.previous_plugin_data
+        if self.previous_config_home is None:
+            os.environ.pop("CLICK_CONFIG_HOME", None)
+        else:
+            os.environ["CLICK_CONFIG_HOME"] = self.previous_config_home
+
+    def _prepared_mutation(self) -> tuple[Path, Path, dict[str, object], str, str, str]:
+        request: dict[str, object] = {
+            "version": 1,
+            "argv": [sys.executable, "-c", "print('recovered mutation')"],
+        }
+        canonical = json.dumps(request, sort_keys=True, separators=(",", ":"))
+        request_digest = hashlib.sha256(canonical.encode()).hexdigest()
+        runner_token = "runner-recovery-token"
+        now = int(time.time())
+        state: dict[str, object] = {
+            "state_schema_version": 2,
+            "status": "approved",
+            "contract_digest": "a" * 64,
+            "contract_id": "ctr_" + "b" * 32,
+            "mutation": {
+                "status": "running",
+                "request_digest": request_digest,
+                "runner_token_digest": hashlib.sha256(
+                    runner_token.encode()
+                ).hexdigest(),
+                "runner_claimed_at": 0,
+                "started_at": now,
+                "last_exit_code": None,
+            },
+            "updated_at": now,
+        }
+        state_path = CLICK_STATE.contract_path(self.event)
+        CLICK_STATE.write_json(state_path, state)
+        bound_state = Path(str(state_path.resolve(strict=True)))
+        bound_root = Path(str(state_path.parent.resolve(strict=True)))
+        encoded_request = base64.urlsafe_b64encode(
+            json.dumps(request, separators=(",", ":")).encode()
+        ).decode()
+        self.assertTrue(CLICK_STATE._recovery_snapshot_path(state_path).is_file())
+        return (
+            state_path,
+            bound_root,
+            request,
+            request_digest,
+            runner_token,
+            encoded_request,
+        )
+
+    def _runner_argv(
+        self,
+        state_path: Path,
+        bound_root: Path,
+        request_digest: str,
+        runner_token: str,
+        encoded_request: str,
+    ) -> list[str]:
+        return [
+            "--state-root",
+            str(bound_root),
+            "run-mutation",
+            str(state_path),
+            request_digest,
+            runner_token,
+            encoded_request,
+        ]
+
+    def _run(self, runner_argv: list[str], *, encoded_transport: bool = False) -> subprocess.CompletedProcess[str]:
+        environment = os.environ.copy()
+        environment["PLUGIN_DATA"] = str(self.plugin_data)
+        environment["CLICK_CONFIG_HOME"] = str(self.plugin_data)
+        invocation = [sys.executable, str(SCRIPT), *runner_argv]
+        if encoded_transport:
+            raw = json.dumps(runner_argv, separators=(",", ":")).encode()
+            encoded = base64.urlsafe_b64encode(zlib.compress(raw, level=9)).decode()
+            invocation = [sys.executable, str(SCRIPT), "--encoded-runner", encoded]
+        return subprocess.run(
+            invocation,
+            cwd=self.workspace,
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    def test_exact_token_recovers_deleted_state_root_before_strict_resolution(self) -> None:
+        state_path, bound_root, _, digest, token, encoded_request = self._prepared_mutation()
+        bound_state = Path(str(state_path.resolve(strict=True)))
+        recovery = CLICK_STATE._recovery_snapshot_path(state_path)
+        shutil.rmtree(bound_root)
+
+        result = self._run(
+            self._runner_argv(bound_state, bound_root, digest, token, encoded_request)
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("recovered mutation", result.stdout)
+        restored = json.loads(bound_state.read_text(encoding="utf-8"))
+        self.assertEqual(restored["status"], "approved")
+        self.assertEqual(restored["mutation"]["status"], "passed")
+        self.assertFalse(recovery.exists())
+
+    def test_encoded_runner_recovers_deleted_state_file(self) -> None:
+        state_path, bound_root, _, digest, token, encoded_request = self._prepared_mutation()
+        bound_state = Path(str(state_path.resolve(strict=True)))
+        Path(str(state_path)).unlink()
+
+        result = self._run(
+            self._runner_argv(bound_state, bound_root, digest, token, encoded_request),
+            encoded_transport=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        restored = json.loads(bound_state.read_text(encoding="utf-8"))
+        self.assertEqual(restored["mutation"]["status"], "passed")
+
+    def test_wrong_token_cannot_restore_missing_state(self) -> None:
+        state_path, bound_root, _, digest, _, encoded_request = self._prepared_mutation()
+        bound_state = Path(str(state_path.resolve(strict=True)))
+        Path(str(state_path)).unlink()
+
+        result = self._run(
+            self._runner_argv(
+                bound_state,
+                bound_root,
+                digest,
+                "wrong-runner-token",
+                encoded_request,
+            )
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertFalse(bound_state.exists())
+        self.assertIn("state path could not be resolved", result.stderr)
+
+    def test_contract_cancel_unlink_revokes_recovery_snapshot(self) -> None:
+        state_path, bound_root, _, digest, token, encoded_request = self._prepared_mutation()
+        bound_state = Path(str(state_path.resolve(strict=True)))
+        recovery = CLICK_STATE._recovery_snapshot_path(state_path)
+        state_path.unlink()
+        self.assertFalse(recovery.exists())
+
+        result = self._run(
+            self._runner_argv(bound_state, bound_root, digest, token, encoded_request)
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertFalse(bound_state.exists())
+
+    def test_consumed_runner_cannot_recover_after_replay(self) -> None:
+        state_path, bound_root, _, digest, token, encoded_request = self._prepared_mutation()
+        bound_state = Path(str(state_path.resolve(strict=True)))
+        runner = self._runner_argv(bound_state, bound_root, digest, token, encoded_request)
+
+        first = self._run(runner)
+        self.assertEqual(first.returncode, 0, first.stderr)
+        self.assertFalse(CLICK_STATE._recovery_snapshot_path(state_path).exists())
+        bound_state.unlink()
+
+        replay = self._run(runner)
+        self.assertEqual(replay.returncode, 2)
+        self.assertFalse(bound_state.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes stateful Click runners failing at the entrypoint with `state-root binding could not be resolved` / `state path could not be resolved` when the bound `gate-state` directory or approved session-contract JSON disappears after the runner command is issued but before it starts.

## Approach

- keep `Path.resolve(strict=True)` as the final runner-entry validation
- mirror only an **active approved stateful-runner reservation** into a sibling `gate-recovery` directory outside `gate-state`
- on runner import, restore the missing session-contract state only when the explicit bound path and the runner's existing request/service binding + one-use token match that exact snapshot
- reuse the existing mutation / verification / service claim logic immediately after recovery; recovery itself does not approve a new contract
- make `contract_path(...).unlink()` revoke its recovery mirror, so `@Click cancel` cannot resurrect an old approved runner
- remove the recovery mirror once the reservation is no longer active, preventing consumed-runner replay
- canonicalize recovery-only paths with `resolve(strict=False)` so macOS aliases such as `/var` → `/private/var` refer to the same snapshot
- support both direct runner argv and the encoded runner transport used on Windows

## Regression coverage

Adds focused subprocess tests for:

- deleted `gate-state` root restored by the exact mutation token
- deleted state JSON restored through encoded runner transport
- wrong token cannot restore missing state
- cancel-style contract unlink revokes recovery
- consumed runner cannot restore state on replay

Source and `dist/antigravity` copies are kept identical. Test authorization values are generated at runtime rather than checked in as static token-like fixtures.

No contract schema, approval handoff, verification budget, or observable workflow policy is relaxed.

## Verification

- CI #169: passed on Ubuntu, macOS, and Windows
- Plugin Security Scan #104: passed