### PR TITLE
fix: fall back when Windows py launcher has no Python

### DIFF
--- a/hooks/click_windows.cmd
+++ b/hooks/click_windows.cmd
@@ -1,13 +1,13 @@
 @echo off
 setlocal
 
-py -3 -c "import sys; raise SystemExit(sys.version_info.major != 3)" >nul 2>&1
+"%ComSpec%" /d /c py -3 -c "import sys; raise SystemExit(sys.version_info.major != 3)" >nul 2>&1
 if not errorlevel 1 goto run_py
 
-python -c "import sys; raise SystemExit(sys.version_info.major != 3)" >nul 2>&1
+"%ComSpec%" /d /c python -c "import sys; raise SystemExit(sys.version_info.major != 3)" >nul 2>&1
 if not errorlevel 1 goto run_python
 
-python3 -c "import sys; raise SystemExit(sys.version_info.major != 3)" >nul 2>&1
+"%ComSpec%" /d /c python3 -c "import sys; raise SystemExit(sys.version_info.major != 3)" >nul 2>&1
 if not errorlevel 1 goto run_python3
 
 goto no_python

--- a/hooks/click_windows.cmd
+++ b/hooks/click_windows.cmd
@@ -1,38 +1,28 @@
 @echo off
 setlocal
 
-if /I "%~1"=="--python" goto exact_python
-
 py -3 -c "import sys; raise SystemExit(sys.version_info.major != 3)" >nul 2>&1
-if not errorlevel 1 (
-  py -3 "%~dp0click_windows.py" %*
-  exit /b %errorlevel%
-)
+if not errorlevel 1 goto run_py
 
 python -c "import sys; raise SystemExit(sys.version_info.major != 3)" >nul 2>&1
-if not errorlevel 1 (
-  python "%~dp0click_windows.py" %*
-  exit /b %errorlevel%
-)
+if not errorlevel 1 goto run_python
 
 python3 -c "import sys; raise SystemExit(sys.version_info.major != 3)" >nul 2>&1
-if not errorlevel 1 (
-  python3 "%~dp0click_windows.py" %*
-  exit /b %errorlevel%
-)
+if not errorlevel 1 goto run_python3
 
 goto no_python
 
-:exact_python
-if "%~2"=="" goto no_python
-if /I not "%~3"=="--encoded-runner" goto invalid_exact
-if "%~4"=="" goto invalid_exact
-"%~2" "%~dp0click_windows.py" --encoded-runner "%~4"
+:run_py
+py -3 "%~dp0click_windows.py" %*
 exit /b %errorlevel%
 
-:invalid_exact
->&2 echo Click Windows runner transport was malformed.
-exit /b 2
+:run_python
+python "%~dp0click_windows.py" %*
+exit /b %errorlevel%
+
+:run_python3
+python3 "%~dp0click_windows.py" %*
+exit /b %errorlevel%
 
 :no_python
 >&2 echo Click requires Python 3. The Windows launcher tried py -3, python, and python3 but none could run Python 3.

--- a/hooks/click_windows.cmd
+++ b/hooks/click_windows.cmd
@@ -1,0 +1,39 @@
+@echo off
+setlocal
+
+if /I "%~1"=="--python" goto exact_python
+
+py -3 -c "import sys; raise SystemExit(sys.version_info.major != 3)" >nul 2>&1
+if not errorlevel 1 (
+  py -3 "%~dp0click_windows.py" %*
+  exit /b %errorlevel%
+)
+
+python -c "import sys; raise SystemExit(sys.version_info.major != 3)" >nul 2>&1
+if not errorlevel 1 (
+  python "%~dp0click_windows.py" %*
+  exit /b %errorlevel%
+)
+
+python3 -c "import sys; raise SystemExit(sys.version_info.major != 3)" >nul 2>&1
+if not errorlevel 1 (
+  python3 "%~dp0click_windows.py" %*
+  exit /b %errorlevel%
+)
+
+goto no_python
+
+:exact_python
+if "%~2"=="" goto no_python
+if /I not "%~3"=="--encoded-runner" goto invalid_exact
+if "%~4"=="" goto invalid_exact
+"%~2" "%~dp0click_windows.py" --encoded-runner "%~4"
+exit /b %errorlevel%
+
+:invalid_exact
+>&2 echo Click Windows runner transport was malformed.
+exit /b 2
+
+:no_python
+>&2 echo Click requires Python 3. The Windows launcher tried py -3, python, and python3 but none could run Python 3.
+exit /b 9009

--- a/hooks/click_windows.py
+++ b/hooks/click_windows.py
@@ -28,14 +28,14 @@ def _runner_shell_command(arguments: list[str]) -> str:
         return "exit 2"
     try:
         interpreter = Path(arguments[0]).resolve(strict=True)
-        launcher = Path(__file__).with_name("click_windows.cmd").resolve(strict=True)
+        script_path = Path(arguments[1]).resolve(strict=True)
     except (OSError, RuntimeError):
         return "exit 2"
-    if not interpreter.is_file() or not launcher.is_file():
+    if not interpreter.is_file() or not script_path.is_file():
         return "exit 2"
     if not all(
         click_gate._windows_launcher_path_is_safe(value)
-        for value in (str(interpreter), str(launcher))
+        for value in (str(interpreter), str(script_path))
     ):
         return "exit 2"
 
@@ -43,9 +43,8 @@ def _runner_shell_command(arguments: list[str]) -> str:
     script = " ".join(
         (
             "&",
-            _powershell_single_quote(str(launcher)),
-            "--python",
             _powershell_single_quote(str(interpreter)),
+            _powershell_single_quote(str(script_path)),
             "--encoded-runner",
             _powershell_single_quote(encoded),
         )

--- a/hooks/click_windows.py
+++ b/hooks/click_windows.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Windows launcher bridge for Click.
+
+The batch launcher selects an available Python 3 interpreter. This bridge keeps
+that exact interpreter for rewritten Click runners so a missing or broken
+`py -3` launcher cannot reappear after the Hook itself starts successfully.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import click_gate
+
+
+_ORIGINAL_RUNNER_SHELL_COMMAND = click_gate._runner_shell_command
+
+
+def _powershell_single_quote(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _runner_shell_command(arguments: list[str]) -> str:
+    if os.name != "nt":
+        return _ORIGINAL_RUNNER_SHELL_COMMAND(arguments)
+    if len(arguments) < 3:
+        return "exit 2"
+    try:
+        interpreter = Path(arguments[0]).resolve(strict=True)
+        launcher = Path(__file__).with_name("click_windows.cmd").resolve(strict=True)
+    except (OSError, RuntimeError):
+        return "exit 2"
+    if not interpreter.is_file() or not launcher.is_file():
+        return "exit 2"
+    if not all(
+        click_gate._windows_launcher_path_is_safe(value)
+        for value in (str(interpreter), str(launcher))
+    ):
+        return "exit 2"
+
+    encoded = click_gate._encode_runner_transport(arguments[2:])
+    script = " ".join(
+        (
+            "&",
+            _powershell_single_quote(str(launcher)),
+            "--python",
+            _powershell_single_quote(str(interpreter)),
+            "--encoded-runner",
+            _powershell_single_quote(encoded),
+        )
+    )
+    command = (
+        "powershell.exe -NoProfile -NonInteractive -Command "
+        + click_gate._windows_shell_quote(script)
+    )
+    if len(command) > click_gate.WINDOWS_COMMAND_LINE_LIMIT:
+        return "exit 2"
+    return command
+
+
+def main() -> int:
+    if os.name == "nt":
+        click_gate._runner_shell_command = _runner_shell_command
+    return click_gate.main()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "python3 \"${PLUGIN_ROOT}/hooks/click_gate.py\" prompt-submit",
-            "commandWindows": "py -3 \"${PLUGIN_ROOT}\\hooks\\click_gate.py\" prompt-submit",
+            "commandWindows": "powershell.exe -NoProfile -NonInteractive -Command \"& '${PLUGIN_ROOT}\\hooks\\click_windows.cmd' prompt-submit\"",
             "timeout": 7,
             "additionalContextLimit": 1400
           }
@@ -21,7 +21,7 @@
           {
             "type": "command",
             "command": "python3 \"${PLUGIN_ROOT}/hooks/click_gate.py\" pre-tool",
-            "commandWindows": "py -3 \"${PLUGIN_ROOT}\\hooks\\click_gate.py\" pre-tool",
+            "commandWindows": "powershell.exe -NoProfile -NonInteractive -Command \"& '${PLUGIN_ROOT}\\hooks\\click_windows.cmd' pre-tool\"",
             "timeout": 7
           }
         ]
@@ -34,7 +34,7 @@
           {
             "type": "command",
             "command": "python3 \"${PLUGIN_ROOT}/hooks/click_gate.py\" post-tool",
-            "commandWindows": "py -3 \"${PLUGIN_ROOT}\\hooks\\click_gate.py\" post-tool",
+            "commandWindows": "powershell.exe -NoProfile -NonInteractive -Command \"& '${PLUGIN_ROOT}\\hooks\\click_windows.cmd' post-tool\"",
             "timeout": 7
           }
         ]
@@ -46,7 +46,7 @@
           {
             "type": "command",
             "command": "python3 \"${PLUGIN_ROOT}/hooks/click_gate.py\" session-end",
-            "commandWindows": "py -3 \"${PLUGIN_ROOT}\\hooks\\click_gate.py\" session-end",
+            "commandWindows": "powershell.exe -NoProfile -NonInteractive -Command \"& '${PLUGIN_ROOT}\\hooks\\click_windows.cmd' session-end\"",
             "timeout": 3
           }
         ]

--- a/tests/test_windows_hook_commands.py
+++ b/tests/test_windows_hook_commands.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -17,6 +18,7 @@ WINDOWS_MODES = {
     "PostToolUse": "post-tool",
     "SessionEnd": "session-end",
 }
+WINDOWS_HOOK_PREFIX = "powershell.exe -NoProfile -NonInteractive -Command "
 
 
 def windows_commands() -> dict[str, str]:
@@ -60,6 +62,10 @@ def synthetic_event(event_name: str, workspace: Path, suffix: str) -> dict[str, 
     return event
 
 
+def rendered_windows_command(command: str, plugin_root: Path) -> str:
+    return command.replace("${PLUGIN_ROOT}", str(plugin_root))
+
+
 class WindowsHookCommandTests(unittest.TestCase):
     def test_commands_use_codex_plugin_root_template(self) -> None:
         commands = windows_commands()
@@ -68,9 +74,11 @@ class WindowsHookCommandTests(unittest.TestCase):
             with self.subTest(event=event_name):
                 self.assertEqual(
                     commands[event_name],
-                    f'py -3 "${{PLUGIN_ROOT}}\\hooks\\click_gate.py" {mode}',
+                    WINDOWS_HOOK_PREFIX
+                    + f'"& \'${{PLUGIN_ROOT}}\\hooks\\click_windows.cmd\' {mode}"',
                 )
                 self.assertNotIn("%PLUGIN_ROOT%", commands[event_name])
+                self.assertNotIn("py -3", commands[event_name].lower())
 
     @unittest.skipUnless(os.name == "nt", "Windows PowerShell integration test")
     def test_commands_execute_in_powershell_from_normal_and_spaced_roots(self) -> None:
@@ -127,13 +135,20 @@ class WindowsHookCommandTests(unittest.TestCase):
                             cwd=workspace,
                             env=environment,
                             check=False,
+                        ) if not shell_options else subprocess.run(
+                            invocation,
+                            capture_output=True,
+                            text=True,
+                            cwd=workspace,
+                            env=environment,
+                            check=False,
                             **shell_options,
                         )
 
                     for event_name, mode in WINDOWS_MODES.items():
                         with self.subTest(plugin_root=root_name, event=event_name):
-                            rendered = commands[event_name].replace(
-                                "${PLUGIN_ROOT}", str(plugin_root)
+                            rendered = rendered_windows_command(
+                                commands[event_name], plugin_root
                             )
                             self.assertNotIn("PLUGIN_ROOT", rendered)
                             event = synthetic_event(
@@ -184,8 +199,8 @@ class WindowsHookCommandTests(unittest.TestCase):
                             + "'"
                         )
                     }
-                    rendered_hook = commands["PreToolUse"].replace(
-                        "${PLUGIN_ROOT}", str(plugin_root)
+                    rendered_hook = rendered_windows_command(
+                        commands["PreToolUse"], plugin_root
                     )
                     hook_result = subprocess.run(
                         [
@@ -209,7 +224,8 @@ class WindowsHookCommandTests(unittest.TestCase):
                     )
                     payload = json.loads(hook_result.stdout)
                     runner = payload["hookSpecificOutput"]["updatedInput"]["command"]
-                    self.assertTrue(runner.startswith("py -3 "), runner)
+                    self.assertTrue(runner.startswith(WINDOWS_HOOK_PREFIX), runner)
+                    self.assertNotIn("py -3", runner.lower())
 
                     for shell_name in ("PowerShell", "cmd.exe"):
                         with self.subTest(plugin_root=root_name, shell=shell_name):
@@ -284,8 +300,10 @@ class WindowsHookCommandTests(unittest.TestCase):
                             "updatedInput"
                         ]["command"]
                         self.assertTrue(
-                            stateful_runner.startswith("py -3 "), stateful_runner
+                            stateful_runner.startswith(WINDOWS_HOOK_PREFIX),
+                            stateful_runner,
                         )
+                        self.assertNotIn("py -3", stateful_runner.lower())
 
                         with self.subTest(
                             plugin_root=root_name,
@@ -305,6 +323,140 @@ class WindowsHookCommandTests(unittest.TestCase):
                             self.assertEqual(
                                 executed.stdout, "portable Windows runner\n"
                             )
+
+    @unittest.skipUnless(os.name == "nt", "Windows Python launcher fallback test")
+    def test_broken_py_launcher_falls_back_to_python_and_runner_keeps_exact_interpreter(
+        self,
+    ) -> None:
+        powershell = shutil.which("pwsh")
+        self.assertIsNotNone(powershell, "pwsh is required on the Windows CI runner")
+        command_prompt = shutil.which("cmd.exe")
+        self.assertIsNotNone(command_prompt, "cmd.exe is required on Windows")
+        commands = windows_commands()
+
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            plugin_root = base / "Click Fallback Root With Spaces"
+            shutil.copytree(
+                ROOT / "hooks",
+                plugin_root / "hooks",
+                ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+            )
+            plugin_data = plugin_root / "plugin data"
+            workspace = plugin_root / "workspace"
+            workspace.mkdir()
+            probe = workspace / "fallback probe.txt"
+            probe.write_text("fallback runner works\n", encoding="utf-8")
+
+            fake_bin = base / "fake python launchers"
+            fake_bin.mkdir()
+            launcher_log = base / "launcher.log"
+            (fake_bin / "py.cmd").write_text(
+                "@echo off\r\n"
+                ">>\"%CLICK_TEST_LAUNCHER_LOG%\" echo py\r\n"
+                ">&2 echo No installed Python found!\r\n"
+                "exit /b 103\r\n",
+                encoding="utf-8",
+            )
+            (fake_bin / "python.cmd").write_text(
+                "@echo off\r\n"
+                ">>\"%CLICK_TEST_LAUNCHER_LOG%\" echo python\r\n"
+                f'"{sys.executable}" %*\r\n'
+                "exit /b %errorlevel%\r\n",
+                encoding="utf-8",
+            )
+
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "PLUGIN_ROOT": str(plugin_root),
+                    "PLUGIN_DATA": str(plugin_data),
+                    "CLICK_CONFIG_HOME": str(plugin_data),
+                    "CLICK_TEST_LAUNCHER_LOG": str(launcher_log),
+                    "PATH": str(fake_bin) + os.pathsep + environment.get("PATH", ""),
+                }
+            )
+            request = {
+                "version": 1,
+                "commands": [["Get-Content", "-Raw", probe.name]],
+            }
+            event = synthetic_event("PreToolUse", workspace, "fallback")
+            event["tool_input"] = {
+                "command": (
+                    "click-gate inspect '"
+                    + json.dumps(request, separators=(",", ":"))
+                    + "'"
+                )
+            }
+            rendered_hook = rendered_windows_command(
+                commands["PreToolUse"], plugin_root
+            )
+            hook_result = subprocess.run(
+                [
+                    powershell,
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-Command",
+                    rendered_hook,
+                ],
+                input=json.dumps(event) + "\n",
+                capture_output=True,
+                text=True,
+                cwd=workspace,
+                env=environment,
+                check=False,
+            )
+            self.assertEqual(
+                hook_result.returncode,
+                0,
+                f"fallback hook failed:\n{hook_result.stderr}\n{hook_result.stdout}",
+            )
+            self.assertNotIn("No installed Python found", hook_result.stderr)
+            payload = json.loads(hook_result.stdout)
+            runner = payload["hookSpecificOutput"]["updatedInput"]["command"]
+            self.assertTrue(runner.startswith(WINDOWS_HOOK_PREFIX), runner)
+            self.assertNotIn("py -3", runner.lower())
+
+            launches_before_runner = launcher_log.read_text(encoding="utf-8").splitlines()
+            self.assertIn("py", launches_before_runner)
+            self.assertIn("python", launches_before_runner)
+
+            for shell_name in ("PowerShell", "cmd.exe"):
+                with self.subTest(shell=shell_name):
+                    if shell_name == "PowerShell":
+                        invocation: str | list[str] = [
+                            powershell,
+                            "-NoProfile",
+                            "-NonInteractive",
+                            "-Command",
+                            runner,
+                        ]
+                        shell_options: dict[str, object] = {}
+                    else:
+                        invocation = runner
+                        shell_options = {
+                            "shell": True,
+                            "executable": command_prompt,
+                        }
+                    result = subprocess.run(
+                        invocation,
+                        capture_output=True,
+                        text=True,
+                        cwd=workspace,
+                        env=environment,
+                        check=False,
+                        **shell_options,
+                    )
+                    self.assertEqual(
+                        result.returncode,
+                        0,
+                        f"{shell_name} fallback runner failed:\n"
+                        f"{result.stderr}\n{result.stdout}",
+                    )
+                    self.assertEqual(result.stdout, "fallback runner works\n")
+
+            launches_after_runner = launcher_log.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(launches_after_runner, launches_before_runner)
 
 
 if __name__ == "__main__":

--- a/tests/test_windows_hook_commands.py
+++ b/tests/test_windows_hook_commands.py
@@ -5,7 +5,6 @@ import os
 from pathlib import Path
 import shutil
 import subprocess
-import sys
 import tempfile
 import unittest
 
@@ -129,13 +128,6 @@ class WindowsHookCommandTests(unittest.TestCase):
                                 "executable": command_prompt,
                             }
                         return subprocess.run(
-                            invocation,
-                            capture_output=True,
-                            text=True,
-                            cwd=workspace,
-                            env=environment,
-                            check=False,
-                        ) if not shell_options else subprocess.run(
                             invocation,
                             capture_output=True,
                             text=True,
@@ -332,6 +324,8 @@ class WindowsHookCommandTests(unittest.TestCase):
         self.assertIsNotNone(powershell, "pwsh is required on the Windows CI runner")
         command_prompt = shutil.which("cmd.exe")
         self.assertIsNotNone(command_prompt, "cmd.exe is required on Windows")
+        real_python = shutil.which("python")
+        self.assertIsNotNone(real_python, "python.exe is required on the Windows CI runner")
         commands = windows_commands()
 
         with tempfile.TemporaryDirectory() as temporary:
@@ -348,7 +342,7 @@ class WindowsHookCommandTests(unittest.TestCase):
             probe = workspace / "fallback probe.txt"
             probe.write_text("fallback runner works\n", encoding="utf-8")
 
-            fake_bin = base / "fake python launchers"
+            fake_bin = base / "broken py launcher"
             fake_bin.mkdir()
             launcher_log = base / "launcher.log"
             (fake_bin / "py.cmd").write_text(
@@ -356,13 +350,6 @@ class WindowsHookCommandTests(unittest.TestCase):
                 ">>\"%CLICK_TEST_LAUNCHER_LOG%\" echo py\r\n"
                 ">&2 echo No installed Python found!\r\n"
                 "exit /b 103\r\n",
-                encoding="utf-8",
-            )
-            (fake_bin / "python.cmd").write_text(
-                "@echo off\r\n"
-                ">>\"%CLICK_TEST_LAUNCHER_LOG%\" echo python\r\n"
-                f'"{sys.executable}" %*\r\n'
-                "exit /b %errorlevel%\r\n",
                 encoding="utf-8",
             )
 
@@ -409,7 +396,13 @@ class WindowsHookCommandTests(unittest.TestCase):
             self.assertEqual(
                 hook_result.returncode,
                 0,
-                f"fallback hook failed:\n{hook_result.stderr}\n{hook_result.stdout}",
+                (
+                    "fallback hook failed:\n"
+                    f"stderr={hook_result.stderr!r}\n"
+                    f"stdout={hook_result.stdout!r}\n"
+                    f"log={launcher_log.read_text(encoding='utf-8') if launcher_log.exists() else '<missing>'}\n"
+                    f"python={real_python}"
+                ),
             )
             self.assertNotIn("No installed Python found", hook_result.stderr)
             payload = json.loads(hook_result.stdout)
@@ -418,8 +411,7 @@ class WindowsHookCommandTests(unittest.TestCase):
             self.assertNotIn("py -3", runner.lower())
 
             launches_before_runner = launcher_log.read_text(encoding="utf-8").splitlines()
-            self.assertIn("py", launches_before_runner)
-            self.assertIn("python", launches_before_runner)
+            self.assertEqual(launches_before_runner, ["py"])
 
             for shell_name in ("PowerShell", "cmd.exe"):
                 with self.subTest(shell=shell_name):


### PR DESCRIPTION
## Summary

Fixes Windows Click startup failing with `No installed Python found!` when `py.exe` exists but cannot resolve an installed Python, or when the Python launcher is absent while `python.exe`/`python3.exe` is available.

## Approach

- route Codex `commandWindows` hooks through a small Windows launcher instead of hard-coding `py -3`
- probe Python 3 in order: `py -3`, `python`, then `python3`; a failed probe is silent so a broken launcher can fall through cleanly
- isolate each probe in a child `cmd.exe` so even a broken `py.cmd` shim cannot terminate the parent fallback launcher
- once the Hook starts, preserve the exact `sys.executable` selected for all rewritten Click runners instead of returning to `py -3`
- rewritten runners invoke that exact interpreter directly through the existing encoded transport rather than re-entering the fallback launcher
- keep the existing state-root binding, token claims, approval state machine, and shell-free capability execution unchanged
- keep plugin roots with spaces working from both PowerShell and `cmd.exe`

## Regression coverage

The Windows integration suite verifies:

- all Hook entrypoints use the fallback launcher rather than hard-coded `py -3`
- normal and spaced plugin roots still work
- rewritten read/stateful runners no longer contain `py -3`
- a broken `py` shim that returns `No installed Python found!` falls back to the real working `python.exe`
- the rewritten runner reuses the exact selected interpreter and does not probe the broken launcher again
- rewritten runners execute from both PowerShell and `cmd.exe`

No Click contract, approval, evidence, state recovery, or verification policy is relaxed.

## Verification

- CI #175: passed on Ubuntu, macOS, and Windows
- Windows suite includes the broken-`py` / working-`python.exe` regression case
- Plugin Security Scan #110: passed