### PR TITLE
Release Click v0.24.6 Windows Desktop compatibility

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/grapefruit0205/click.git",
-        "ref": "v0.24.5"
+        "ref": "v0.24.6"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "click",
-  "version": "0.24.5",
+  "version": "0.24.6",
   "description": "Choose Always ON or @Click Manual. Click turns a software change into one compact plain-language execution contract, waits for approval, then keeps Codex inside that boundary with structured commands and only the primary evidence needed for completion—without repeated planning or repository-wide rescans.",
   "author": {
     "name": "Junseok Pak",

--- a/README.ko.md
+++ b/README.ko.md
@@ -222,16 +222,16 @@ Antigravity IDE에서는 `dist/antigravity`를 워크스페이스의 `.agents/pl
 
 Antigravity의 Hook contract는 Codex와 다릅니다. native file/search와 별도 MCP·Skill 도구는 계속 사용할 수 있지만 cross-tool 중복 제거와 Browser evidence는 아직 지원하지 않습니다. 정확한 제한은 [`platforms/antigravity/README.md`](platforms/antigravity/README.md)를 확인하세요.
 
-## 기존 설치 업데이트 — v0.24.5
+## 기존 설치 업데이트 — v0.24.6
 
-현재 릴리스는 **v0.24.5**입니다.
+현재 릴리스는 **v0.24.6**입니다.
 
 ```bash
 codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-ChatGPT 데스크톱 앱을 다시 시작하고 갱신된 Hook을 검토해 신뢰하세요. 이전 설치가 만든 실행 대기 중 runner 명령은 재사용하지 말고 새 Hook이 다시 발급하게 합니다.
+ChatGPT 데스크톱 앱을 다시 시작하고 갱신된 Hook을 검토해 신뢰하세요. Windows에서 v0.24.6은 Python launcher fallback을 추가하고, 호스트가 해당 Hook 이벤트를 전달하는 경우 Desktop의 `exec_command` 계열 실행을 Click 경로로 정규화합니다. 이전 설치가 만든 실행 대기 중 runner 명령은 재사용하지 말고 새 Hook이 다시 발급하게 합니다.
 
 자세한 릴리스 이력은 [RELEASE_NOTES.md](RELEASE_NOTES.md)에 있습니다.
 
@@ -243,6 +243,7 @@ Hook이 다음을 할 수 있다고 주장하지 않습니다.
 
 - 숨은 추론이나 자연어로만 작성된 계획을 검사;
 - matcher 밖 모든 connector나 hosted tool을 관찰;
+- Codex 클라이언트가 일치하는 Hook 이벤트를 전달하지 않는 실행 경로를 강제;
 - 의미적 경계 준수나 아키텍처 정확성을 단독으로 증명;
 - matcher 밖 수동·외부 attestation이 실제로 수행됐는지 독립적으로 증명;
 - 허용된 사용자 프로그램 내부에 숨은 여러 동작을 차단;

--- a/README.md
+++ b/README.md
@@ -222,16 +222,16 @@ Antigravity IDE users may also copy `dist/antigravity` into `.agents/plugins/cli
 
 Antigravity's Hook contract differs from Codex. Native file/search and unrelated MCP or Skill tools remain available, but cross-tool deduplication and Browser evidence are not currently supported. See [`platforms/antigravity/README.md`](platforms/antigravity/README.md) for the exact limits.
 
-## Update an existing installation — v0.24.5
+## Update an existing installation — v0.24.6
 
-The current release is **v0.24.5**.
+The current release is **v0.24.6**.
 
 ```bash
 codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-Restart the ChatGPT desktop app and review/trust the updated Hook. Do not reuse a pending runner command created by an older installation; let the updated Hook issue a fresh one.
+Restart the ChatGPT desktop app and review/trust the updated Hook. On Windows, v0.24.6 adds Python-launcher fallback and routes Desktop `exec_command` aliases through Click when the host dispatches the matching Hook event. Do not reuse a pending runner command created by an older installation; let the updated Hook issue a fresh one.
 
 Detailed release history is in [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
@@ -243,6 +243,7 @@ It does **not** claim that the Hook can:
 
 - inspect hidden reasoning or a plan written only in prose;
 - observe every unmatched connector or hosted tool;
+- enforce a host execution path when the Codex client does not dispatch the matching Hook event;
 - independently prove semantic boundary compliance or architectural correctness;
 - prove that an unmatched manual or external attestation truly occurred;
 - stop allowed custom code from hiding multiple operations;

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -222,16 +222,16 @@ Antigravity IDE 用户也可以把 `dist/antigravity` 复制到工作区的 `.ag
 
 Antigravity 的 Hook contract 与 Codex 不同。native file/search 和其他 MCP、Skill 工具仍可使用，但目前还不支持 cross-tool 去重和 Browser evidence。准确限制请参阅 [`platforms/antigravity/README.md`](platforms/antigravity/README.md)。
 
-## 更新现有安装 — v0.24.5
+## 更新现有安装 — v0.24.6
 
-当前版本是 **v0.24.5**。
+当前版本是 **v0.24.6**。
 
 ```bash
 codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-重启 ChatGPT 桌面应用并检查、信任更新后的 Hook。不要复用旧安装留下的待执行 runner 命令；让更新后的 Hook 重新签发。
+重启 ChatGPT 桌面应用并检查、信任更新后的 Hook。在 Windows 上，v0.24.6 增加 Python launcher fallback；当宿主实际派发匹配的 Hook 事件时，Desktop 的 `exec_command` 类执行会被规范化到 Click 路径。不要复用旧安装留下的待执行 runner 命令；让更新后的 Hook 重新签发。
 
 详细发布历史见 [RELEASE_NOTES.md](RELEASE_NOTES.md)。
 
@@ -243,6 +243,7 @@ Click 只在 Hook 真正可以观察并强制执行的范围内做强声明。
 
 - 检查隐藏推理或只写在自然语言中的计划；
 - 观察所有 matcher 外的 connector 或 hosted tool；
+- 在 Codex 客户端没有派发匹配 Hook 事件时强制对应的宿主执行路径；
 - 单独证明语义边界合规或架构正确性；
 - 独立证明 matcher 外部人工或外部 attestation 真实发生；
 - 阻止已允许自定义程序内部隐藏多项操作；

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,69 @@
 # Release notes
 
+## v0.24.6 — 2026-08-31
+
+Click v0.24.6 is a focused Windows/Codex Desktop compatibility and runner-state
+recovery patch. Contract shape, approval semantics, evidence protocol,
+verification budgets, and the observable workflow policy remain unchanged.
+
+### Recover approved runner state before strict path resolution
+
+- Stateful mutation, verification, and managed-service runners keep the final
+  canonical `Path.resolve(strict=True)` admission check, but an already-issued
+  approved runner may now restore its exact missing session-contract state from
+  a short-lived recovery mirror before that strict check runs.
+- Recovery requires the explicit bound state path plus the existing request or
+  service binding and one-use runner token to match. Wrong tokens, mismatched
+  requests, cancelled contracts, expired reservations, and consumed-runner
+  replay remain fail-closed.
+- Explicit contract cancellation removes the recovery mirror. Recovery-only
+  paths use non-strict canonicalization so macOS aliases such as `/var` and
+  `/private/var` resolve to the same snapshot without weakening the final state
+  path validation.
+
+### Windows Python launcher fallback
+
+- Windows lifecycle Hooks no longer assume that `py -3` can resolve an
+  installed interpreter. The launcher probes Python 3 through `py -3`, then
+  `python`, then `python3`, and a broken `py` launcher can fall through to a
+  working `python.exe`.
+- Once the Hook starts, rewritten Click runners reuse the exact selected
+  `sys.executable` instead of returning to `py -3`. Existing encoded transport,
+  runner claims, state-root binding, and shell-free capability execution remain
+  unchanged.
+- The Windows regression suite includes a fake `py` launcher that reports
+  `No installed Python found!` while a real `python.exe` remains available.
+
+### Codex Desktop exec routing and Hook launch
+
+- The existing canonical `Bash|apply_patch|...` PreToolUse matcher remains
+  unchanged. A separate Desktop execution matcher covers `exec_command`,
+  `shell_command`, `unified_exec`, function-qualified forms, and observed Code
+  Mode aliases.
+- Direct execution aliases are normalized onto Click's canonical Bash policy
+  before the core state machine sees the event, so `click-gate` control commands
+  and structured reads receive the same rewrite and enforcement when the host
+  dispatches the matching Hook event.
+- Windows lifecycle Hooks invoke the quoted `.cmd` launcher directly instead of
+  wrapping the entrypoint in an embedded PowerShell `-Command` payload.
+  UserPromptSubmit, PreToolUse, PostToolUse, and SessionEnd keep their existing
+  lifecycle semantics and timeouts.
+- This does not claim to solve a host path that never dispatches PreToolUse.
+  If Codex Code Mode executes through a surface for which the client emits no
+  matching Hook event, Click cannot observe or enforce that execution.
+
+### Regression and release gate
+
+- Focused regressions cover deleted state-root/state-file recovery, wrong-token
+  rejection, cancel/replay revocation, Windows encoded-runner recovery, broken
+  `py` fallback, direct `cmd.exe` UserPromptSubmit context, Desktop
+  `exec_command` rewriting, structured inspection, and rewritten runner
+  execution through PowerShell and `cmd.exe`.
+- The compatibility patches passed deterministic CI on Ubuntu, macOS, and
+  Windows and the Plugin Security Scan before this release metadata was staged.
+- The immutable `v0.24.6` tag and GitHub Release must point to the exact merged
+  main commit that passes the final release CI and security checks.
+
 ## v0.24.5 — 2026-08-31
 
 Click v0.24.5 is a focused Windows internal-runner shell compatibility

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -21,6 +21,63 @@ def _reference(name: str) -> str:
 class RepositoryPolicyTests(core.RepositoryPolicyTests):
     """Preserve the full policy suite while keeping protocol internals out of the README hero."""
 
+    def test_manifest_declares_click_one_shot_release(self) -> None:
+        manifest = json.loads(
+            (ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(manifest["name"], "click")
+        self.assertEqual(manifest["version"], "0.24.6")
+        self.assertEqual(manifest["license"], "MIT")
+        self.assertIn("always on", manifest["description"].lower())
+        self.assertIn("manual", manifest["description"].lower())
+        self.assertIn("plain-language", manifest["description"].lower())
+        self.assertIn("execution contract", manifest["description"].lower())
+        self.assertIn("compact", manifest["description"].lower())
+        self.assertIn("one shot", manifest["interface"]["longDescription"].lower())
+        self.assertIn("verification", manifest["interface"]["longDescription"].lower())
+        self.assertIn(
+            "cheapest sufficient primary evidence",
+            manifest["interface"]["longDescription"].lower(),
+        )
+        self.assertIn("automatically", manifest["interface"]["longDescription"].lower())
+        self.assertIn("replanning", manifest["interface"]["longDescription"].lower())
+        self.assertIn(
+            "isolated child process groups",
+            manifest["interface"]["longDescription"].lower(),
+        )
+        self.assertIn(
+            "process-control executables",
+            manifest["interface"]["longDescription"].lower(),
+        )
+        self.assertIn("contract_id", manifest["interface"]["longDescription"])
+        self.assertIn(
+            "never the json again",
+            manifest["interface"]["longDescription"].lower(),
+        )
+        self.assertIn("anti-loop", manifest["keywords"])
+        self.assertIn("@Click", manifest["description"])
+        self.assertIn("structured", manifest["description"].lower())
+        self.assertIn("keeps codex inside that boundary", manifest["description"].lower())
+        self.assertEqual(
+            manifest["interface"]["shortDescription"],
+            "Approve one clear boundary, then build and verify without replanning.",
+        )
+        self.assertLessEqual(len(manifest["interface"]["defaultPrompt"]), 3)
+        for prompt in manifest["interface"]["defaultPrompt"]:
+            self.assertLessEqual(len(prompt), 128)
+
+    def test_marketplace_exposes_click_from_the_click_catalog(self) -> None:
+        marketplace = json.loads(
+            (ROOT / ".agents" / "plugins" / "marketplace.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(marketplace["name"], "click")
+        self.assertEqual(marketplace["plugins"][0]["name"], "click")
+        self.assertEqual(
+            marketplace["plugins"][0]["source"]["ref"], "v0.24.6"
+        )
+
     def test_readmes_lead_with_hook_enforced_state_machine_positioning(self) -> None:
         english, korean, chinese = _readmes().values()
         for marker in (
@@ -126,7 +183,7 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
         for marker in ("shell=False", "process group", "process-control", "pkill"):
             self.assertIn(marker, protocol)
 
-    def test_release_documents_identify_v0246_and_preserve_release_history(self) -> None:
+    def test_release_documents_identify_v0245_and_preserve_release_history(self) -> None:
         for readme in _readmes().values():
             self.assertIn("v0.24.6", readme)
             self.assertIn("codex plugin marketplace upgrade click", readme)

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -126,13 +126,14 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
         for marker in ("shell=False", "process group", "process-control", "pkill"):
             self.assertIn(marker, protocol)
 
-    def test_release_documents_identify_v0245_and_preserve_release_history(self) -> None:
+    def test_release_documents_identify_v0246_and_preserve_release_history(self) -> None:
         for readme in _readmes().values():
-            self.assertIn("v0.24.5", readme)
+            self.assertIn("v0.24.6", readme)
             self.assertIn("codex plugin marketplace upgrade click", readme)
             self.assertIn("codex plugin add click@click", readme)
         notes = (ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8")
         for marker in (
+            "## v0.24.6",
             "## v0.24.5",
             "## v0.24.4",
             "## v0.24.3",


### PR DESCRIPTION
## Summary

Release Click v0.24.6 from the current main after the focused Windows/Codex Desktop compatibility fixes.

This release includes:

- approved runner-state recovery when the bound `gate-state` root or session-contract JSON disappears immediately before execution (#35)
- Windows Python launcher fallback from broken/unavailable `py -3` to `python` / `python3`, while reusing the exact selected interpreter for rewritten runners (#36)
- Codex Desktop execution routing for `exec_command` / shell aliases plus direct Windows `.cmd` lifecycle Hook entrypoints (#37)

Contract shape, approval handoff, evidence protocol, verification budgets, and observable workflow policy are unchanged.

## Release metadata

- bump `.codex-plugin/plugin.json` to `0.24.6`
- pin the repository marketplace to immutable `v0.24.6`
- update English, Korean, and Simplified Chinese upgrade docs
- add v0.24.6 release notes
- align repository-policy release assertions

## Honest host boundary

Click can enforce `exec_command` and equivalent aliases when Codex dispatches the matching Hook event. If a Codex Code Mode execution path does not emit `PreToolUse` at all, Click cannot observe or enforce that host-side execution path.

## Required release gate

- deterministic tests on Ubuntu, macOS, and Windows
- distribution validation, Python compilation, and whitespace validation
- Plugin Security Scan
- merge only after the exact release candidate is green

The immutable `v0.24.6` tag and GitHub Release must point to the exact merged-main commit that passes the final release checks.