### PR TITLE
Release Click v0.30.0 authorization and evidence core

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/grapefruit0205/click.git",
-        "ref": "v0.24.6"
+        "ref": "v0.30.0"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "click",
-  "version": "0.24.6",
+  "version": "0.30.0",
   "description": "Choose Always ON or @Click Manual. Click binds a software change to one compact plain-language execution contract, waits for approval, then uses structured runners to return revision-bound evidence for the authorized execution.",
   "author": {
     "name": "Junseok Pak",

--- a/GUARD_CLASSIFICATION.md
+++ b/GUARD_CLASSIFICATION.md
@@ -38,11 +38,11 @@ not claim that every hard gate has already been moved to its target layer.
 | Current strategic guard | Current owner | Target behavior |
 | --- | --- | --- |
 | Advising on a repeated successful read or search and on repeated incomplete/failing reads | observation preparation in `hooks/click_gate.py` | Advisory only — fresh separately authorized repeats use a new one-use runner; an active same-digest reservation remains a Core interlock |
-| Advising after broad repository inventory | broad-exploration classifiers, observation preparation and host adapters | Advisory only — cross-digest running/success hard denial removed in the v0.25 candidate; active same-digest reservations and execution interlocks remain separate |
-| Advising on `update_plan` or equivalent host plan tools | plan-tool branch in `hooks/click_gate.py`; host matchers and adapters | Advisory only — hard denial removed in the v0.25 candidate |
+| Advising after broad repository inventory | broad-exploration classifiers, observation preparation and host adapters | Advisory only — cross-digest running/success hard denial removed in v0.30.0; active same-digest reservations and execution interlocks remain separate |
+| Advising on `update_plan` or equivalent host plan tools | plan-tool branch in `hooks/click_gate.py`; host matchers and adapters | Advisory only — hard denial removed in v0.30.0 |
 | Choosing the proposed evidence source and qualitative verification profile before approval, concrete argv during execution, and the cheapest proof strategy | Skill, eval and documentation policy | Model strategy or an explicit user constraint; Click records the choice but does not interpret it as runtime authority |
 | Legacy verification class-unit values | `hooks/click_verification_policy.py` and `hooks/click_verification_meter.py` | Compatibility data only — they do not produce runtime advice, prove cost or sufficiency, or participate in receipt authority |
-| Requiring a mutation after a fixed number of otherwise legitimate failed retries | argv verification and Browser retry handling | Advisory only in the v0.25 candidate; fresh authorization remains distinct from replay of an active or consumed runner |
+| Requiring a mutation after a fixed number of otherwise legitimate failed retries | argv verification and Browser retry handling | Advisory only in v0.30.0; fresh authorization remains distinct from replay of an active or consumed runner |
 | Browser repeat/retry guidance, preferred timing thresholds and interaction-history depth | `hooks/click_browser_advisory.py`; bounded history compaction in Browser preparation | Advisory only — normalized repeats and long timed interactions remain receipt-bound and allowed; old per-input guidance is compacted instead of blocking a new call |
 | Contract compactness, planning prose and workflow-shape preferences beyond parser or transport safety | `hooks/click_contract.py` schema policy | Keep only identity-bearing protocol fields in Core |
 | Main Skill authoring compactness | reference split, plugin validation and review | Heuristic documentation quality — no word-count permission gate; required links and protocol structure remain testable without optimizing prose to an arbitrary number |
@@ -96,6 +96,13 @@ implementation safeguard, become an explicitly configured user policy, or stop
 hard-blocking. They must not be promoted as product identity merely because the
 current implementation enforces them.
 
+For v0.30.0, contract prose length, verification check count, and the former
+6,000-character raw capability threshold stop hard-blocking. Inspection retains
+an eight-command cap because one request is one atomic read-runner claim with
+bounded output exposure. Decoded transport, actual Windows command-line, argv,
+output and retained-state bounds remain implementation safeguards to review
+against the same rule rather than workflow-quality judgments.
+
 These gaps must remain explicit. Marketing and documentation must not claim a
 stronger guarantee than the runtime can observe.
 
@@ -103,14 +110,14 @@ stronger guarantee than the runtime can observe.
 
 1. **Complete:** Treat the v0.24.6 state-root recovery, distribution, tests and release as complete.
 2. **Complete:** Establish this classification without changing behavior.
-3. **Complete in the v0.25 candidate:** Convert plan-tool hard denial to advisory output.
-4. **Complete in the v0.25 candidate:** Convert broad-inventory counting to advisory output while retaining active exact-digest reservations and Core execution interlocks.
-5. **Complete in the v0.25 candidate:** Convert fresh duplicate-read and fixed legitimate argv-retry denials to advisory output while retaining active-runner and verification-time mutation denials.
-6. **Complete in the v0.25 candidate:** Separate model-selected verification strategy, qualitative profile metadata, legacy unit compatibility, and exact receipt binding; remove plugin-authored cumulative ceilings and numeric overage advice from runtime authority.
-7. **Complete in the v0.25 candidate:** Separate Browser source, serial-call,
+3. **Complete in v0.30.0:** Convert plan-tool hard denial to advisory output.
+4. **Complete in v0.30.0:** Convert broad-inventory counting to advisory output while retaining active exact-digest reservations and Core execution interlocks.
+5. **Complete in v0.30.0:** Convert fresh duplicate-read and fixed legitimate argv-retry denials to advisory output while retaining active-runner and verification-time mutation denials.
+6. **Complete in v0.30.0:** Separate model-selected verification strategy, qualitative profile metadata, legacy unit compatibility, and exact receipt binding; remove plugin-authored cumulative ceilings and numeric overage advice from runtime authority.
+7. **Complete in v0.30.0:** Separate Browser source, serial-call,
    result, revision and replay integrity from non-blocking repeat, retry and
    timing guidance.
-8. **Complete in the v0.25 candidate:** Update Skill, evals, manifest, README and
+8. **Complete in v0.30.0:** Update Skill, evals, manifest, README and
    host distributions together with the behavior they describe.
 
 Each migration is a separate behavior-preserving-for-Core change. It must retain

--- a/README.ko.md
+++ b/README.ko.md
@@ -238,16 +238,16 @@ Antigravity IDE에서는 `dist/antigravity`를 워크스페이스의 `.agents/pl
 
 Antigravity의 Hook contract는 Codex와 다릅니다. native file/search와 별도 MCP·Skill 도구는 계속 사용할 수 있지만 cross-tool 중복 제거와 Browser evidence는 아직 지원하지 않습니다. 정확한 제한은 [`platforms/antigravity/README.md`](platforms/antigravity/README.md)를 확인하세요.
 
-## 기존 설치 업데이트 — v0.24.6
+## 기존 설치 업데이트 — v0.30.0
 
-현재 릴리스는 **v0.24.6**입니다.
+현재 릴리스는 **v0.30.0**입니다.
 
 ```bash
 codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-ChatGPT 데스크톱 앱을 다시 시작하고 갱신된 Hook을 검토해 신뢰하세요. Windows에서 v0.24.6은 Python launcher fallback을 추가하고, 호스트가 해당 Hook 이벤트를 전달하는 경우 Desktop의 `exec_command` 계열 실행을 Click 경로로 정규화합니다. 이전 설치가 만든 실행 대기 중 runner 명령은 재사용하지 말고 새 Hook이 다시 발급하게 합니다.
+ChatGPT 데스크톱 앱을 다시 시작하고 갱신된 Hook을 검토해 신뢰하세요. v0.30.0은 runtime 권한을 승인, one-use 실행, evidence 무결성에 집중합니다. 전략 카운터와 숫자형 검증 profile은 더 이상 작업을 차단하지 않으며, 계약 prose 길이와 verification check 개수도 권한 gate가 아닙니다. inspection 요청당 8개 제한은 실행기의 운영 경계로 유지됩니다. 이전 설치의 대기 중 runner를 재사용하지 말고 업그레이드 후 새 계약을 시작하세요.
 
 자세한 릴리스 이력은 [RELEASE_NOTES.md](RELEASE_NOTES.md)에 있습니다.
 

--- a/README.md
+++ b/README.md
@@ -239,16 +239,16 @@ Antigravity IDE users may also copy `dist/antigravity` into `.agents/plugins/cli
 
 Antigravity's Hook contract differs from Codex. Native file/search and unrelated MCP or Skill tools remain available, but cross-tool deduplication and Browser evidence are not currently supported. See [`platforms/antigravity/README.md`](platforms/antigravity/README.md) for the exact limits.
 
-## Update an existing installation — v0.24.6
+## Update an existing installation — v0.30.0
 
-The current release is **v0.24.6**.
+The current release is **v0.30.0**.
 
 ```bash
 codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-Restart the ChatGPT desktop app and review/trust the updated Hook. On Windows, v0.24.6 adds Python-launcher fallback and routes Desktop `exec_command` aliases through Click when the host dispatches the matching Hook event. Do not reuse a pending runner command created by an older installation; let the updated Hook issue a fresh one.
+Restart the ChatGPT desktop app and review/trust the updated Hook. v0.30.0 narrows runtime authority to approval, one-use execution, and evidence integrity. Strategy counters and numeric verification profiles no longer block work; contract prose length and verification check count are not permission gates. The eight-command inspection bound remains an operational runner limit. Begin a fresh contract after upgrading instead of reusing a pending runner from an older installation.
 
 Detailed release history is in [RELEASE_NOTES.md](RELEASE_NOTES.md).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -237,16 +237,16 @@ Antigravity IDE 用户也可以把 `dist/antigravity` 复制到工作区的 `.ag
 
 Antigravity 的 Hook contract 与 Codex 不同。native file/search 和其他 MCP、Skill 工具仍可使用，但目前还不支持 cross-tool 去重和 Browser evidence。准确限制请参阅 [`platforms/antigravity/README.md`](platforms/antigravity/README.md)。
 
-## 更新现有安装 — v0.24.6
+## 更新现有安装 — v0.30.0
 
-当前版本是 **v0.24.6**。
+当前版本是 **v0.30.0**。
 
 ```bash
 codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-重启 ChatGPT 桌面应用并检查、信任更新后的 Hook。在 Windows 上，v0.24.6 增加 Python launcher fallback；当宿主实际派发匹配的 Hook 事件时，Desktop 的 `exec_command` 类执行会被规范化到 Click 路径。不要复用旧安装留下的待执行 runner 命令；让更新后的 Hook 重新签发。
+重启 ChatGPT 桌面应用并检查、信任更新后的 Hook。v0.30.0 将 runtime 权限聚焦于批准、one-use 执行与 evidence 完整性。策略计数器和数字化验证 profile 不再阻断工作；contract prose 长度和 verification check 数量也不再是权限 gate。每次 inspection 最多八条命令仍作为 runner 的运行边界保留。升级后请开始新 contract，不要复用旧安装留下的待执行 runner。
 
 详细发布历史见 [RELEASE_NOTES.md](RELEASE_NOTES.md)。
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Unreleased v0.25 candidate — authorization and evidence core
+## v0.30.0 — 2026-08-31
 
 Click now states its stable product boundary directly: bind AI execution to
 approved intent and return verifiable evidence. Model workflow strategy is not
@@ -60,8 +60,8 @@ runtime authority.
   revision, environment, executable fingerprints, and observed results remain
   receipt facts; legacy class-unit values remain compatibility data only.
 - Separate leaf modules now own profile names and legacy unit arithmetic.
-  Contract and gate compatibility symbols, contract schema, error messages,
-  one-use runners, evidence receipts, and completion behavior remain unchanged.
+  Contract schema, one-use runners, evidence receipts, and completion behavior
+  remain unchanged except for the prose-length gate described below.
 - A future exact numeric ceiling belongs in an explicit opt-in user-policy
   field; plugin-authored defaults will not silently stand in for that choice.
 
@@ -99,6 +99,37 @@ runtime authority.
   reference links, lifecycle markers, manifest shape, Skill validation, and
   distribution consistency remain checked, while prose length and clarity stay
   authoring-review concerns rather than runtime or CI permission rules.
+- This item remains in the v0.30.0 notes because the policy removal landed
+  after v0.24.6 and has not previously shipped in a stable release.
+
+### Contract and verification size heuristics stop granting authority
+
+- A valid Execution Contract is no longer rejected solely because its encoded
+  prose exceeds 4,000 characters. Typed schema validation and contract-digest
+  binding remain unchanged.
+- A verification request is no longer rejected solely because it contains more
+  than eight checks or its JSON exceeds the former arbitrary 6,000-character
+  threshold. Argv policy, exact source-group binding, serial execution, and
+  mutation detection remain.
+- Inspection, mutation, service, and explicit evidence requests likewise no
+  longer inherit that raw-JSON character heuristic from the common decoder.
+- Inspection retains its eight-command request cap: it bounds one atomic
+  read-runner claim and its output exposure rather than judging model strategy.
+- Capability transport remains bounded by its decoded payload guard and the
+  host-imposed Windows command-line limit; those execution checks replace the
+  unrelated raw-JSON character heuristic.
+- Unused `_verification_executable_digest` and
+  `_is_broad_exploration_command` compatibility-free helpers are removed.
+
+### Evidence reuse boundary
+
+- v0.30.0 continues to reuse a successful exact receipt only when its active
+  contract, mutation revision, protected Git tree, normalized check group,
+  canonical environment, and executable fingerprint still match.
+- A dependency-aware cache across revisions is intentionally not included. It
+  requires a separate invalidation design backed by repository-owned dependency
+  data, with whole-tree invalidation as the safe fallback; model-declared impact
+  alone will not become receipt authority.
 
 ## v0.24.6 — 2026-08-31
 

--- a/dist/antigravity/hooks/click_contract.py
+++ b/dist/antigravity/hooks/click_contract.py
@@ -36,15 +36,9 @@ EVIDENCE_ID_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9_-]{0,31}$")
 VERIFICATION_SCALES = click_verification_policy.VERIFICATION_SCALES
 VERIFICATION_UNIT_LIMITS = click_verification_policy.VERIFICATION_UNIT_LIMITS
 VERIFICATION_CLASSES = click_verification_meter.VERIFICATION_CLASSES
-MAX_CONTRACT_CHARS = 4_000
 
 
 def validate_contract(raw: str) -> tuple[dict[str, Any] | None, str]:
-    if len(raw) > MAX_CONTRACT_CHARS:
-        return (
-            None,
-            "Execution Contract is too large; keep it compact and under 4,000 characters.",
-        )
     try:
         value = json.loads(raw)
     except json.JSONDecodeError:

--- a/dist/antigravity/hooks/click_gate.py
+++ b/dist/antigravity/hooks/click_gate.py
@@ -162,11 +162,8 @@ DEEP_VERIFICATION_MARKERS = {
     "load_test",
     "security",
 }
-MAX_CAPABILITY_COMMANDS = 8
+MAX_INSPECTION_COMMANDS = 8
 MAX_ARGV_ITEMS = 128
-MAX_CONTRACT_CHARS = click_contract.MAX_CONTRACT_CHARS
-MAX_CAPABILITY_REQUEST_CHARS = 6_000
-MAX_VERIFICATION_BATCH_CHARS = 6_000
 MAX_OBSERVATION_OUTPUT_BYTES = 48_000
 MAX_OBSERVATION_ENTRIES = 64
 MAX_BROWSER_UNIQUE_INPUTS = 256
@@ -1014,11 +1011,8 @@ def _decode_capability_request(
     raw: str,
     label: str,
     *,
-    limit: int = MAX_CAPABILITY_REQUEST_CHARS,
     version: int = CAPABILITY_PROTOCOL_VERSION,
 ) -> tuple[dict[str, Any] | None, str]:
-    if len(raw) > limit:
-        return None, f"{label} request must stay under {limit:,} characters."
     try:
         value = json.loads(raw)
     except json.JSONDecodeError:
@@ -1121,11 +1115,11 @@ def _validate_inspection_request(
     commands = value.get("commands")
     if not isinstance(commands, list) or not commands:
         return None, False, "Inspection `commands` must be a non-empty argv-list list."
-    if len(commands) > MAX_CAPABILITY_COMMANDS:
+    if len(commands) > MAX_INSPECTION_COMMANDS:
         return (
             None,
             False,
-            f"Inspection may contain at most {MAX_CAPABILITY_COMMANDS} commands.",
+            f"Inspection may contain at most {MAX_INSPECTION_COMMANDS} commands.",
         )
     normalized: list[list[str]] = []
     broad = False
@@ -1209,7 +1203,6 @@ def _validate_verification_batch(
     value, error = _decode_capability_request(
         raw,
         "Verification batch",
-        limit=MAX_VERIFICATION_BATCH_CHARS,
         version=VERIFICATION_PROTOCOL_VERSION,
     )
     if error:
@@ -1229,8 +1222,6 @@ def _validate_verification_batch(
     checks = value.get("checks")
     if not isinstance(checks, list) or not checks:
         return None, 0, "Verification batch `checks` must be a non-empty list."
-    if len(checks) > MAX_CAPABILITY_COMMANDS:
-        return None, 0, f"Verification may contain at most {MAX_CAPABILITY_COMMANDS} checks."
     normalized: list[dict[str, Any]] = []
     units = 0
     for index, check in enumerate(checks, start=1):
@@ -1577,19 +1568,6 @@ def _verification_executable_payload(
         }
         for executable in executables
     ]
-
-
-def _verification_executable_digest(
-    checks: list[dict[str, Any]], *, cwd: Path, environment: dict[str, str] | None = None
-) -> str:
-    executables = _verification_executable_records(
-        checks, cwd=cwd, environment=environment
-    )
-    if executables is None:
-        return ""
-    return _capability_digest(
-        {"executables": _verification_executable_payload(executables)}
-    )
 
 
 def _verification_environment_digest_from_records(
@@ -2207,13 +2185,6 @@ def _is_broad_exploration_tokens(tokens: list[str]) -> bool:
             targets = remainder[remainder.index("--") + 1 :]
             return _targets_repository_root(targets)
     return False
-
-
-def _is_broad_exploration_command(command: str) -> bool:
-    segments = _shell_segments(command)
-    return bool(segments) and any(
-        _is_broad_exploration_tokens(segment) for segment in segments
-    )
 
 
 def _capability_digest(request: dict[str, Any]) -> str:

--- a/hooks/click_contract.py
+++ b/hooks/click_contract.py
@@ -36,15 +36,9 @@ EVIDENCE_ID_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9_-]{0,31}$")
 VERIFICATION_SCALES = click_verification_policy.VERIFICATION_SCALES
 VERIFICATION_UNIT_LIMITS = click_verification_policy.VERIFICATION_UNIT_LIMITS
 VERIFICATION_CLASSES = click_verification_meter.VERIFICATION_CLASSES
-MAX_CONTRACT_CHARS = 4_000
 
 
 def validate_contract(raw: str) -> tuple[dict[str, Any] | None, str]:
-    if len(raw) > MAX_CONTRACT_CHARS:
-        return (
-            None,
-            "Execution Contract is too large; keep it compact and under 4,000 characters.",
-        )
     try:
         value = json.loads(raw)
     except json.JSONDecodeError:

--- a/hooks/click_gate.py
+++ b/hooks/click_gate.py
@@ -162,9 +162,8 @@ DEEP_VERIFICATION_MARKERS = {
     "load_test",
     "security",
 }
-MAX_CAPABILITY_COMMANDS = 8
+MAX_INSPECTION_COMMANDS = 8
 MAX_ARGV_ITEMS = 128
-MAX_CONTRACT_CHARS = click_contract.MAX_CONTRACT_CHARS
 MAX_CAPABILITY_REQUEST_CHARS = 6_000
 MAX_VERIFICATION_BATCH_CHARS = 6_000
 MAX_OBSERVATION_OUTPUT_BYTES = 48_000
@@ -1121,11 +1120,11 @@ def _validate_inspection_request(
     commands = value.get("commands")
     if not isinstance(commands, list) or not commands:
         return None, False, "Inspection `commands` must be a non-empty argv-list list."
-    if len(commands) > MAX_CAPABILITY_COMMANDS:
+    if len(commands) > MAX_INSPECTION_COMMANDS:
         return (
             None,
             False,
-            f"Inspection may contain at most {MAX_CAPABILITY_COMMANDS} commands.",
+            f"Inspection may contain at most {MAX_INSPECTION_COMMANDS} commands.",
         )
     normalized: list[list[str]] = []
     broad = False
@@ -1229,8 +1228,6 @@ def _validate_verification_batch(
     checks = value.get("checks")
     if not isinstance(checks, list) or not checks:
         return None, 0, "Verification batch `checks` must be a non-empty list."
-    if len(checks) > MAX_CAPABILITY_COMMANDS:
-        return None, 0, f"Verification may contain at most {MAX_CAPABILITY_COMMANDS} checks."
     normalized: list[dict[str, Any]] = []
     units = 0
     for index, check in enumerate(checks, start=1):
@@ -1577,19 +1574,6 @@ def _verification_executable_payload(
         }
         for executable in executables
     ]
-
-
-def _verification_executable_digest(
-    checks: list[dict[str, Any]], *, cwd: Path, environment: dict[str, str] | None = None
-) -> str:
-    executables = _verification_executable_records(
-        checks, cwd=cwd, environment=environment
-    )
-    if executables is None:
-        return ""
-    return _capability_digest(
-        {"executables": _verification_executable_payload(executables)}
-    )
 
 
 def _verification_environment_digest_from_records(
@@ -2207,13 +2191,6 @@ def _is_broad_exploration_tokens(tokens: list[str]) -> bool:
             targets = remainder[remainder.index("--") + 1 :]
             return _targets_repository_root(targets)
     return False
-
-
-def _is_broad_exploration_command(command: str) -> bool:
-    segments = _shell_segments(command)
-    return bool(segments) and any(
-        _is_broad_exploration_tokens(segment) for segment in segments
-    )
 
 
 def _capability_digest(request: dict[str, Any]) -> str:

--- a/hooks/click_gate.py
+++ b/hooks/click_gate.py
@@ -164,8 +164,6 @@ DEEP_VERIFICATION_MARKERS = {
 }
 MAX_INSPECTION_COMMANDS = 8
 MAX_ARGV_ITEMS = 128
-MAX_CAPABILITY_REQUEST_CHARS = 6_000
-MAX_VERIFICATION_BATCH_CHARS = 6_000
 MAX_OBSERVATION_OUTPUT_BYTES = 48_000
 MAX_OBSERVATION_ENTRIES = 64
 MAX_BROWSER_UNIQUE_INPUTS = 256
@@ -1013,11 +1011,8 @@ def _decode_capability_request(
     raw: str,
     label: str,
     *,
-    limit: int = MAX_CAPABILITY_REQUEST_CHARS,
     version: int = CAPABILITY_PROTOCOL_VERSION,
 ) -> tuple[dict[str, Any] | None, str]:
-    if len(raw) > limit:
-        return None, f"{label} request must stay under {limit:,} characters."
     try:
         value = json.loads(raw)
     except json.JSONDecodeError:
@@ -1208,7 +1203,6 @@ def _validate_verification_batch(
     value, error = _decode_capability_request(
         raw,
         "Verification batch",
-        limit=MAX_VERIFICATION_BATCH_CHARS,
         version=VERIFICATION_PROTOCOL_VERSION,
     )
     if error:

--- a/tests/repository_policy_core.py
+++ b/tests/repository_policy_core.py
@@ -276,7 +276,7 @@ class RepositoryPolicyTests(unittest.TestCase):
         self.assertIn("workflow_dispatch:", workflow)
         self.assertTrue((ROOT / "scripts" / "validate_distribution.py").is_file())
 
-    def test_release_documents_identify_v0245_and_preserve_release_history(self) -> None:
+    def test_release_documents_identify_current_and_preserve_release_history(self) -> None:
         for readme_name in README_NAMES:
             with self.subTest(readme=readme_name):
                 readme = (ROOT / readme_name).read_text(encoding="utf-8")
@@ -288,7 +288,7 @@ class RepositoryPolicyTests(unittest.TestCase):
                 self.assertIn("v0.23.0", readme)
                 self.assertIn("v0.21.0", readme)
         notes = (ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8")
-        self.assertIn("## Unreleased v0.25 candidate", notes)
+        self.assertIn("## v0.30.0", notes)
         self.assertIn("## v0.24.5", notes)
         self.assertIn("## v0.24.4", notes)
         self.assertIn("## v0.24.3", notes)
@@ -420,7 +420,7 @@ class RepositoryPolicyTests(unittest.TestCase):
         self.assertIn("do not produce runtime advice", classification)
         self.assertIn("## Operational limits requiring disposition", classification)
         self.assertIn("## Migration order", classification)
-        self.assertIn("Complete in the v0.25 candidate", classification)
+        self.assertIn("Complete in v0.30.0", classification)
         self.assertIn("fresh, separately authorized retries", classification)
         self.assertIn("verification-time mutation", classification)
         self.assertIn("hooks/click_verification_policy.py", classification)

--- a/tests/test_click_contract.py
+++ b/tests/test_click_contract.py
@@ -89,11 +89,6 @@ class ClickContractTests(unittest.TestCase):
         for name, expected in aliases.items():
             with self.subTest(name=name):
                 self.assertIs(getattr(click_gate, name), expected)
-        self.assertEqual(
-            click_gate.MAX_CONTRACT_CHARS,
-            click_contract.MAX_CONTRACT_CHARS,
-        )
-
     def test_valid_contract_is_returned_without_normalization(self) -> None:
         full = copy.deepcopy(self.contract)
         full["build"]["semantics"] = ["preserve errors"]
@@ -148,11 +143,6 @@ class ClickContractTests(unittest.TestCase):
         )
 
         cases = (
-            (
-                "oversized",
-                "x" * (click_contract.MAX_CONTRACT_CHARS + 1),
-                "Execution Contract is too large; keep it compact and under 4,000 characters.",
-            ),
             ("invalid json", "{", "Execution Contract must be valid JSON."),
             ("not object", "[]", "Execution Contract must be a JSON object."),
             (
@@ -212,6 +202,17 @@ class ClickContractTests(unittest.TestCase):
                     click_contract.validate_contract(raw),
                     (None, expected),
                 )
+
+    def test_valid_contract_is_not_rejected_by_prose_length(self) -> None:
+        contract = copy.deepcopy(self.contract)
+        contract["plain_language"] = "계약의 의미를 충분히 설명합니다. " * 300
+
+        value, error = click_contract.validate_contract(
+            json.dumps(contract, ensure_ascii=False)
+        )
+
+        self.assertEqual(error, "")
+        self.assertEqual(value, contract)
 
     def test_profile_recommendation_does_not_limit_argv_source_count(self) -> None:
         contract = copy.deepcopy(self.contract)

--- a/tests/test_click_gate_contract.py
+++ b/tests/test_click_gate_contract.py
@@ -602,14 +602,14 @@ class ClickGateContractTests(ClickGateTestCase):
         self.assertEqual(output["permissionDecision"], "deny")
         self.assertIn("surprise_scope", output["permissionDecisionReason"])
 
-    def test_contract_size_is_capped_to_prevent_planning_bloat(self) -> None:
+    def test_contract_prose_length_does_not_control_staging_authority(self) -> None:
         contract = self.contract()
         contract["outcome"] = "x" * 4_000
-        command = f"click-gate stage {shlex.quote(json.dumps(contract))}"
-        payload = self.pre_tool("Bash", command)
+        self.arm_gate("turn-large-contract")
+        payload = self.stage_gate(contract, "turn-large-contract")
         output = payload["hookSpecificOutput"]
-        self.assertEqual(output["permissionDecision"], "deny")
-        self.assertIn("4,000", output["permissionDecisionReason"])
+        self.assertEqual(output["permissionDecision"], "allow")
+        self.assertNotIn("4,000", output.get("permissionDecisionReason", ""))
 
     def test_legacy_verbose_contract_fields_are_rejected(self) -> None:
         for field in (

--- a/tests/test_click_gate_inspection.py
+++ b/tests/test_click_gate_inspection.py
@@ -927,6 +927,20 @@ class ClickGateInspectionTests(ClickGateTestCase):
         self.assertEqual(denied["hookSpecificOutput"]["permissionDecision"], "deny")
         self.assertIn("version", denied["hookSpecificOutput"]["permissionDecisionReason"])
 
+    def test_inspection_request_retains_the_eight_command_operational_cap(self) -> None:
+        request, broad, error = CLICK_GATE._validate_inspection_request(
+            json.dumps(
+                {
+                    "version": 1,
+                    "commands": [["git", "status", "--short"] for _ in range(9)],
+                }
+            )
+        )
+
+        self.assertIsNone(request)
+        self.assertFalse(broad)
+        self.assertEqual(error, "Inspection may contain at most 8 commands.")
+
     def test_shell_chaining_is_not_treated_as_read_only(self) -> None:
         self.arm_gate()
         for command in (

--- a/tests/test_click_gate_verification.py
+++ b/tests/test_click_gate_verification.py
@@ -40,6 +40,31 @@ class ClickGateVerificationTests(ClickGateTestCase):
         assert batch is not None
         self.assertEqual(len(batch["checks"]), 9)
 
+    def test_verification_batch_has_no_arbitrary_character_cap(self) -> None:
+        raw = json.dumps(
+            {
+                "version": 2,
+                "checks": [
+                    {
+                        "argv": [
+                            "git",
+                            "diff",
+                            "--check",
+                            "--",
+                            "x" * 6_500,
+                        ],
+                        "class": "targeted",
+                    }
+                ],
+            }
+        )
+        self.assertGreater(len(raw), 6_000)
+
+        batch, _, error = CLICK_GATE._validate_verification_batch(raw, "focused")
+
+        self.assertEqual(error, "")
+        self.assertIsNotNone(batch)
+
     def test_quick_profile_does_not_control_verification_authority(self) -> None:
         contract = self.contract()
         contract["verification"]["scale"] = "quick"

--- a/tests/test_click_gate_verification.py
+++ b/tests/test_click_gate_verification.py
@@ -21,6 +21,25 @@ from click_gate_test_support import (
 
 
 class ClickGateVerificationTests(ClickGateTestCase):
+    def test_verification_batch_has_no_fixed_check_count_cap(self) -> None:
+        checks = [
+            {
+                "argv": ["git", "diff", "--check"],
+                "class": "targeted",
+            }
+            for _ in range(9)
+        ]
+
+        batch, _, error = CLICK_GATE._validate_verification_batch(
+            json.dumps({"version": 2, "checks": checks}),
+            "focused",
+        )
+
+        self.assertEqual(error, "")
+        self.assertIsNotNone(batch)
+        assert batch is not None
+        self.assertEqual(len(batch["checks"]), 9)
+
     def test_quick_profile_does_not_control_verification_authority(self) -> None:
         contract = self.contract()
         contract["verification"]["scale"] = "quick"

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -26,7 +26,7 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
             (ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
         )
         self.assertEqual(manifest["name"], "click")
-        self.assertEqual(manifest["version"], "0.24.6")
+        self.assertEqual(manifest["version"], "0.30.0")
         self.assertEqual(manifest["license"], "MIT")
         self.assertIn("always on", manifest["description"].lower())
         self.assertIn("manual", manifest["description"].lower())
@@ -94,7 +94,7 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
         self.assertEqual(marketplace["name"], "click")
         self.assertEqual(marketplace["plugins"][0]["name"], "click")
         self.assertEqual(
-            marketplace["plugins"][0]["source"]["ref"], "v0.24.6"
+            marketplace["plugins"][0]["source"]["ref"], "v0.30.0"
         )
 
     def test_readmes_lead_with_hook_enforced_state_machine_positioning(self) -> None:
@@ -217,14 +217,14 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
         for marker in ("shell=False", "process group", "process-control", "pkill"):
             self.assertIn(marker, protocol)
 
-    def test_release_documents_identify_v0245_and_preserve_release_history(self) -> None:
+    def test_release_documents_identify_current_and_preserve_release_history(self) -> None:
         for readme in _readmes().values():
-            self.assertIn("v0.24.6", readme)
+            self.assertIn("v0.30.0", readme)
             self.assertIn("codex plugin marketplace upgrade click", readme)
             self.assertIn("codex plugin add click@click", readme)
         notes = (ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8")
         for marker in (
-            "## Unreleased v0.25 candidate",
+            "## v0.30.0",
             "## v0.24.6",
             "## v0.24.5",
             "## v0.24.4",


### PR DESCRIPTION
## Summary
- remove the heuristic 4,000-character contract gate, fixed eight-check verification cap, and arbitrary 6,000-character capability JSON cap
- retain observable execution safeguards, including exact receipt binding, decoded transport bounds, the host-imposed Windows command-line ceiling, and the eight-command inspection runner boundary
- delete two unused gate helpers and synchronize the Antigravity distribution
- publish the cumulative post-v0.24.6 authorization/evidence changes as v0.30.0 metadata

## Evidence cache boundary
- current exact receipt reuse remains unchanged
- dependency-aware cross-revision caching is deliberately deferred to a separate invalidation design backed by repository-owned dependency data

## Verification
- `python3 -m unittest discover -s tests -q` — 331 passed, 3 skipped
- `python3 scripts/validate_distribution.py`
- Codex plugin validator
- Click and Fix Skill validators
- `python3 -m compileall -q hooks scripts tests`
- `git diff --check`

## Release-note audit
The 900/350-word policy removal remains in these notes because it landed after v0.24.6 and has not previously shipped in a stable release.