### PR TITLE
fix: route Codex Desktop exec hooks through Click

### DIFF
--- a/hooks/click_hook.py
+++ b/hooks/click_hook.py
@@ -2,7 +2,7 @@
 """Codex Hook entrypoint that normalizes equivalent tool names for Click.
 
 Codex clients do not always expose shell execution under the historical `Bash`
-name.  This adapter maps direct shell/exec surfaces onto Click's canonical Bash
+name. This adapter maps direct shell/exec surfaces onto Click's canonical Bash
 path while leaving the core contract state machine unchanged.
 """
 
@@ -13,7 +13,10 @@ import json
 import sys
 from typing import Any
 
-import click_gate
+if __package__:
+    from . import click_gate
+else:
+    import click_gate
 
 
 DIRECT_EXEC_TOOL_NAMES = {

--- a/hooks/click_hook.py
+++ b/hooks/click_hook.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Codex Hook entrypoint that normalizes equivalent tool names for Click.
+
+Codex clients do not always expose shell execution under the historical `Bash`
+name.  This adapter maps direct shell/exec surfaces onto Click's canonical Bash
+path while leaving the core contract state machine unchanged.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from typing import Any
+
+import click_gate
+
+
+DIRECT_EXEC_TOOL_NAMES = {
+    "Bash",
+    "exec_command",
+    "functions.exec_command",
+    "shell_command",
+    "functions.shell_command",
+    "unified_exec",
+    "functions.unified_exec",
+}
+
+# Current Codex Code Mode may not emit Hook events at all for this surface.
+# When an event is available, map it onto the conservative command path so an
+# active Click workflow fails closed instead of silently bypassing the gate.
+CODE_MODE_TOOL_NAMES = {
+    "exec",
+    "functions.exec",
+    "code_mode_exec",
+}
+
+
+def normalize_event(event: dict[str, Any], mode: str) -> dict[str, Any]:
+    if mode != "pre-tool":
+        return event
+    tool_name = str(event.get("tool_name", ""))
+    if tool_name not in DIRECT_EXEC_TOOL_NAMES | CODE_MODE_TOOL_NAMES:
+        return event
+    normalized = dict(event)
+    normalized["tool_name"] = "Bash"
+    return normalized
+
+
+def route_stdin_event(mode: str) -> None:
+    if mode not in {"pre-tool", "post-tool", "prompt-submit", "session-end"}:
+        return
+    raw = sys.stdin.read()
+    if not raw:
+        sys.stdin = io.StringIO(raw)
+        return
+    try:
+        event = json.loads(raw)
+    except json.JSONDecodeError:
+        sys.stdin = io.StringIO(raw)
+        return
+    if isinstance(event, dict):
+        event = normalize_event(event, mode)
+        raw = json.dumps(event, ensure_ascii=False, separators=(",", ":"))
+    sys.stdin = io.StringIO(raw)
+
+
+def main() -> int:
+    mode = sys.argv[1] if len(sys.argv) == 2 else ""
+    route_stdin_event(mode)
+    return click_gate.main()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/click_windows.py
+++ b/hooks/click_windows.py
@@ -12,6 +12,7 @@ import os
 from pathlib import Path
 
 import click_gate
+import click_hook
 
 
 _ORIGINAL_RUNNER_SHELL_COMMAND = click_gate._runner_shell_command
@@ -61,7 +62,7 @@ def _runner_shell_command(arguments: list[str]) -> str:
 def main() -> int:
     if os.name == "nt":
         click_gate._runner_shell_command = _runner_shell_command
-    return click_gate.main()
+    return click_hook.main()
 
 
 if __name__ == "__main__":

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,8 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/hooks/click_gate.py\" prompt-submit",
-            "commandWindows": "powershell.exe -NoProfile -NonInteractive -Command \"& '${PLUGIN_ROOT}\\hooks\\click_windows.cmd' prompt-submit\"",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/click_hook.py\" prompt-submit",
+            "commandWindows": "\"${PLUGIN_ROOT}\\hooks\\click_windows.cmd\" prompt-submit",
             "timeout": 7,
             "additionalContextLimit": 1400
           }
@@ -16,12 +16,12 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "^(Bash|apply_patch|Edit|Write|update_plan|functions\\.update_plan|mcp__node_repl__js)$",
+        "matcher": "^(Bash|shell_command|functions\\.shell_command|exec_command|functions\\.exec_command|unified_exec|functions\\.unified_exec|exec|functions\\.exec|code_mode_exec|apply_patch|functions\\.apply_patch|Edit|Write|update_plan|functions\\.update_plan|mcp__node_repl__js)$",
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/hooks/click_gate.py\" pre-tool",
-            "commandWindows": "powershell.exe -NoProfile -NonInteractive -Command \"& '${PLUGIN_ROOT}\\hooks\\click_windows.cmd' pre-tool\"",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/click_hook.py\" pre-tool",
+            "commandWindows": "\"${PLUGIN_ROOT}\\hooks\\click_windows.cmd\" pre-tool",
             "timeout": 7
           }
         ]
@@ -33,8 +33,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/hooks/click_gate.py\" post-tool",
-            "commandWindows": "powershell.exe -NoProfile -NonInteractive -Command \"& '${PLUGIN_ROOT}\\hooks\\click_windows.cmd' post-tool\"",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/click_hook.py\" post-tool",
+            "commandWindows": "\"${PLUGIN_ROOT}\\hooks\\click_windows.cmd\" post-tool",
             "timeout": 7
           }
         ]
@@ -45,8 +45,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/hooks/click_gate.py\" session-end",
-            "commandWindows": "powershell.exe -NoProfile -NonInteractive -Command \"& '${PLUGIN_ROOT}\\hooks\\click_windows.cmd' session-end\"",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/click_hook.py\" session-end",
+            "commandWindows": "\"${PLUGIN_ROOT}\\hooks\\click_windows.cmd\" session-end",
             "timeout": 3
           }
         ]

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/hooks/click_hook.py\" prompt-submit",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/click_gate.py\" prompt-submit",
             "commandWindows": "\"${PLUGIN_ROOT}\\hooks\\click_windows.cmd\" prompt-submit",
             "timeout": 7,
             "additionalContextLimit": 1400
@@ -16,7 +16,18 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "^(Bash|shell_command|functions\\.shell_command|exec_command|functions\\.exec_command|unified_exec|functions\\.unified_exec|exec|functions\\.exec|code_mode_exec|apply_patch|functions\\.apply_patch|Edit|Write|update_plan|functions\\.update_plan|mcp__node_repl__js)$",
+        "matcher": "^(Bash|apply_patch|Edit|Write|update_plan|functions\\.update_plan|mcp__node_repl__js)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/click_gate.py\" pre-tool",
+            "commandWindows": "\"${PLUGIN_ROOT}\\hooks\\click_windows.cmd\" pre-tool",
+            "timeout": 7
+          }
+        ]
+      },
+      {
+        "matcher": "^(shell_command|functions\\.shell_command|exec_command|functions\\.exec_command|unified_exec|functions\\.unified_exec|exec|functions\\.exec|code_mode_exec|functions\\.apply_patch)$",
         "hooks": [
           {
             "type": "command",
@@ -33,7 +44,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/hooks/click_hook.py\" post-tool",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/click_gate.py\" post-tool",
             "commandWindows": "\"${PLUGIN_ROOT}\\hooks\\click_windows.cmd\" post-tool",
             "timeout": 7
           }
@@ -45,7 +56,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/hooks/click_hook.py\" session-end",
+            "command": "python3 \"${PLUGIN_ROOT}/hooks/click_gate.py\" session-end",
             "commandWindows": "\"${PLUGIN_ROOT}\\hooks\\click_windows.cmd\" session-end",
             "timeout": 3
           }

--- a/tests/test_click_hook.py
+++ b/tests/test_click_hook.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import unittest
+
+from hooks import click_hook
+
+
+class ClickHookRoutingTests(unittest.TestCase):
+    def test_direct_exec_aliases_normalize_to_canonical_bash_path(self) -> None:
+        for tool_name in click_hook.DIRECT_EXEC_TOOL_NAMES:
+            with self.subTest(tool_name=tool_name):
+                event = {
+                    "tool_name": tool_name,
+                    "tool_input": {"command": "click-gate default status"},
+                }
+                normalized = click_hook.normalize_event(event, "pre-tool")
+                self.assertEqual(normalized["tool_name"], "Bash")
+                self.assertEqual(normalized["tool_input"], event["tool_input"])
+
+    def test_code_mode_aliases_fail_into_the_same_conservative_gate_when_visible(self) -> None:
+        for tool_name in click_hook.CODE_MODE_TOOL_NAMES:
+            with self.subTest(tool_name=tool_name):
+                event = {
+                    "tool_name": tool_name,
+                    "tool_input": {"command": "return tools.exec_command(...)"},
+                }
+                normalized = click_hook.normalize_event(event, "pre-tool")
+                self.assertEqual(normalized["tool_name"], "Bash")
+
+    def test_non_pre_tool_events_and_unrelated_tools_are_unchanged(self) -> None:
+        event = {"tool_name": "mcp__node_repl__js", "tool_input": {"code": "1"}}
+        self.assertIs(click_hook.normalize_event(event, "post-tool"), event)
+        self.assertIs(click_hook.normalize_event(event, "pre-tool"), event)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_windows_hook_commands.py
+++ b/tests/test_windows_hook_commands.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import re
 import shutil
 import subprocess
 import tempfile
@@ -17,20 +18,42 @@ WINDOWS_MODES = {
     "PostToolUse": "post-tool",
     "SessionEnd": "session-end",
 }
-WINDOWS_HOOK_PREFIX = "powershell.exe -NoProfile -NonInteractive -Command "
+WINDOWS_RUNNER_PREFIX = "powershell.exe -NoProfile -NonInteractive -Command "
+DESKTOP_EXEC_NAMES = {
+    "Bash",
+    "shell_command",
+    "functions.shell_command",
+    "exec_command",
+    "functions.exec_command",
+    "unified_exec",
+    "functions.unified_exec",
+    "exec",
+    "functions.exec",
+    "code_mode_exec",
+}
+
+
+def hook_config() -> dict[str, object]:
+    return json.loads(HOOK_CONFIG.read_text(encoding="utf-8"))
 
 
 def windows_commands() -> dict[str, str]:
-    config = json.loads(HOOK_CONFIG.read_text(encoding="utf-8"))
+    config = hook_config()
+    hooks = config["hooks"]
+    assert isinstance(hooks, dict)
     return {
-        event_name: config["hooks"][event_name][0]["hooks"][0][
-            "commandWindows"
-        ]
+        event_name: hooks[event_name][0]["hooks"][0]["commandWindows"]
         for event_name in WINDOWS_MODES
     }
 
 
-def synthetic_event(event_name: str, workspace: Path, suffix: str) -> dict[str, object]:
+def synthetic_event(
+    event_name: str,
+    workspace: Path,
+    suffix: str,
+    *,
+    tool_name: str = "Bash",
+) -> dict[str, object]:
     event: dict[str, object] = {
         "session_id": f"windows-hook-{suffix}",
         "turn_id": f"windows-turn-{suffix}",
@@ -44,7 +67,7 @@ def synthetic_event(event_name: str, workspace: Path, suffix: str) -> dict[str, 
     elif event_name == "PreToolUse":
         event.update(
             {
-                "tool_name": "Bash",
+                "tool_name": tool_name,
                 "tool_use_id": f"windows-tool-{suffix}",
                 "tool_input": {"command": "click-gate default status"},
             }
@@ -66,25 +89,41 @@ def rendered_windows_command(command: str, plugin_root: Path) -> str:
 
 
 class WindowsHookCommandTests(unittest.TestCase):
-    def test_commands_use_codex_plugin_root_template(self) -> None:
+    def test_commands_use_direct_batch_launcher_and_desktop_matchers(self) -> None:
+        config = hook_config()
+        hooks = config["hooks"]
+        assert isinstance(hooks, dict)
         commands = windows_commands()
         self.assertEqual(set(commands), set(WINDOWS_MODES))
         for event_name, mode in WINDOWS_MODES.items():
             with self.subTest(event=event_name):
                 self.assertEqual(
                     commands[event_name],
-                    WINDOWS_HOOK_PREFIX
-                    + f'"& \'${{PLUGIN_ROOT}}\\hooks\\click_windows.cmd\' {mode}"',
+                    f'"${{PLUGIN_ROOT}}\\hooks\\click_windows.cmd" {mode}',
                 )
-                self.assertNotIn("%PLUGIN_ROOT%", commands[event_name])
+                self.assertNotIn("powershell", commands[event_name].lower())
                 self.assertNotIn("py -3", commands[event_name].lower())
+                command = hooks[event_name][0]["hooks"][0]["command"]
+                self.assertIn("click_hook.py", command)
 
-    @unittest.skipUnless(os.name == "nt", "Windows PowerShell integration test")
-    def test_commands_execute_in_powershell_from_normal_and_spaced_roots(self) -> None:
-        powershell = shutil.which("pwsh")
-        self.assertIsNotNone(powershell, "pwsh is required on the Windows CI runner")
+        matcher = hooks["PreToolUse"][0]["matcher"]
+        compiled = re.compile(matcher)
+        for name in DESKTOP_EXEC_NAMES | {
+            "apply_patch",
+            "functions.apply_patch",
+            "update_plan",
+            "functions.update_plan",
+            "mcp__node_repl__js",
+        }:
+            with self.subTest(matcher=name):
+                self.assertIsNotNone(compiled.fullmatch(name))
+
+    @unittest.skipUnless(os.name == "nt", "Windows cmd integration test")
+    def test_hooks_execute_via_cmd_and_exec_aliases_rewrite(self) -> None:
         command_prompt = shutil.which("cmd.exe")
         self.assertIsNotNone(command_prompt, "cmd.exe is required on Windows")
+        powershell = shutil.which("pwsh")
+        self.assertIsNotNone(powershell, "pwsh is required on the Windows CI runner")
         commands = windows_commands()
 
         with tempfile.TemporaryDirectory() as temporary:
@@ -109,69 +148,52 @@ class WindowsHookCommandTests(unittest.TestCase):
                         }
                     )
 
-                    def run_runner(
-                        shell_name: str, runner: str
-                    ) -> subprocess.CompletedProcess[str]:
-                        if shell_name == "PowerShell":
-                            invocation: str | list[str] = [
-                                powershell,
-                                "-NoProfile",
-                                "-NonInteractive",
-                                "-Command",
-                                runner,
-                            ]
-                            shell_options: dict[str, object] = {}
-                        else:
-                            invocation = runner
-                            shell_options = {
-                                "shell": True,
-                                "executable": command_prompt,
-                            }
+                    def run_hook(event_name: str, event: dict[str, object]) -> subprocess.CompletedProcess[str]:
+                        rendered = rendered_windows_command(commands[event_name], plugin_root)
+                        self.assertNotIn("PLUGIN_ROOT", rendered)
                         return subprocess.run(
-                            invocation,
+                            rendered,
+                            shell=True,
+                            executable=command_prompt,
+                            input=json.dumps(event) + "\n",
                             capture_output=True,
                             text=True,
                             cwd=workspace,
                             env=environment,
                             check=False,
-                            **shell_options,
                         )
 
-                    for event_name, mode in WINDOWS_MODES.items():
-                        with self.subTest(plugin_root=root_name, event=event_name):
-                            rendered = rendered_windows_command(
-                                commands[event_name], plugin_root
-                            )
-                            self.assertNotIn("PLUGIN_ROOT", rendered)
+                    prompt_result = run_hook(
+                        "UserPromptSubmit",
+                        synthetic_event("UserPromptSubmit", workspace, root_name),
+                    )
+                    self.assertEqual(
+                        prompt_result.returncode,
+                        0,
+                        f"prompt hook failed:\n{prompt_result.stderr}\n{prompt_result.stdout}",
+                    )
+                    prompt_payload = json.loads(prompt_result.stdout)
+                    self.assertTrue(
+                        prompt_payload["hookSpecificOutput"]["additionalContext"]
+                    )
+
+                    for alias in ("Bash", "exec_command", "functions.exec_command", "shell_command"):
+                        with self.subTest(plugin_root=root_name, alias=alias):
                             event = synthetic_event(
-                                event_name,
+                                "PreToolUse",
                                 workspace,
-                                f"{root_name}-{mode}".replace(" ", "-"),
+                                f"{root_name}-{alias}".replace(" ", "-"),
+                                tool_name=alias,
                             )
-                            result = subprocess.run(
-                                [
-                                    powershell,
-                                    "-NoProfile",
-                                    "-NonInteractive",
-                                    "-Command",
-                                    rendered,
-                                ],
-                                input=json.dumps(event) + "\n",
-                                capture_output=True,
-                                text=True,
-                                cwd=workspace,
-                                env=environment,
-                                check=False,
-                            )
+                            result = run_hook("PreToolUse", event)
                             self.assertEqual(
                                 result.returncode,
                                 0,
-                                f"{event_name} failed:\n{result.stderr}\n{result.stdout}",
+                                f"{alias} hook failed:\n{result.stderr}\n{result.stdout}",
                             )
-                            if event_name == "PreToolUse":
-                                payload = json.loads(result.stdout)
-                                updated = payload["hookSpecificOutput"]["updatedInput"]
-                                self.assertIn("Click default mode:", updated["command"])
+                            payload = json.loads(result.stdout)
+                            updated = payload["hookSpecificOutput"]["updatedInput"]
+                            self.assertIn("Click default mode:", updated["command"])
 
                     probe = workspace / "runner probe.txt"
                     probe.write_text("portable Windows runner\n", encoding="utf-8")
@@ -183,6 +205,7 @@ class WindowsHookCommandTests(unittest.TestCase):
                         "PreToolUse",
                         workspace,
                         f"{root_name}-inspect".replace(" ", "-"),
+                        tool_name="functions.exec_command",
                     )
                     inspect_event["tool_input"] = {
                         "command": (
@@ -191,24 +214,7 @@ class WindowsHookCommandTests(unittest.TestCase):
                             + "'"
                         )
                     }
-                    rendered_hook = rendered_windows_command(
-                        commands["PreToolUse"], plugin_root
-                    )
-                    hook_result = subprocess.run(
-                        [
-                            powershell,
-                            "-NoProfile",
-                            "-NonInteractive",
-                            "-Command",
-                            rendered_hook,
-                        ],
-                        input=json.dumps(inspect_event) + "\n",
-                        capture_output=True,
-                        text=True,
-                        cwd=workspace,
-                        env=environment,
-                        check=False,
-                    )
+                    hook_result = run_hook("PreToolUse", inspect_event)
                     self.assertEqual(
                         hook_result.returncode,
                         0,
@@ -216,116 +222,48 @@ class WindowsHookCommandTests(unittest.TestCase):
                     )
                     payload = json.loads(hook_result.stdout)
                     runner = payload["hookSpecificOutput"]["updatedInput"]["command"]
-                    self.assertTrue(runner.startswith(WINDOWS_HOOK_PREFIX), runner)
+                    self.assertTrue(runner.startswith(WINDOWS_RUNNER_PREFIX), runner)
                     self.assertNotIn("py -3", runner.lower())
 
                     for shell_name in ("PowerShell", "cmd.exe"):
-                        with self.subTest(plugin_root=root_name, shell=shell_name):
-                            runner_result = run_runner(shell_name, runner)
-                            self.assertEqual(
-                                runner_result.returncode,
-                                0,
-                                f"{shell_name} runner failed:\n"
-                                f"{runner_result.stderr}\n{runner_result.stdout}",
+                        with self.subTest(plugin_root=root_name, runner_shell=shell_name):
+                            if shell_name == "PowerShell":
+                                invocation: str | list[str] = [
+                                    powershell,
+                                    "-NoProfile",
+                                    "-NonInteractive",
+                                    "-Command",
+                                    runner,
+                                ]
+                                shell_options: dict[str, object] = {}
+                            else:
+                                invocation = runner
+                                shell_options = {
+                                    "shell": True,
+                                    "executable": command_prompt,
+                                }
+                            executed = subprocess.run(
+                                invocation,
+                                capture_output=True,
+                                text=True,
+                                cwd=workspace,
+                                env=environment,
+                                check=False,
+                                **shell_options,
                             )
-                            self.assertEqual(
-                                runner_result.stdout, "portable Windows runner\n"
-                            )
-
-                    for shell_name in ("PowerShell", "cmd.exe"):
-                        suffix = (
-                            f"{root_name}-{shell_name}-stateful".replace(" ", "-")
-                        )
-                        review_event = synthetic_event(
-                            "PreToolUse", workspace, suffix
-                        )
-                        review_event["tool_input"] = {"command": "click-gate review"}
-                        review_result = subprocess.run(
-                            [
-                                powershell,
-                                "-NoProfile",
-                                "-NonInteractive",
-                                "-Command",
-                                rendered_hook,
-                            ],
-                            input=json.dumps(review_event) + "\n",
-                            capture_output=True,
-                            text=True,
-                            cwd=workspace,
-                            env=environment,
-                            check=False,
-                        )
-                        self.assertEqual(
-                            review_result.returncode,
-                            0,
-                            f"review hook failed:\n"
-                            f"{review_result.stderr}\n{review_result.stdout}",
-                        )
-
-                        stateful_event = synthetic_event(
-                            "PreToolUse", workspace, suffix
-                        )
-                        stateful_event["tool_input"] = inspect_event["tool_input"]
-                        stateful_result = subprocess.run(
-                            [
-                                powershell,
-                                "-NoProfile",
-                                "-NonInteractive",
-                                "-Command",
-                                rendered_hook,
-                            ],
-                            input=json.dumps(stateful_event) + "\n",
-                            capture_output=True,
-                            text=True,
-                            cwd=workspace,
-                            env=environment,
-                            check=False,
-                        )
-                        self.assertEqual(
-                            stateful_result.returncode,
-                            0,
-                            f"stateful inspect hook failed:\n"
-                            f"{stateful_result.stderr}\n{stateful_result.stdout}",
-                        )
-                        stateful_payload = json.loads(stateful_result.stdout)
-                        stateful_runner = stateful_payload["hookSpecificOutput"][
-                            "updatedInput"
-                        ]["command"]
-                        self.assertTrue(
-                            stateful_runner.startswith(WINDOWS_HOOK_PREFIX),
-                            stateful_runner,
-                        )
-                        self.assertNotIn("py -3", stateful_runner.lower())
-
-                        with self.subTest(
-                            plugin_root=root_name,
-                            shell=shell_name,
-                            runner="stateful",
-                        ):
-                            executed = run_runner(shell_name, stateful_runner)
                             self.assertEqual(
                                 executed.returncode,
                                 0,
-                                f"{shell_name} stateful runner failed:\n"
-                                f"{executed.stderr}\n{executed.stdout}",
+                                f"{shell_name} runner failed:\n{executed.stderr}\n{executed.stdout}",
                             )
-                            self.assertNotIn(
-                                "state-root binding", executed.stderr.lower()
-                            )
-                            self.assertEqual(
-                                executed.stdout, "portable Windows runner\n"
-                            )
+                            self.assertEqual(executed.stdout, "portable Windows runner\n")
 
     @unittest.skipUnless(os.name == "nt", "Windows Python launcher fallback test")
-    def test_broken_py_launcher_falls_back_to_python_and_runner_keeps_exact_interpreter(
-        self,
-    ) -> None:
-        powershell = shutil.which("pwsh")
-        self.assertIsNotNone(powershell, "pwsh is required on the Windows CI runner")
+    def test_broken_py_launcher_falls_back_to_python(self) -> None:
         command_prompt = shutil.which("cmd.exe")
         self.assertIsNotNone(command_prompt, "cmd.exe is required on Windows")
         real_python = shutil.which("python")
-        self.assertIsNotNone(real_python, "python.exe is required on the Windows CI runner")
+        self.assertIsNotNone(real_python, "python.exe is required on Windows")
         commands = windows_commands()
 
         with tempfile.TemporaryDirectory() as temporary:
@@ -336,12 +274,9 @@ class WindowsHookCommandTests(unittest.TestCase):
                 plugin_root / "hooks",
                 ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
             )
-            plugin_data = plugin_root / "plugin data"
             workspace = plugin_root / "workspace"
             workspace.mkdir()
-            probe = workspace / "fallback probe.txt"
-            probe.write_text("fallback runner works\n", encoding="utf-8")
-
+            plugin_data = plugin_root / "plugin data"
             fake_bin = base / "broken py launcher"
             fake_bin.mkdir()
             launcher_log = base / "launcher.log"
@@ -352,7 +287,6 @@ class WindowsHookCommandTests(unittest.TestCase):
                 "exit /b 103\r\n",
                 encoding="utf-8",
             )
-
             environment = os.environ.copy()
             environment.update(
                 {
@@ -363,29 +297,14 @@ class WindowsHookCommandTests(unittest.TestCase):
                     "PATH": str(fake_bin) + os.pathsep + environment.get("PATH", ""),
                 }
             )
-            request = {
-                "version": 1,
-                "commands": [["Get-Content", "-Raw", probe.name]],
-            }
-            event = synthetic_event("PreToolUse", workspace, "fallback")
-            event["tool_input"] = {
-                "command": (
-                    "click-gate inspect '"
-                    + json.dumps(request, separators=(",", ":"))
-                    + "'"
-                )
-            }
-            rendered_hook = rendered_windows_command(
-                commands["PreToolUse"], plugin_root
+            event = synthetic_event(
+                "PreToolUse", workspace, "fallback", tool_name="exec_command"
             )
-            hook_result = subprocess.run(
-                [
-                    powershell,
-                    "-NoProfile",
-                    "-NonInteractive",
-                    "-Command",
-                    rendered_hook,
-                ],
+            rendered = rendered_windows_command(commands["PreToolUse"], plugin_root)
+            result = subprocess.run(
+                rendered,
+                shell=True,
+                executable=command_prompt,
                 input=json.dumps(event) + "\n",
                 capture_output=True,
                 text=True,
@@ -394,61 +313,19 @@ class WindowsHookCommandTests(unittest.TestCase):
                 check=False,
             )
             self.assertEqual(
-                hook_result.returncode,
+                result.returncode,
                 0,
-                (
-                    "fallback hook failed:\n"
-                    f"stderr={hook_result.stderr!r}\n"
-                    f"stdout={hook_result.stdout!r}\n"
-                    f"log={launcher_log.read_text(encoding='utf-8') if launcher_log.exists() else '<missing>'}\n"
-                    f"python={real_python}"
-                ),
+                f"fallback hook failed:\n{result.stderr}\n{result.stdout}",
             )
-            self.assertNotIn("No installed Python found", hook_result.stderr)
-            payload = json.loads(hook_result.stdout)
-            runner = payload["hookSpecificOutput"]["updatedInput"]["command"]
-            self.assertTrue(runner.startswith(WINDOWS_HOOK_PREFIX), runner)
-            self.assertNotIn("py -3", runner.lower())
-
-            launches_before_runner = launcher_log.read_text(encoding="utf-8").splitlines()
-            self.assertEqual(launches_before_runner, ["py"])
-
-            for shell_name in ("PowerShell", "cmd.exe"):
-                with self.subTest(shell=shell_name):
-                    if shell_name == "PowerShell":
-                        invocation: str | list[str] = [
-                            powershell,
-                            "-NoProfile",
-                            "-NonInteractive",
-                            "-Command",
-                            runner,
-                        ]
-                        shell_options: dict[str, object] = {}
-                    else:
-                        invocation = runner
-                        shell_options = {
-                            "shell": True,
-                            "executable": command_prompt,
-                        }
-                    result = subprocess.run(
-                        invocation,
-                        capture_output=True,
-                        text=True,
-                        cwd=workspace,
-                        env=environment,
-                        check=False,
-                        **shell_options,
-                    )
-                    self.assertEqual(
-                        result.returncode,
-                        0,
-                        f"{shell_name} fallback runner failed:\n"
-                        f"{result.stderr}\n{result.stdout}",
-                    )
-                    self.assertEqual(result.stdout, "fallback runner works\n")
-
-            launches_after_runner = launcher_log.read_text(encoding="utf-8").splitlines()
-            self.assertEqual(launches_after_runner, launches_before_runner)
+            self.assertNotIn("No installed Python found", result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertIn(
+                "Click default mode:",
+                payload["hookSpecificOutput"]["updatedInput"]["command"],
+            )
+            self.assertEqual(
+                launcher_log.read_text(encoding="utf-8").splitlines(), ["py"]
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_windows_hook_commands.py
+++ b/tests/test_windows_hook_commands.py
@@ -104,10 +104,12 @@ class WindowsHookCommandTests(unittest.TestCase):
                 self.assertNotIn("powershell", commands[event_name].lower())
                 self.assertNotIn("py -3", commands[event_name].lower())
                 command = hooks[event_name][0]["hooks"][0]["command"]
-                self.assertIn("click_hook.py", command)
+                self.assertIn("click_gate.py", command)
 
-        matcher = hooks["PreToolUse"][0]["matcher"]
-        compiled = re.compile(matcher)
+        matchers = [
+            re.compile(entry["matcher"])
+            for entry in hooks["PreToolUse"]
+        ]
         for name in DESKTOP_EXEC_NAMES | {
             "apply_patch",
             "functions.apply_patch",
@@ -116,7 +118,12 @@ class WindowsHookCommandTests(unittest.TestCase):
             "mcp__node_repl__js",
         }:
             with self.subTest(matcher=name):
-                self.assertIsNotNone(compiled.fullmatch(name))
+                self.assertTrue(
+                    any(compiled.fullmatch(name) for compiled in matchers),
+                    name,
+                )
+        desktop_handler = hooks["PreToolUse"][1]["hooks"][0]
+        self.assertIn("click_hook.py", desktop_handler["command"])
 
     @unittest.skipUnless(os.name == "nt", "Windows cmd integration test")
     def test_hooks_execute_via_cmd_and_exec_aliases_rewrite(self) -> None:


### PR DESCRIPTION
## Summary

Fixes Click 0.24.5 failing to enforce on Codex Desktop when direct execution is exposed as `exec_command` instead of the historical `Bash` tool name, and removes the embedded PowerShell `-Command` wrapper from Windows Hook entrypoints.

## Changes

- preserve the existing canonical `Bash|apply_patch|...` PreToolUse route unchanged
- add a separate Desktop execution matcher for `exec_command`, `shell_command`, `unified_exec`, their function-qualified forms, and observed Code Mode aliases
- normalize those execution aliases onto Click's existing Bash policy before the core state machine sees the event
- invoke Windows Hook entrypoints directly through the quoted `.cmd` launcher instead of embedding a PowerShell `-Command` payload
- keep the Windows Python fallback bridge and exact selected interpreter reuse from #36
- keep normal non-Windows lifecycle hooks on the existing `click_gate.py` entrypoint; only the additional Desktop-exec route uses the normalization adapter

## Regression coverage

- Windows UserPromptSubmit executes through the real `cmd.exe` hook path and returns additional context
- `Bash`, `exec_command`, `functions.exec_command`, and `shell_command` rewrite `click-gate` control commands through the same gate
- structured inspection through `functions.exec_command` returns a working rewritten runner
- rewritten runners execute from both PowerShell and `cmd.exe`
- a broken `py` launcher still falls back to a working `python.exe`
- package and direct-script imports of the normalizer are covered
- the original canonical matcher remains pinned by the existing regression suite

## Upstream host limitation

Current Codex Code Mode has an open upstream issue where `functions.exec` / Code Mode `exec` may not emit `PreToolUse` at all. Click cannot enforce an event the host never dispatches. This patch covers direct `exec_command` routes and maps Code Mode aliases into the conservative gate whenever the host actually exposes the event.

No contract, approval, evidence, verification-budget, or state-recovery semantics are relaxed.

## Verification

- CI #180: passed on Ubuntu, macOS, and Windows
- Plugin Security Scan #115: passed