### PR TITLE
Refactor managed service runtime boundary

### DIFF
--- a/GUARD_CLASSIFICATION.md
+++ b/GUARD_CLASSIFICATION.md
@@ -14,8 +14,8 @@ not claim that every hard gate has already been moved to its target layer.
 | Guard or invariant | Current owner | Why it remains Core |
 | --- | --- | --- |
 | Canonical contract validation, digest and ID binding, later-turn approval, session and working-directory identity | `hooks/click_contract.py`; approval lifecycle in `hooks/click_gate.py` | Prevents mutation under an unapproved or substituted intent |
-| Mutation and external side-effect authorization | mutation and managed-service prepare/claim/record paths in `hooks/click_gate.py` | Controls observable effects rather than model strategy |
-| Exact one-use runner token, action, request, root and state binding | runner claim paths in `hooks/click_gate.py` | Prevents replay, request substitution and cross-state execution |
+| Mutation and external side-effect authorization | mutation paths in `hooks/click_gate.py`; managed-service prepare/claim/record paths in `hooks/click_service.py` | Controls observable effects rather than model strategy |
+| Exact one-use runner token, action, request, root and state binding | managed-service claims in `hooks/click_service.py`; remaining runner claim paths in `hooks/click_gate.py` | Prevents replay, request substitution and cross-state execution |
 | Canonical state paths, locks, atomic writes and authorized state-root recovery | `hooks/click_state.py` | Preserves approval state across failure without weakening identity checks |
 | Cancellation, expiry, consumed-runner and tampering revocation | `hooks/click_state.py`; lifecycle branches in `hooks/click_gate.py` | Prevents stale authority from becoming executable again |
 | Evidence registry identity, current-revision state and receipt matching | `hooks/click_evidence.py`; verification claim/result paths in `hooks/click_gate.py` | Prevents evidence from a different request or revision from completing work |
@@ -23,7 +23,7 @@ not claim that every hard gate has already been moved to its target layer.
 | Protected Git-tree, environment and executable fingerprints for argv verification; verification-time mutation detection | verification receipt helpers and runners in `hooks/click_gate.py` | Preserves the identity of the code and environment actually checked by Click's argv runner |
 | Opt-in dependency provider, relevant-entry and resolved-path receipts, plus approved mutation pre/post binding | `hooks/click_dependency_cache.py`; mutation-boundary and receipt transitions in `hooks/click_gate.py` | Allows cross-revision reuse without treating a model's post-approval assertion, unrelated manifest content, or later workspace drift as proof |
 | Direct-argv capability safety, executable/path/environment checks, process-control rejection and read-only side-effect defenses | capability constants and validators in `hooks/click_gate.py` | Prevents an admitted inspect, verify or service request from gaining unapproved effects |
-| Mutation, verification and managed-service interlocks around active runner claims | runner reservation and claim state in `hooks/click_gate.py` | Prevents an authorized side effect or receipt from racing into a different state without treating distinct observation concurrency as authority |
+| Mutation, verification and managed-service interlocks around active runner claims | managed-service reservation and claim state in `hooks/click_service.py`; remaining runner state in `hooks/click_gate.py` | Prevents an authorized side effect or receipt from racing into a different state without treating distinct observation concurrency as authority |
 | Host coverage identity, event normalization and state/receipt-preserving result mapping | `hooks/click_host_coverage.py`, `hooks/click_hook.py`, `hooks/antigravity_gate.py`, `hooks/platform_protocol.py` | Keeps the known pre/post surface symmetric and prevents verification receipts from crossing a host or coverage-registry revision while making the limited assurance explicit |
 
 ## USER_POLICY

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,18 @@
 # Release notes
 
+## Unreleased v0.33 candidate — runtime domain boundaries
+
+- Managed local-service validation, admission, one-use start and supervisor
+  claims, stop polling, process ownership, and exact state updates now live in
+  the standard-library-only `click_service.py` runtime domain.
+- `click_gate.py` retains event routing and the existing compatibility surface,
+  while supplying the cross-domain contract-mutation transition required before
+  service start. The service domain imports only the lower `click_state.py` and
+  `click_process.py` leaves.
+- Service request schema, error text, runner argv transport, digest and
+  constant-time token bindings, timeout behavior, and public/private compatibility
+  symbols remain unchanged. Antigravity bundles the same extracted runtime.
+
 ## v0.32.0 — 2026-09-01
 
 - Codex and Antigravity now derive their known mutation, plan, Browser, and

--- a/dist/antigravity/hooks/click_gate.py
+++ b/dist/antigravity/hooks/click_gate.py
@@ -39,6 +39,7 @@ if __package__:
         click_evidence,
         click_host_coverage,
         click_process,
+        click_service,
         click_verification_meter,
         click_verification_policy,
     )
@@ -65,6 +66,7 @@ else:  # Executed directly from the bundled hooks directory.
     import click_evidence
     import click_host_coverage
     import click_process
+    import click_service
     import click_verification_meter
     import click_verification_policy
     from click_state import (
@@ -107,6 +109,16 @@ _fresh_external_evidence_state = click_evidence.fresh_external_state
 # schema validation now lives in the one-way click_contract boundary.
 _validate_contract = click_contract.validate_contract
 
+# Compatibility aliases for direct callers and the deterministic suite. The
+# managed local-service state machine and runner lifecycle live in the one-way
+# click_service boundary; gate wrappers below provide only cross-domain routing.
+_fresh_service_state = click_service.fresh_state
+_looks_like_managed_service = click_service.looks_like_managed_service
+_request_service_stop = click_service.request_stop
+_service_snapshot = click_service.service_snapshot
+_record_service_fields = click_service.record_service_fields
+_claim_service_runner = click_service.claim_service_runner
+
 
 CONTROL_COMMAND = "click-gate"
 CLICK_AUTHORIZATION_PATTERNS = (
@@ -135,7 +147,7 @@ VERIFICATION_PROTOCOL_VERSION = 2
 CONTRACT_STATE_SCHEMA_VERSION = 2
 INSPECTION_REQUEST_FIELDS = {"version", "commands"}
 MUTATION_REQUEST_FIELDS = {"version", "argv"}
-SERVICE_REQUEST_FIELDS = {"version", "action", "argv"}
+SERVICE_REQUEST_FIELDS = click_service.SERVICE_REQUEST_FIELDS
 VERIFICATION_BATCH_FIELDS = {"version", "checks"}
 VERIFICATION_CHECK_FIELDS = {"evidence_id", "argv", "class"}
 EVIDENCE_RESULT_FIELDS = {"version", "evidence_id"}
@@ -216,27 +228,12 @@ PROCESS_CONTROL_EXECUTABLES = {
 
 BROWSER_TOOL_NAMES = click_host_coverage.CODEX_BROWSER_TOOL_NAMES
 BROWSER_WAIT_PATTERNS = click_browser_advisory.BROWSER_WAIT_PATTERNS
-MANAGED_SERVICE_EXECUTABLES = {
-    "flask",
-    "gunicorn",
-    "http-server",
-    "next",
-    "serve",
-    "uvicorn",
-    "vite",
-    "webpack-dev-server",
-}
-MANAGED_SERVICE_ACTIONS = {"start", "stop"}
-MANAGED_SERVICE_SCRIPT_MARKERS = {
-    "dev",
-    "preview",
-    "runserver",
-    "serve",
-    "start",
-}
-SERVICE_START_TIMEOUT_SECONDS = 8
-SERVICE_STOP_TIMEOUT_SECONDS = 8
-MANAGED_SERVICE_MAX_SECONDS = 2 * 60 * 60
+MANAGED_SERVICE_EXECUTABLES = click_service.MANAGED_SERVICE_EXECUTABLES
+MANAGED_SERVICE_ACTIONS = click_service.MANAGED_SERVICE_ACTIONS
+MANAGED_SERVICE_SCRIPT_MARKERS = click_service.MANAGED_SERVICE_SCRIPT_MARKERS
+SERVICE_START_TIMEOUT_SECONDS = click_service.SERVICE_START_TIMEOUT_SECONDS
+SERVICE_STOP_TIMEOUT_SECONDS = click_service.SERVICE_STOP_TIMEOUT_SECONDS
+MANAGED_SERVICE_MAX_SECONDS = click_service.MANAGED_SERVICE_MAX_SECONDS
 
 VERIFICATION_EXECUTABLES = {
     "bandit",
@@ -634,22 +631,6 @@ def _evidence_sources(state: dict[str, Any]) -> dict[str, Any] | None:
         state,
         expected_contract_schema_version=CONTRACT_STATE_SCHEMA_VERSION,
     )
-
-
-def _fresh_service_state() -> dict[str, Any]:
-    return {
-        "status": "idle",
-        "service_id": "",
-        "request_digest": "",
-        "runner_token_digest": "",
-        "runner_claimed_at": 0,
-        "supervisor_claimed_at": 0,
-        "stop_requested": False,
-        "supervisor_pid": 0,
-        "child_pid": 0,
-        "started_at": 0,
-        "last_exit_code": None,
-    }
 
 
 def _fresh_observation_state() -> dict[str, Any]:
@@ -1153,38 +1134,6 @@ def _policy_executable_name(value: str) -> str:
     return executable
 
 
-def _looks_like_managed_service(argv: list[str]) -> bool:
-    executable = Path(argv[0]).name.lower()
-    if executable.endswith(".exe"):
-        executable = executable[:-4]
-    arguments = [argument.lower() for argument in argv[1:]]
-    if executable in MANAGED_SERVICE_EXECUTABLES:
-        return True
-    if executable == "py" or re.fullmatch(r"(?:python|pypy)\d*(?:\.\d+)?", executable):
-        if executable == "py" and arguments and re.fullmatch(
-            r"-\d+(?:\.\d+)?(?:-\d+)?", arguments[0]
-        ):
-            arguments = arguments[1:]
-        if len(arguments) >= 2 and arguments[:2] == ["-m", "http.server"]:
-            return True
-        return any(marker in arguments for marker in {"runserver"})
-    if executable in {"npm", "pnpm", "yarn", "bun"}:
-        meaningful = {
-            argument
-            for argument in arguments
-            if argument not in {"run", "exec", "x", "--"}
-            and not argument.startswith("-")
-        }
-        return bool(meaningful & MANAGED_SERVICE_SCRIPT_MARKERS)
-    if executable in {"npx", "pnpx", "bunx"}:
-        return any(
-            Path(argument).name.lower() in MANAGED_SERVICE_EXECUTABLES
-            for argument in arguments
-            if not argument.startswith("-")
-        )
-    return any(marker in arguments for marker in {"runserver"})
-
-
 def _validate_inspection_request(
     raw: str,
 ) -> tuple[dict[str, Any] | None, bool, str]:
@@ -1246,37 +1195,11 @@ def _validate_mutation_request(raw: str) -> tuple[dict[str, Any] | None, str]:
 
 
 def _validate_service_request(raw: str) -> tuple[dict[str, Any] | None, str]:
-    value, error = _decode_capability_request(raw, "Managed service")
-    if error:
-        return None, error
-    assert value is not None
-    unknown = sorted(set(value) - SERVICE_REQUEST_FIELDS)
-    if unknown:
-        rendered = ", ".join(f"`{field}`" for field in unknown)
-        return None, f"Managed service request contains unsupported field(s): {rendered}."
-    action = value.get("action")
-    if action not in MANAGED_SERVICE_ACTIONS:
-        allowed = ", ".join(sorted(MANAGED_SERVICE_ACTIONS))
-        return None, f"Managed service `action` must be one of: {allowed}."
-    if action == "stop":
-        if "argv" in value:
-            return None, "Managed service stop must omit `argv`."
-        return {"version": CAPABILITY_PROTOCOL_VERSION, "action": "stop"}, ""
-    argv, argv_error = _validate_argv(value.get("argv"), "Managed service")
-    if argv_error:
-        return None, argv_error
-    assert argv is not None
-    if not _looks_like_managed_service(argv):
-        return (
-            None,
-            "Managed service start accepts a recognizable local development server, "
-            "not an arbitrary detached command.",
-        )
-    return {
-        "version": CAPABILITY_PROTOCOL_VERSION,
-        "action": "start",
-        "argv": argv,
-    }, ""
+    return click_service.validate_request(
+        raw,
+        validate_argv=_validate_argv,
+        protocol_version=CAPABILITY_PROTOCOL_VERSION,
+    )
 
 
 def _validate_verification_batch(
@@ -2773,97 +2696,26 @@ def _service_runner_command(
     service_id: str,
     runner_token: str = "",
 ) -> str:
-    arguments = [
-        *_stateful_runner_prefix(
-            "run-service-start" if request["action"] == "start" else "run-service-stop"
-        ),
-        str(_contract_path(event).resolve()),
+    return click_service.service_runner_command(
+        event,
+        request,
         service_id,
-    ]
-    if request["action"] == "start":
-        arguments.extend(
-            [
-                runner_token,
-                str(Path(str(event.get("cwd", ""))).resolve()),
-                _encoded_request(request),
-            ]
-        )
-    return _runner_shell_command(arguments)
-
-
-def _request_service_stop(event: dict[str, Any]) -> bool:
-    state = _read_contract_state(event)
-    service = state.get("service")
-    if not isinstance(service, dict) or service.get("status") not in {
-        "starting",
-        "launching",
-        "running",
-        "stopping",
-    }:
-        return False
-    service["status"] = "stopping"
-    service["stop_requested"] = True
-    state["service"] = service
-    _save_contract_state(event, state)
-    return True
+        runner_token=runner_token,
+        runner_script=Path(__file__).resolve(),
+        render_command=_runner_shell_command,
+    )
 
 
 def _prepare_service(event: dict[str, Any], raw: str) -> tuple[str, str]:
-    request, error = _validate_service_request(raw)
-    if error:
-        return "", error
-    assert request is not None
-    state = _read_contract_state(event)
-    if state.get("status") != "approved":
-        return "", "Approve the staged Click execution contract before managing a service."
-    service = state.get("service")
-    if not isinstance(service, dict):
-        service = _fresh_service_state()
-    if request["action"] == "stop":
-        if service.get("status") not in {
-            "starting",
-            "launching",
-            "running",
-            "stopping",
-        }:
-            return "echo Click managed service already stopped", ""
-        service["status"] = "stopping"
-        service["stop_requested"] = True
-        state["service"] = service
-        _save_contract_state(event, state)
-        return _service_runner_command(event, request, str(service["service_id"])), ""
-
-    if service.get("status") in {"starting", "launching", "running", "stopping"}:
-        started_at = int(service.get("started_at", 0))
-        if not (
-            service.get("status") == "starting"
-            and started_at
-            and time.time() - started_at > SERVICE_START_TIMEOUT_SECONDS * 2
-        ):
-            return "", "One Click-managed local service is already active. Stop it first."
-    mutation_error = _mark_contract_mutated(event)
-    if mutation_error:
-        return "", mutation_error
-    state = _read_contract_state(event)
-    service_id = secrets.token_urlsafe(24)
-    runner_token = secrets.token_urlsafe(24)
-    cwd_raw = str(Path(str(event.get("cwd", ""))).resolve())
-    request_digest = _capability_digest({"request": request, "cwd": cwd_raw})
-    state["service"] = {
-        "status": "starting",
-        "service_id": service_id,
-        "request_digest": request_digest,
-        "runner_token_digest": hashlib.sha256(runner_token.encode()).hexdigest(),
-        "runner_claimed_at": 0,
-        "supervisor_claimed_at": 0,
-        "stop_requested": False,
-        "supervisor_pid": 0,
-        "child_pid": 0,
-        "started_at": int(time.time()),
-        "last_exit_code": None,
-    }
-    _save_contract_state(event, state)
-    return _service_runner_command(event, request, service_id, runner_token), ""
+    return click_service.prepare_service(
+        event,
+        raw,
+        validate_argv=_validate_argv,
+        protocol_version=CAPABILITY_PROTOCOL_VERSION,
+        mark_contract_mutated=_mark_contract_mutated,
+        runner_script=Path(__file__).resolve(),
+        render_command=_runner_shell_command,
+    )
 
 
 def _verification_runner_command(
@@ -5703,323 +5555,29 @@ def _managed_observation_path(path: Path) -> bool:
     return _managed_state_path(path, ("session-contract-", "review-"))
 
 
-def _service_snapshot(path: Path, service_id: str) -> dict[str, Any] | None:
-    if not _managed_contract_path(path):
-        return None
-    state: Any = None
-    for attempt in range(5):
-        try:
-            state = json.loads(path.read_text(encoding="utf-8"))
-            break
-        except PermissionError:
-            # Windows may briefly deny a reader while another process replaces
-            # the state file. Do not mistake that sharing collision for a
-            # missing or stopped managed service.
-            if attempt == 4:
-                return None
-            time.sleep(0.02)
-        except (FileNotFoundError, json.JSONDecodeError, OSError):
-            return None
-    if not isinstance(state, dict) or state.get("status") != "approved":
-        return None
-    service = state.get("service")
-    if not isinstance(service, dict) or service.get("service_id") != service_id:
-        return None
-    return dict(service)
-
-
-def _record_service_fields(
-    path: Path,
-    service_id: str,
-    *,
-    expected_statuses: tuple[str, ...] | None = None,
-    **fields: Any,
-) -> bool:
-    if not _managed_contract_path(path):
-        return False
-    try:
-        state = json.loads(path.read_text(encoding="utf-8"))
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
-        return False
-    if not isinstance(state, dict) or state.get("status") != "approved":
-        return False
-    service = state.get("service")
-    if not isinstance(service, dict) or service.get("service_id") != service_id:
-        return False
-    if expected_statuses is not None and service.get("status") not in expected_statuses:
-        return False
-    service.update(fields)
-    state["service"] = service
-    state["updated_at"] = int(time.time())
-    _write_json(path, state)
-    return True
-
-
-def _claim_service_runner(
-    path: Path,
-    service_id: str,
-    request: dict[str, Any],
-    cwd_raw: str,
-    runner_token: str,
-    *,
-    supervisor: bool,
-) -> str:
-    if not _managed_contract_path(path):
-        return "Click managed service runner received an unmanaged state path."
-    try:
-        state = json.loads(path.read_text(encoding="utf-8"))
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
-        return "Click managed service runner could not read its contract state."
-    if not isinstance(state, dict) or state.get("status") != "approved":
-        return "Click managed service runner is no longer authorized to execute."
-    service = state.get("service")
-    expected_status = "launching" if supervisor else "starting"
-    if (
-        not isinstance(service, dict)
-        or service.get("service_id") != service_id
-        or service.get("status") != expected_status
-        or service.get("stop_requested") is True
-    ):
-        return "Click managed service runner is no longer authorized to execute."
-    request_digest = _capability_digest({"request": request, "cwd": cwd_raw})
-    if service.get("request_digest") != request_digest:
-        return "Click managed service runner request digest did not match active state."
-    token_digest = hashlib.sha256(runner_token.encode()).hexdigest()
-    if not secrets.compare_digest(
-        str(service.get("runner_token_digest", "")), token_digest
-    ):
-        return "Click managed service runner token did not match active state."
-    runner_claimed_at = service.get("runner_claimed_at", 0)
-    supervisor_claimed_at = service.get("supervisor_claimed_at", 0)
-    for claimed_at in (runner_claimed_at, supervisor_claimed_at):
-        if not isinstance(claimed_at, int) or isinstance(claimed_at, bool):
-            return "Click managed service runner claim state is malformed."
-    if supervisor:
-        if runner_claimed_at <= 0 or supervisor_claimed_at > 0:
-            return "Click managed service supervisor was already claimed or not launched."
-        if not _unclaimed_reservation_is_fresh(
-            runner_claimed_at, SERVICE_START_TIMEOUT_SECONDS * 2
-        ):
-            return "Click managed service supervisor authorization expired before launch."
-        service["supervisor_claimed_at"] = int(time.time()) or 1
-    else:
-        if runner_claimed_at > 0 or supervisor_claimed_at > 0:
-            return "Click managed service start runner was already claimed."
-        if not _unclaimed_reservation_is_fresh(
-            service.get("started_at", 0), SERVICE_START_TIMEOUT_SECONDS * 2
-        ):
-            return "Click managed service start authorization expired before launch."
-        service["runner_claimed_at"] = int(time.time()) or 1
-        service["status"] = "launching"
-    state["service"] = service
-    state["updated_at"] = int(time.time())
-    _write_json(path, state)
-    return ""
-
-
 def _run_service_supervisor(arguments: list[str]) -> int:
-    if len(arguments) != 5:
-        return 2
-    state_path = Path(arguments[0])
-    service_id, runner_token, cwd_raw, encoded = arguments[1:]
-    raw, error = _decode_encoded_request(encoded, "managed service")
-    if error:
-        return 2
-    request, error = _validate_service_request(raw)
-    if error or request is None or request.get("action") != "start":
-        return 2
-    with _state_lock():
-        claim_error = _claim_service_runner(
-            state_path,
-            service_id,
-            request,
-            cwd_raw,
-            runner_token,
-            supervisor=True,
-        )
-    if claim_error:
-        return 2
-    cwd = Path(cwd_raw)
-    if not cwd.is_dir():
-        with _state_lock():
-            _record_service_fields(
-                state_path,
-                service_id,
-                expected_statuses=("launching",),
-                status="failed",
-                last_exit_code=2,
-            )
-        return 2
-    try:
-        child = click_process.spawn_argv(
-            _execution_argv(request["argv"]),
-            cwd=cwd,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            close_fds=True,
-        )
-    except OSError:
-        with _state_lock():
-            _record_service_fields(
-                state_path,
-                service_id,
-                expected_statuses=("launching",),
-                status="failed",
-                last_exit_code=127,
-                stop_requested=False,
-            )
-        return 127
-
-    time.sleep(0.2)
-    early_exit = child.poll()
-    with _state_lock():
-        recorded = _record_service_fields(
-            state_path,
-            service_id,
-            expected_statuses=("launching",),
-            status="failed" if early_exit is not None else "running",
-            supervisor_pid=os.getpid(),
-            child_pid=child.pid,
-            last_exit_code=int(early_exit) if early_exit is not None else None,
-        )
-    if early_exit is not None or not recorded:
-        if early_exit is None:
-            _terminate_managed_child(child)
-        return int(early_exit or 2)
-
-    started = time.monotonic()
-    stop_requested = False
-    while True:
-        exit_code = child.poll()
-        if exit_code is not None:
-            break
-        snapshot = _service_snapshot(state_path, service_id)
-        if snapshot is None or snapshot.get("stop_requested") is True:
-            stop_requested = True
-            exit_code = _terminate_managed_child(child)
-            break
-        if time.monotonic() - started >= MANAGED_SERVICE_MAX_SECONDS:
-            stop_requested = True
-            exit_code = _terminate_managed_child(child)
-            break
-        time.sleep(0.2)
-
-    with _state_lock():
-        _record_service_fields(
-            state_path,
-            service_id,
-            expected_statuses=("running", "stopping", "launching"),
-            status="stopped" if stop_requested else "failed",
-            stop_requested=False,
-            child_pid=0,
-            supervisor_pid=0,
-            last_exit_code=int(exit_code or 0),
-        )
-    return int(exit_code or 0)
+    return click_service.run_service_supervisor(
+        arguments,
+        validate_argv=_validate_argv,
+        protocol_version=CAPABILITY_PROTOCOL_VERSION,
+        execution_argv=_execution_argv,
+    )
 
 
 def _run_service_start(arguments: list[str]) -> int:
-    if len(arguments) != 5:
-        sys.stderr.write(
-            "usage: click_gate.py run-service-start "
-            "<state> <id> <token> <cwd> <request>\n"
-        )
-        return 2
-    state_path = Path(arguments[0])
-    service_id, runner_token, cwd_raw, encoded = arguments[1:]
-    raw, error = _decode_encoded_request(encoded, "managed service")
-    if error:
-        sys.stderr.write(f"{error}\n")
-        return 2
-    request, error = _validate_service_request(raw)
-    if error or request is None or request.get("action") != "start":
-        sys.stderr.write(f"{error or 'Managed service start request is invalid.'}\n")
-        return 2
-    with _state_lock():
-        claim_error = _claim_service_runner(
-            state_path,
-            service_id,
-            request,
-            cwd_raw,
-            runner_token,
-            supervisor=False,
-        )
-    if claim_error:
-        sys.stderr.write(f"{claim_error}\n")
-        return 2
-    supervisor = [
-        *_stateful_runner_prefix("run-service-supervisor"),
-        str(state_path.resolve()),
-        service_id,
-        runner_token,
-        cwd_raw,
-        encoded,
-    ]
-    try:
-        click_process.spawn_argv(
-            supervisor,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            close_fds=True,
-        )
-    except OSError as exc:
-        with _state_lock():
-            _record_service_fields(
-                state_path,
-                service_id,
-                expected_statuses=("launching",),
-                status="failed",
-                last_exit_code=127,
-            )
-        sys.stderr.write(f"Click could not start the managed service supervisor: {exc}\n")
-        return 127
-    deadline = time.monotonic() + SERVICE_START_TIMEOUT_SECONDS
-    while time.monotonic() < deadline:
-        snapshot = _service_snapshot(state_path, service_id)
-        if snapshot is None:
-            return 2
-        if snapshot.get("status") == "running":
-            sys.stdout.write("Click managed service started\n")
-            return 0
-        if snapshot.get("status") == "failed":
-            sys.stderr.write("Click managed service exited during startup.\n")
-            return int(snapshot.get("last_exit_code") or 2)
-        if snapshot.get("status") in {"stopping", "stopped"}:
-            return 2
-        time.sleep(0.05)
-    with _state_lock():
-        _record_service_fields(
-            state_path,
-            service_id,
-            expected_statuses=("launching", "starting"),
-            status="stopping",
-            stop_requested=True,
-        )
-    sys.stderr.write("Click managed service did not start within its bounded timeout.\n")
-    return 2
+    return click_service.run_service_start(
+        arguments,
+        validate_argv=_validate_argv,
+        protocol_version=CAPABILITY_PROTOCOL_VERSION,
+        runner_script=Path(__file__).resolve(),
+    )
 
 
 def _run_service_stop(arguments: list[str]) -> int:
-    if len(arguments) != 2:
-        sys.stderr.write("usage: click_gate.py run-service-stop <state> <id>\n")
-        return 2
-    state_path = Path(arguments[0])
-    service_id = arguments[1]
-    deadline = time.monotonic() + SERVICE_STOP_TIMEOUT_SECONDS
-    while time.monotonic() < deadline:
-        snapshot = _service_snapshot(state_path, service_id)
-        if snapshot is not None and snapshot.get("status") in {
-            "failed",
-            "idle",
-            "stopped",
-        }:
-            sys.stdout.write("Click managed service stopped\n")
-            return 0
-        time.sleep(0.05)
-    sys.stderr.write("Click managed service did not stop within its bounded timeout.\n")
-    return 2
+    return click_service.run_service_stop(
+        arguments,
+        snapshot_reader=_service_snapshot,
+    )
 
 
 def _git_capture(cwd: Path, arguments: list[str]) -> bytes | None:

--- a/dist/antigravity/hooks/click_service.py
+++ b/dist/antigravity/hooks/click_service.py
@@ -1,0 +1,698 @@
+#!/usr/bin/env python3
+"""Managed local-service admission, state, and runner lifecycle for Click.
+
+This module owns only the recognizable development-service capability. It may
+depend on the state and shell-free process leaves, but it must not import the
+gate, contract lifecycle, evidence, observation, Browser, or verification
+layers. The caller supplies the one cross-domain transition that marks an
+approved contract mutated before a service starts.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Callable
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+import subprocess
+import sys
+import time
+from typing import Any
+
+if __package__:
+    from . import click_process, click_state
+else:  # Executed from the bundled hooks directory.
+    import click_process
+    import click_state
+
+
+SERVICE_REQUEST_FIELDS = {"version", "action", "argv"}
+MANAGED_SERVICE_EXECUTABLES = {
+    "flask",
+    "gunicorn",
+    "http-server",
+    "next",
+    "serve",
+    "uvicorn",
+    "vite",
+    "webpack-dev-server",
+}
+MANAGED_SERVICE_ACTIONS = {"start", "stop"}
+MANAGED_SERVICE_SCRIPT_MARKERS = {
+    "dev",
+    "preview",
+    "runserver",
+    "serve",
+    "start",
+}
+SERVICE_START_TIMEOUT_SECONDS = 8
+SERVICE_STOP_TIMEOUT_SECONDS = 8
+MANAGED_SERVICE_MAX_SECONDS = 2 * 60 * 60
+
+
+ValidateArgv = Callable[[Any, str], tuple[list[str] | None, str]]
+MarkContractMutated = Callable[[dict[str, Any]], str]
+RenderRunnerCommand = Callable[[list[str]], str]
+ExecutionArgv = Callable[[list[str]], list[str]]
+SnapshotReader = Callable[[Path, str], dict[str, Any] | None]
+
+
+def fresh_state() -> dict[str, Any]:
+    return {
+        "status": "idle",
+        "service_id": "",
+        "request_digest": "",
+        "runner_token_digest": "",
+        "runner_claimed_at": 0,
+        "supervisor_claimed_at": 0,
+        "stop_requested": False,
+        "supervisor_pid": 0,
+        "child_pid": 0,
+        "started_at": 0,
+        "last_exit_code": None,
+    }
+
+
+def looks_like_managed_service(argv: list[str]) -> bool:
+    executable = Path(argv[0]).name.lower()
+    if executable.endswith(".exe"):
+        executable = executable[:-4]
+    arguments = [argument.lower() for argument in argv[1:]]
+    if executable in MANAGED_SERVICE_EXECUTABLES:
+        return True
+    if executable == "py" or re.fullmatch(r"(?:python|pypy)\d*(?:\.\d+)?", executable):
+        if executable == "py" and arguments and re.fullmatch(
+            r"-\d+(?:\.\d+)?(?:-\d+)?", arguments[0]
+        ):
+            arguments = arguments[1:]
+        if len(arguments) >= 2 and arguments[:2] == ["-m", "http.server"]:
+            return True
+        return any(marker in arguments for marker in {"runserver"})
+    if executable in {"npm", "pnpm", "yarn", "bun"}:
+        meaningful = {
+            argument
+            for argument in arguments
+            if argument not in {"run", "exec", "x", "--"}
+            and not argument.startswith("-")
+        }
+        return bool(meaningful & MANAGED_SERVICE_SCRIPT_MARKERS)
+    if executable in {"npx", "pnpx", "bunx"}:
+        return any(
+            Path(argument).name.lower() in MANAGED_SERVICE_EXECUTABLES
+            for argument in arguments
+            if not argument.startswith("-")
+        )
+    return any(marker in arguments for marker in {"runserver"})
+
+
+def _decode_request(
+    raw: str, *, protocol_version: int
+) -> tuple[dict[str, Any] | None, str]:
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError:
+        return None, "Managed service request must be valid JSON."
+    if not isinstance(value, dict):
+        return None, "Managed service request must be a JSON object."
+    if value.get("version") != protocol_version:
+        return (
+            None,
+            f"Managed service request `version` must be {protocol_version}.",
+        )
+    return value, ""
+
+
+def validate_request(
+    raw: str,
+    *,
+    validate_argv: ValidateArgv,
+    protocol_version: int,
+) -> tuple[dict[str, Any] | None, str]:
+    value, error = _decode_request(raw, protocol_version=protocol_version)
+    if error:
+        return None, error
+    assert value is not None
+    unknown = sorted(set(value) - SERVICE_REQUEST_FIELDS)
+    if unknown:
+        rendered = ", ".join(f"`{field}`" for field in unknown)
+        return None, f"Managed service request contains unsupported field(s): {rendered}."
+    action = value.get("action")
+    if action not in MANAGED_SERVICE_ACTIONS:
+        allowed = ", ".join(sorted(MANAGED_SERVICE_ACTIONS))
+        return None, f"Managed service `action` must be one of: {allowed}."
+    if action == "stop":
+        if "argv" in value:
+            return None, "Managed service stop must omit `argv`."
+        return {"version": protocol_version, "action": "stop"}, ""
+    argv, argv_error = validate_argv(value.get("argv"), "Managed service")
+    if argv_error:
+        return None, argv_error
+    assert argv is not None
+    if not looks_like_managed_service(argv):
+        return (
+            None,
+            "Managed service start accepts a recognizable local development server, "
+            "not an arbitrary detached command.",
+        )
+    return {
+        "version": protocol_version,
+        "action": "start",
+        "argv": argv,
+    }, ""
+
+
+def _capability_digest(request: dict[str, Any]) -> str:
+    canonical = json.dumps(request, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def _encoded_request(request: dict[str, Any]) -> str:
+    return base64.urlsafe_b64encode(
+        json.dumps(request, ensure_ascii=False, separators=(",", ":")).encode()
+    ).decode()
+
+
+def _decode_encoded_request(encoded: str) -> tuple[str, str]:
+    try:
+        return base64.urlsafe_b64decode(encoded.encode()).decode(), ""
+    except (ValueError, UnicodeDecodeError):
+        return "", "Click managed service runner received an invalid request."
+
+
+def _read_contract_state(event: dict[str, Any]) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            click_state.contract_path(event).read_text(encoding="utf-8")
+        )
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {"status": "none", "contract_digest": ""}
+    return value if isinstance(value, dict) else {"status": "none", "contract_digest": ""}
+
+
+def _save_contract_state(event: dict[str, Any], state: dict[str, Any]) -> None:
+    state["updated_at"] = int(time.time())
+    click_state.write_json(click_state.contract_path(event), state)
+
+
+def _runner_prefix(action: str, runner_script: Path) -> list[str]:
+    return [
+        sys.executable,
+        str(runner_script.resolve()),
+        "--state-root",
+        str(click_state.state_root().resolve()),
+        action,
+    ]
+
+
+def service_runner_command(
+    event: dict[str, Any],
+    request: dict[str, Any],
+    service_id: str,
+    *,
+    runner_script: Path,
+    render_command: RenderRunnerCommand,
+    runner_token: str = "",
+) -> str:
+    arguments = [
+        *_runner_prefix(
+            "run-service-start" if request["action"] == "start" else "run-service-stop",
+            runner_script,
+        ),
+        str(click_state.contract_path(event).resolve()),
+        service_id,
+    ]
+    if request["action"] == "start":
+        arguments.extend(
+            [
+                runner_token,
+                str(Path(str(event.get("cwd", ""))).resolve()),
+                _encoded_request(request),
+            ]
+        )
+    return render_command(arguments)
+
+
+def request_stop(event: dict[str, Any]) -> bool:
+    state = _read_contract_state(event)
+    service = state.get("service")
+    if not isinstance(service, dict) or service.get("status") not in {
+        "starting",
+        "launching",
+        "running",
+        "stopping",
+    }:
+        return False
+    service["status"] = "stopping"
+    service["stop_requested"] = True
+    state["service"] = service
+    _save_contract_state(event, state)
+    return True
+
+
+def prepare_service(
+    event: dict[str, Any],
+    raw: str,
+    *,
+    validate_argv: ValidateArgv,
+    protocol_version: int,
+    mark_contract_mutated: MarkContractMutated,
+    runner_script: Path,
+    render_command: RenderRunnerCommand,
+) -> tuple[str, str]:
+    request, error = validate_request(
+        raw,
+        validate_argv=validate_argv,
+        protocol_version=protocol_version,
+    )
+    if error:
+        return "", error
+    assert request is not None
+    state = _read_contract_state(event)
+    if state.get("status") != "approved":
+        return "", "Approve the staged Click execution contract before managing a service."
+    service = state.get("service")
+    if not isinstance(service, dict):
+        service = fresh_state()
+    if request["action"] == "stop":
+        if service.get("status") not in {
+            "starting",
+            "launching",
+            "running",
+            "stopping",
+        }:
+            return "echo Click managed service already stopped", ""
+        service["status"] = "stopping"
+        service["stop_requested"] = True
+        state["service"] = service
+        _save_contract_state(event, state)
+        return (
+            service_runner_command(
+                event,
+                request,
+                str(service["service_id"]),
+                runner_script=runner_script,
+                render_command=render_command,
+            ),
+            "",
+        )
+
+    if service.get("status") in {"starting", "launching", "running", "stopping"}:
+        started_at = int(service.get("started_at", 0))
+        if not (
+            service.get("status") == "starting"
+            and started_at
+            and time.time() - started_at > SERVICE_START_TIMEOUT_SECONDS * 2
+        ):
+            return "", "One Click-managed local service is already active. Stop it first."
+    mutation_error = mark_contract_mutated(event)
+    if mutation_error:
+        return "", mutation_error
+    state = _read_contract_state(event)
+    service_id = secrets.token_urlsafe(24)
+    runner_token = secrets.token_urlsafe(24)
+    cwd_raw = str(Path(str(event.get("cwd", ""))).resolve())
+    request_digest = _capability_digest({"request": request, "cwd": cwd_raw})
+    state["service"] = {
+        "status": "starting",
+        "service_id": service_id,
+        "request_digest": request_digest,
+        "runner_token_digest": hashlib.sha256(runner_token.encode()).hexdigest(),
+        "runner_claimed_at": 0,
+        "supervisor_claimed_at": 0,
+        "stop_requested": False,
+        "supervisor_pid": 0,
+        "child_pid": 0,
+        "started_at": int(time.time()),
+        "last_exit_code": None,
+    }
+    _save_contract_state(event, state)
+    return (
+        service_runner_command(
+            event,
+            request,
+            service_id,
+            runner_token=runner_token,
+            runner_script=runner_script,
+            render_command=render_command,
+        ),
+        "",
+    )
+
+
+def _managed_contract_path(path: Path) -> bool:
+    return click_state.managed_state_path(path, ("session-contract-",))
+
+
+def service_snapshot(path: Path, service_id: str) -> dict[str, Any] | None:
+    if not _managed_contract_path(path):
+        return None
+    state: Any = None
+    for attempt in range(5):
+        try:
+            state = json.loads(path.read_text(encoding="utf-8"))
+            break
+        except PermissionError:
+            # Windows may briefly deny a reader while another process replaces
+            # the state file. Do not mistake that sharing collision for a
+            # missing or stopped managed service.
+            if attempt == 4:
+                return None
+            time.sleep(0.02)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return None
+    if not isinstance(state, dict) or state.get("status") != "approved":
+        return None
+    service = state.get("service")
+    if not isinstance(service, dict) or service.get("service_id") != service_id:
+        return None
+    return dict(service)
+
+
+def record_service_fields(
+    path: Path,
+    service_id: str,
+    *,
+    expected_statuses: tuple[str, ...] | None = None,
+    **fields: Any,
+) -> bool:
+    if not _managed_contract_path(path):
+        return False
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return False
+    if not isinstance(state, dict) or state.get("status") != "approved":
+        return False
+    service = state.get("service")
+    if not isinstance(service, dict) or service.get("service_id") != service_id:
+        return False
+    if expected_statuses is not None and service.get("status") not in expected_statuses:
+        return False
+    service.update(fields)
+    state["service"] = service
+    state["updated_at"] = int(time.time())
+    click_state.write_json(path, state)
+    return True
+
+
+def claim_service_runner(
+    path: Path,
+    service_id: str,
+    request: dict[str, Any],
+    cwd_raw: str,
+    runner_token: str,
+    *,
+    supervisor: bool,
+) -> str:
+    if not _managed_contract_path(path):
+        return "Click managed service runner received an unmanaged state path."
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return "Click managed service runner could not read its contract state."
+    if not isinstance(state, dict) or state.get("status") != "approved":
+        return "Click managed service runner is no longer authorized to execute."
+    service = state.get("service")
+    expected_status = "launching" if supervisor else "starting"
+    if (
+        not isinstance(service, dict)
+        or service.get("service_id") != service_id
+        or service.get("status") != expected_status
+        or service.get("stop_requested") is True
+    ):
+        return "Click managed service runner is no longer authorized to execute."
+    request_digest = _capability_digest({"request": request, "cwd": cwd_raw})
+    if service.get("request_digest") != request_digest:
+        return "Click managed service runner request digest did not match active state."
+    token_digest = hashlib.sha256(runner_token.encode()).hexdigest()
+    if not secrets.compare_digest(
+        str(service.get("runner_token_digest", "")), token_digest
+    ):
+        return "Click managed service runner token did not match active state."
+    runner_claimed_at = service.get("runner_claimed_at", 0)
+    supervisor_claimed_at = service.get("supervisor_claimed_at", 0)
+    for claimed_at in (runner_claimed_at, supervisor_claimed_at):
+        if not isinstance(claimed_at, int) or isinstance(claimed_at, bool):
+            return "Click managed service runner claim state is malformed."
+    if supervisor:
+        if runner_claimed_at <= 0 or supervisor_claimed_at > 0:
+            return "Click managed service supervisor was already claimed or not launched."
+        if not _unclaimed_reservation_is_fresh(
+            runner_claimed_at, SERVICE_START_TIMEOUT_SECONDS * 2
+        ):
+            return "Click managed service supervisor authorization expired before launch."
+        service["supervisor_claimed_at"] = int(time.time()) or 1
+    else:
+        if runner_claimed_at > 0 or supervisor_claimed_at > 0:
+            return "Click managed service start runner was already claimed."
+        if not _unclaimed_reservation_is_fresh(
+            service.get("started_at", 0), SERVICE_START_TIMEOUT_SECONDS * 2
+        ):
+            return "Click managed service start authorization expired before launch."
+        service["runner_claimed_at"] = int(time.time()) or 1
+        service["status"] = "launching"
+    state["service"] = service
+    state["updated_at"] = int(time.time())
+    click_state.write_json(path, state)
+    return ""
+
+
+def _unclaimed_reservation_is_fresh(value: Any, ttl_seconds: int) -> bool:
+    return bool(
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and value > 0
+        and 0 <= time.time() - value <= ttl_seconds
+    )
+
+
+def run_service_supervisor(
+    arguments: list[str],
+    *,
+    validate_argv: ValidateArgv,
+    protocol_version: int,
+    execution_argv: ExecutionArgv,
+) -> int:
+    if len(arguments) != 5:
+        return 2
+    state_path = Path(arguments[0])
+    service_id, runner_token, cwd_raw, encoded = arguments[1:]
+    raw, error = _decode_encoded_request(encoded)
+    if error:
+        return 2
+    request, error = validate_request(
+        raw,
+        validate_argv=validate_argv,
+        protocol_version=protocol_version,
+    )
+    if error or request is None or request.get("action") != "start":
+        return 2
+    with click_state.state_lock():
+        claim_error = claim_service_runner(
+            state_path,
+            service_id,
+            request,
+            cwd_raw,
+            runner_token,
+            supervisor=True,
+        )
+    if claim_error:
+        return 2
+    cwd = Path(cwd_raw)
+    if not cwd.is_dir():
+        with click_state.state_lock():
+            record_service_fields(
+                state_path,
+                service_id,
+                expected_statuses=("launching",),
+                status="failed",
+                last_exit_code=2,
+            )
+        return 2
+    try:
+        child = click_process.spawn_argv(
+            execution_argv(request["argv"]),
+            cwd=cwd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+        )
+    except OSError:
+        with click_state.state_lock():
+            record_service_fields(
+                state_path,
+                service_id,
+                expected_statuses=("launching",),
+                status="failed",
+                last_exit_code=127,
+                stop_requested=False,
+            )
+        return 127
+
+    time.sleep(0.2)
+    early_exit = child.poll()
+    with click_state.state_lock():
+        recorded = record_service_fields(
+            state_path,
+            service_id,
+            expected_statuses=("launching",),
+            status="failed" if early_exit is not None else "running",
+            supervisor_pid=os.getpid(),
+            child_pid=child.pid,
+            last_exit_code=int(early_exit) if early_exit is not None else None,
+        )
+    if early_exit is not None or not recorded:
+        if early_exit is None:
+            click_process.terminate_process_group(child)
+        return int(early_exit or 2)
+
+    started = time.monotonic()
+    stop_requested = False
+    while True:
+        exit_code = child.poll()
+        if exit_code is not None:
+            break
+        snapshot = service_snapshot(state_path, service_id)
+        if snapshot is None or snapshot.get("stop_requested") is True:
+            stop_requested = True
+            exit_code = click_process.terminate_process_group(child)
+            break
+        if time.monotonic() - started >= MANAGED_SERVICE_MAX_SECONDS:
+            stop_requested = True
+            exit_code = click_process.terminate_process_group(child)
+            break
+        time.sleep(0.2)
+
+    with click_state.state_lock():
+        record_service_fields(
+            state_path,
+            service_id,
+            expected_statuses=("running", "stopping", "launching"),
+            status="stopped" if stop_requested else "failed",
+            stop_requested=False,
+            child_pid=0,
+            supervisor_pid=0,
+            last_exit_code=int(exit_code or 0),
+        )
+    return int(exit_code or 0)
+
+
+def run_service_start(
+    arguments: list[str],
+    *,
+    validate_argv: ValidateArgv,
+    protocol_version: int,
+    runner_script: Path,
+) -> int:
+    if len(arguments) != 5:
+        sys.stderr.write(
+            "usage: click_gate.py run-service-start "
+            "<state> <id> <token> <cwd> <request>\n"
+        )
+        return 2
+    state_path = Path(arguments[0])
+    service_id, runner_token, cwd_raw, encoded = arguments[1:]
+    raw, error = _decode_encoded_request(encoded)
+    if error:
+        sys.stderr.write(f"{error}\n")
+        return 2
+    request, error = validate_request(
+        raw,
+        validate_argv=validate_argv,
+        protocol_version=protocol_version,
+    )
+    if error or request is None or request.get("action") != "start":
+        sys.stderr.write(f"{error or 'Managed service start request is invalid.'}\n")
+        return 2
+    with click_state.state_lock():
+        claim_error = claim_service_runner(
+            state_path,
+            service_id,
+            request,
+            cwd_raw,
+            runner_token,
+            supervisor=False,
+        )
+    if claim_error:
+        sys.stderr.write(f"{claim_error}\n")
+        return 2
+    supervisor = [
+        *_runner_prefix("run-service-supervisor", runner_script),
+        str(state_path.resolve()),
+        service_id,
+        runner_token,
+        cwd_raw,
+        encoded,
+    ]
+    try:
+        click_process.spawn_argv(
+            supervisor,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+        )
+    except OSError as exc:
+        with click_state.state_lock():
+            record_service_fields(
+                state_path,
+                service_id,
+                expected_statuses=("launching",),
+                status="failed",
+                last_exit_code=127,
+            )
+        sys.stderr.write(f"Click could not start the managed service supervisor: {exc}\n")
+        return 127
+    deadline = time.monotonic() + SERVICE_START_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        snapshot = service_snapshot(state_path, service_id)
+        if snapshot is None:
+            return 2
+        if snapshot.get("status") == "running":
+            sys.stdout.write("Click managed service started\n")
+            return 0
+        if snapshot.get("status") == "failed":
+            sys.stderr.write("Click managed service exited during startup.\n")
+            return int(snapshot.get("last_exit_code") or 2)
+        if snapshot.get("status") in {"stopping", "stopped"}:
+            return 2
+        time.sleep(0.05)
+    with click_state.state_lock():
+        record_service_fields(
+            state_path,
+            service_id,
+            expected_statuses=("launching", "starting"),
+            status="stopping",
+            stop_requested=True,
+        )
+    sys.stderr.write("Click managed service did not start within its bounded timeout.\n")
+    return 2
+
+
+def run_service_stop(
+    arguments: list[str], *, snapshot_reader: SnapshotReader | None = None
+) -> int:
+    if len(arguments) != 2:
+        sys.stderr.write("usage: click_gate.py run-service-stop <state> <id>\n")
+        return 2
+    state_path = Path(arguments[0])
+    service_id = arguments[1]
+    reader = snapshot_reader or service_snapshot
+    deadline = time.monotonic() + SERVICE_STOP_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        snapshot = reader(state_path, service_id)
+        if snapshot is not None and snapshot.get("status") in {
+            "failed",
+            "idle",
+            "stopped",
+        }:
+            sys.stdout.write("Click managed service stopped\n")
+            return 0
+        time.sleep(0.05)
+    sys.stderr.write("Click managed service did not stop within its bounded timeout.\n")
+    return 2

--- a/hooks/click_gate.py
+++ b/hooks/click_gate.py
@@ -39,6 +39,7 @@ if __package__:
         click_evidence,
         click_host_coverage,
         click_process,
+        click_service,
         click_verification_meter,
         click_verification_policy,
     )
@@ -65,6 +66,7 @@ else:  # Executed directly from the bundled hooks directory.
     import click_evidence
     import click_host_coverage
     import click_process
+    import click_service
     import click_verification_meter
     import click_verification_policy
     from click_state import (
@@ -107,6 +109,16 @@ _fresh_external_evidence_state = click_evidence.fresh_external_state
 # schema validation now lives in the one-way click_contract boundary.
 _validate_contract = click_contract.validate_contract
 
+# Compatibility aliases for direct callers and the deterministic suite. The
+# managed local-service state machine and runner lifecycle live in the one-way
+# click_service boundary; gate wrappers below provide only cross-domain routing.
+_fresh_service_state = click_service.fresh_state
+_looks_like_managed_service = click_service.looks_like_managed_service
+_request_service_stop = click_service.request_stop
+_service_snapshot = click_service.service_snapshot
+_record_service_fields = click_service.record_service_fields
+_claim_service_runner = click_service.claim_service_runner
+
 
 CONTROL_COMMAND = "click-gate"
 CLICK_AUTHORIZATION_PATTERNS = (
@@ -135,7 +147,7 @@ VERIFICATION_PROTOCOL_VERSION = 2
 CONTRACT_STATE_SCHEMA_VERSION = 2
 INSPECTION_REQUEST_FIELDS = {"version", "commands"}
 MUTATION_REQUEST_FIELDS = {"version", "argv"}
-SERVICE_REQUEST_FIELDS = {"version", "action", "argv"}
+SERVICE_REQUEST_FIELDS = click_service.SERVICE_REQUEST_FIELDS
 VERIFICATION_BATCH_FIELDS = {"version", "checks"}
 VERIFICATION_CHECK_FIELDS = {"evidence_id", "argv", "class"}
 EVIDENCE_RESULT_FIELDS = {"version", "evidence_id"}
@@ -216,27 +228,12 @@ PROCESS_CONTROL_EXECUTABLES = {
 
 BROWSER_TOOL_NAMES = click_host_coverage.CODEX_BROWSER_TOOL_NAMES
 BROWSER_WAIT_PATTERNS = click_browser_advisory.BROWSER_WAIT_PATTERNS
-MANAGED_SERVICE_EXECUTABLES = {
-    "flask",
-    "gunicorn",
-    "http-server",
-    "next",
-    "serve",
-    "uvicorn",
-    "vite",
-    "webpack-dev-server",
-}
-MANAGED_SERVICE_ACTIONS = {"start", "stop"}
-MANAGED_SERVICE_SCRIPT_MARKERS = {
-    "dev",
-    "preview",
-    "runserver",
-    "serve",
-    "start",
-}
-SERVICE_START_TIMEOUT_SECONDS = 8
-SERVICE_STOP_TIMEOUT_SECONDS = 8
-MANAGED_SERVICE_MAX_SECONDS = 2 * 60 * 60
+MANAGED_SERVICE_EXECUTABLES = click_service.MANAGED_SERVICE_EXECUTABLES
+MANAGED_SERVICE_ACTIONS = click_service.MANAGED_SERVICE_ACTIONS
+MANAGED_SERVICE_SCRIPT_MARKERS = click_service.MANAGED_SERVICE_SCRIPT_MARKERS
+SERVICE_START_TIMEOUT_SECONDS = click_service.SERVICE_START_TIMEOUT_SECONDS
+SERVICE_STOP_TIMEOUT_SECONDS = click_service.SERVICE_STOP_TIMEOUT_SECONDS
+MANAGED_SERVICE_MAX_SECONDS = click_service.MANAGED_SERVICE_MAX_SECONDS
 
 VERIFICATION_EXECUTABLES = {
     "bandit",
@@ -634,22 +631,6 @@ def _evidence_sources(state: dict[str, Any]) -> dict[str, Any] | None:
         state,
         expected_contract_schema_version=CONTRACT_STATE_SCHEMA_VERSION,
     )
-
-
-def _fresh_service_state() -> dict[str, Any]:
-    return {
-        "status": "idle",
-        "service_id": "",
-        "request_digest": "",
-        "runner_token_digest": "",
-        "runner_claimed_at": 0,
-        "supervisor_claimed_at": 0,
-        "stop_requested": False,
-        "supervisor_pid": 0,
-        "child_pid": 0,
-        "started_at": 0,
-        "last_exit_code": None,
-    }
 
 
 def _fresh_observation_state() -> dict[str, Any]:
@@ -1153,38 +1134,6 @@ def _policy_executable_name(value: str) -> str:
     return executable
 
 
-def _looks_like_managed_service(argv: list[str]) -> bool:
-    executable = Path(argv[0]).name.lower()
-    if executable.endswith(".exe"):
-        executable = executable[:-4]
-    arguments = [argument.lower() for argument in argv[1:]]
-    if executable in MANAGED_SERVICE_EXECUTABLES:
-        return True
-    if executable == "py" or re.fullmatch(r"(?:python|pypy)\d*(?:\.\d+)?", executable):
-        if executable == "py" and arguments and re.fullmatch(
-            r"-\d+(?:\.\d+)?(?:-\d+)?", arguments[0]
-        ):
-            arguments = arguments[1:]
-        if len(arguments) >= 2 and arguments[:2] == ["-m", "http.server"]:
-            return True
-        return any(marker in arguments for marker in {"runserver"})
-    if executable in {"npm", "pnpm", "yarn", "bun"}:
-        meaningful = {
-            argument
-            for argument in arguments
-            if argument not in {"run", "exec", "x", "--"}
-            and not argument.startswith("-")
-        }
-        return bool(meaningful & MANAGED_SERVICE_SCRIPT_MARKERS)
-    if executable in {"npx", "pnpx", "bunx"}:
-        return any(
-            Path(argument).name.lower() in MANAGED_SERVICE_EXECUTABLES
-            for argument in arguments
-            if not argument.startswith("-")
-        )
-    return any(marker in arguments for marker in {"runserver"})
-
-
 def _validate_inspection_request(
     raw: str,
 ) -> tuple[dict[str, Any] | None, bool, str]:
@@ -1246,37 +1195,11 @@ def _validate_mutation_request(raw: str) -> tuple[dict[str, Any] | None, str]:
 
 
 def _validate_service_request(raw: str) -> tuple[dict[str, Any] | None, str]:
-    value, error = _decode_capability_request(raw, "Managed service")
-    if error:
-        return None, error
-    assert value is not None
-    unknown = sorted(set(value) - SERVICE_REQUEST_FIELDS)
-    if unknown:
-        rendered = ", ".join(f"`{field}`" for field in unknown)
-        return None, f"Managed service request contains unsupported field(s): {rendered}."
-    action = value.get("action")
-    if action not in MANAGED_SERVICE_ACTIONS:
-        allowed = ", ".join(sorted(MANAGED_SERVICE_ACTIONS))
-        return None, f"Managed service `action` must be one of: {allowed}."
-    if action == "stop":
-        if "argv" in value:
-            return None, "Managed service stop must omit `argv`."
-        return {"version": CAPABILITY_PROTOCOL_VERSION, "action": "stop"}, ""
-    argv, argv_error = _validate_argv(value.get("argv"), "Managed service")
-    if argv_error:
-        return None, argv_error
-    assert argv is not None
-    if not _looks_like_managed_service(argv):
-        return (
-            None,
-            "Managed service start accepts a recognizable local development server, "
-            "not an arbitrary detached command.",
-        )
-    return {
-        "version": CAPABILITY_PROTOCOL_VERSION,
-        "action": "start",
-        "argv": argv,
-    }, ""
+    return click_service.validate_request(
+        raw,
+        validate_argv=_validate_argv,
+        protocol_version=CAPABILITY_PROTOCOL_VERSION,
+    )
 
 
 def _validate_verification_batch(
@@ -2773,97 +2696,26 @@ def _service_runner_command(
     service_id: str,
     runner_token: str = "",
 ) -> str:
-    arguments = [
-        *_stateful_runner_prefix(
-            "run-service-start" if request["action"] == "start" else "run-service-stop"
-        ),
-        str(_contract_path(event).resolve()),
+    return click_service.service_runner_command(
+        event,
+        request,
         service_id,
-    ]
-    if request["action"] == "start":
-        arguments.extend(
-            [
-                runner_token,
-                str(Path(str(event.get("cwd", ""))).resolve()),
-                _encoded_request(request),
-            ]
-        )
-    return _runner_shell_command(arguments)
-
-
-def _request_service_stop(event: dict[str, Any]) -> bool:
-    state = _read_contract_state(event)
-    service = state.get("service")
-    if not isinstance(service, dict) or service.get("status") not in {
-        "starting",
-        "launching",
-        "running",
-        "stopping",
-    }:
-        return False
-    service["status"] = "stopping"
-    service["stop_requested"] = True
-    state["service"] = service
-    _save_contract_state(event, state)
-    return True
+        runner_token=runner_token,
+        runner_script=Path(__file__).resolve(),
+        render_command=_runner_shell_command,
+    )
 
 
 def _prepare_service(event: dict[str, Any], raw: str) -> tuple[str, str]:
-    request, error = _validate_service_request(raw)
-    if error:
-        return "", error
-    assert request is not None
-    state = _read_contract_state(event)
-    if state.get("status") != "approved":
-        return "", "Approve the staged Click execution contract before managing a service."
-    service = state.get("service")
-    if not isinstance(service, dict):
-        service = _fresh_service_state()
-    if request["action"] == "stop":
-        if service.get("status") not in {
-            "starting",
-            "launching",
-            "running",
-            "stopping",
-        }:
-            return "echo Click managed service already stopped", ""
-        service["status"] = "stopping"
-        service["stop_requested"] = True
-        state["service"] = service
-        _save_contract_state(event, state)
-        return _service_runner_command(event, request, str(service["service_id"])), ""
-
-    if service.get("status") in {"starting", "launching", "running", "stopping"}:
-        started_at = int(service.get("started_at", 0))
-        if not (
-            service.get("status") == "starting"
-            and started_at
-            and time.time() - started_at > SERVICE_START_TIMEOUT_SECONDS * 2
-        ):
-            return "", "One Click-managed local service is already active. Stop it first."
-    mutation_error = _mark_contract_mutated(event)
-    if mutation_error:
-        return "", mutation_error
-    state = _read_contract_state(event)
-    service_id = secrets.token_urlsafe(24)
-    runner_token = secrets.token_urlsafe(24)
-    cwd_raw = str(Path(str(event.get("cwd", ""))).resolve())
-    request_digest = _capability_digest({"request": request, "cwd": cwd_raw})
-    state["service"] = {
-        "status": "starting",
-        "service_id": service_id,
-        "request_digest": request_digest,
-        "runner_token_digest": hashlib.sha256(runner_token.encode()).hexdigest(),
-        "runner_claimed_at": 0,
-        "supervisor_claimed_at": 0,
-        "stop_requested": False,
-        "supervisor_pid": 0,
-        "child_pid": 0,
-        "started_at": int(time.time()),
-        "last_exit_code": None,
-    }
-    _save_contract_state(event, state)
-    return _service_runner_command(event, request, service_id, runner_token), ""
+    return click_service.prepare_service(
+        event,
+        raw,
+        validate_argv=_validate_argv,
+        protocol_version=CAPABILITY_PROTOCOL_VERSION,
+        mark_contract_mutated=_mark_contract_mutated,
+        runner_script=Path(__file__).resolve(),
+        render_command=_runner_shell_command,
+    )
 
 
 def _verification_runner_command(
@@ -5703,323 +5555,29 @@ def _managed_observation_path(path: Path) -> bool:
     return _managed_state_path(path, ("session-contract-", "review-"))
 
 
-def _service_snapshot(path: Path, service_id: str) -> dict[str, Any] | None:
-    if not _managed_contract_path(path):
-        return None
-    state: Any = None
-    for attempt in range(5):
-        try:
-            state = json.loads(path.read_text(encoding="utf-8"))
-            break
-        except PermissionError:
-            # Windows may briefly deny a reader while another process replaces
-            # the state file. Do not mistake that sharing collision for a
-            # missing or stopped managed service.
-            if attempt == 4:
-                return None
-            time.sleep(0.02)
-        except (FileNotFoundError, json.JSONDecodeError, OSError):
-            return None
-    if not isinstance(state, dict) or state.get("status") != "approved":
-        return None
-    service = state.get("service")
-    if not isinstance(service, dict) or service.get("service_id") != service_id:
-        return None
-    return dict(service)
-
-
-def _record_service_fields(
-    path: Path,
-    service_id: str,
-    *,
-    expected_statuses: tuple[str, ...] | None = None,
-    **fields: Any,
-) -> bool:
-    if not _managed_contract_path(path):
-        return False
-    try:
-        state = json.loads(path.read_text(encoding="utf-8"))
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
-        return False
-    if not isinstance(state, dict) or state.get("status") != "approved":
-        return False
-    service = state.get("service")
-    if not isinstance(service, dict) or service.get("service_id") != service_id:
-        return False
-    if expected_statuses is not None and service.get("status") not in expected_statuses:
-        return False
-    service.update(fields)
-    state["service"] = service
-    state["updated_at"] = int(time.time())
-    _write_json(path, state)
-    return True
-
-
-def _claim_service_runner(
-    path: Path,
-    service_id: str,
-    request: dict[str, Any],
-    cwd_raw: str,
-    runner_token: str,
-    *,
-    supervisor: bool,
-) -> str:
-    if not _managed_contract_path(path):
-        return "Click managed service runner received an unmanaged state path."
-    try:
-        state = json.loads(path.read_text(encoding="utf-8"))
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
-        return "Click managed service runner could not read its contract state."
-    if not isinstance(state, dict) or state.get("status") != "approved":
-        return "Click managed service runner is no longer authorized to execute."
-    service = state.get("service")
-    expected_status = "launching" if supervisor else "starting"
-    if (
-        not isinstance(service, dict)
-        or service.get("service_id") != service_id
-        or service.get("status") != expected_status
-        or service.get("stop_requested") is True
-    ):
-        return "Click managed service runner is no longer authorized to execute."
-    request_digest = _capability_digest({"request": request, "cwd": cwd_raw})
-    if service.get("request_digest") != request_digest:
-        return "Click managed service runner request digest did not match active state."
-    token_digest = hashlib.sha256(runner_token.encode()).hexdigest()
-    if not secrets.compare_digest(
-        str(service.get("runner_token_digest", "")), token_digest
-    ):
-        return "Click managed service runner token did not match active state."
-    runner_claimed_at = service.get("runner_claimed_at", 0)
-    supervisor_claimed_at = service.get("supervisor_claimed_at", 0)
-    for claimed_at in (runner_claimed_at, supervisor_claimed_at):
-        if not isinstance(claimed_at, int) or isinstance(claimed_at, bool):
-            return "Click managed service runner claim state is malformed."
-    if supervisor:
-        if runner_claimed_at <= 0 or supervisor_claimed_at > 0:
-            return "Click managed service supervisor was already claimed or not launched."
-        if not _unclaimed_reservation_is_fresh(
-            runner_claimed_at, SERVICE_START_TIMEOUT_SECONDS * 2
-        ):
-            return "Click managed service supervisor authorization expired before launch."
-        service["supervisor_claimed_at"] = int(time.time()) or 1
-    else:
-        if runner_claimed_at > 0 or supervisor_claimed_at > 0:
-            return "Click managed service start runner was already claimed."
-        if not _unclaimed_reservation_is_fresh(
-            service.get("started_at", 0), SERVICE_START_TIMEOUT_SECONDS * 2
-        ):
-            return "Click managed service start authorization expired before launch."
-        service["runner_claimed_at"] = int(time.time()) or 1
-        service["status"] = "launching"
-    state["service"] = service
-    state["updated_at"] = int(time.time())
-    _write_json(path, state)
-    return ""
-
-
 def _run_service_supervisor(arguments: list[str]) -> int:
-    if len(arguments) != 5:
-        return 2
-    state_path = Path(arguments[0])
-    service_id, runner_token, cwd_raw, encoded = arguments[1:]
-    raw, error = _decode_encoded_request(encoded, "managed service")
-    if error:
-        return 2
-    request, error = _validate_service_request(raw)
-    if error or request is None or request.get("action") != "start":
-        return 2
-    with _state_lock():
-        claim_error = _claim_service_runner(
-            state_path,
-            service_id,
-            request,
-            cwd_raw,
-            runner_token,
-            supervisor=True,
-        )
-    if claim_error:
-        return 2
-    cwd = Path(cwd_raw)
-    if not cwd.is_dir():
-        with _state_lock():
-            _record_service_fields(
-                state_path,
-                service_id,
-                expected_statuses=("launching",),
-                status="failed",
-                last_exit_code=2,
-            )
-        return 2
-    try:
-        child = click_process.spawn_argv(
-            _execution_argv(request["argv"]),
-            cwd=cwd,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            close_fds=True,
-        )
-    except OSError:
-        with _state_lock():
-            _record_service_fields(
-                state_path,
-                service_id,
-                expected_statuses=("launching",),
-                status="failed",
-                last_exit_code=127,
-                stop_requested=False,
-            )
-        return 127
-
-    time.sleep(0.2)
-    early_exit = child.poll()
-    with _state_lock():
-        recorded = _record_service_fields(
-            state_path,
-            service_id,
-            expected_statuses=("launching",),
-            status="failed" if early_exit is not None else "running",
-            supervisor_pid=os.getpid(),
-            child_pid=child.pid,
-            last_exit_code=int(early_exit) if early_exit is not None else None,
-        )
-    if early_exit is not None or not recorded:
-        if early_exit is None:
-            _terminate_managed_child(child)
-        return int(early_exit or 2)
-
-    started = time.monotonic()
-    stop_requested = False
-    while True:
-        exit_code = child.poll()
-        if exit_code is not None:
-            break
-        snapshot = _service_snapshot(state_path, service_id)
-        if snapshot is None or snapshot.get("stop_requested") is True:
-            stop_requested = True
-            exit_code = _terminate_managed_child(child)
-            break
-        if time.monotonic() - started >= MANAGED_SERVICE_MAX_SECONDS:
-            stop_requested = True
-            exit_code = _terminate_managed_child(child)
-            break
-        time.sleep(0.2)
-
-    with _state_lock():
-        _record_service_fields(
-            state_path,
-            service_id,
-            expected_statuses=("running", "stopping", "launching"),
-            status="stopped" if stop_requested else "failed",
-            stop_requested=False,
-            child_pid=0,
-            supervisor_pid=0,
-            last_exit_code=int(exit_code or 0),
-        )
-    return int(exit_code or 0)
+    return click_service.run_service_supervisor(
+        arguments,
+        validate_argv=_validate_argv,
+        protocol_version=CAPABILITY_PROTOCOL_VERSION,
+        execution_argv=_execution_argv,
+    )
 
 
 def _run_service_start(arguments: list[str]) -> int:
-    if len(arguments) != 5:
-        sys.stderr.write(
-            "usage: click_gate.py run-service-start "
-            "<state> <id> <token> <cwd> <request>\n"
-        )
-        return 2
-    state_path = Path(arguments[0])
-    service_id, runner_token, cwd_raw, encoded = arguments[1:]
-    raw, error = _decode_encoded_request(encoded, "managed service")
-    if error:
-        sys.stderr.write(f"{error}\n")
-        return 2
-    request, error = _validate_service_request(raw)
-    if error or request is None or request.get("action") != "start":
-        sys.stderr.write(f"{error or 'Managed service start request is invalid.'}\n")
-        return 2
-    with _state_lock():
-        claim_error = _claim_service_runner(
-            state_path,
-            service_id,
-            request,
-            cwd_raw,
-            runner_token,
-            supervisor=False,
-        )
-    if claim_error:
-        sys.stderr.write(f"{claim_error}\n")
-        return 2
-    supervisor = [
-        *_stateful_runner_prefix("run-service-supervisor"),
-        str(state_path.resolve()),
-        service_id,
-        runner_token,
-        cwd_raw,
-        encoded,
-    ]
-    try:
-        click_process.spawn_argv(
-            supervisor,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            close_fds=True,
-        )
-    except OSError as exc:
-        with _state_lock():
-            _record_service_fields(
-                state_path,
-                service_id,
-                expected_statuses=("launching",),
-                status="failed",
-                last_exit_code=127,
-            )
-        sys.stderr.write(f"Click could not start the managed service supervisor: {exc}\n")
-        return 127
-    deadline = time.monotonic() + SERVICE_START_TIMEOUT_SECONDS
-    while time.monotonic() < deadline:
-        snapshot = _service_snapshot(state_path, service_id)
-        if snapshot is None:
-            return 2
-        if snapshot.get("status") == "running":
-            sys.stdout.write("Click managed service started\n")
-            return 0
-        if snapshot.get("status") == "failed":
-            sys.stderr.write("Click managed service exited during startup.\n")
-            return int(snapshot.get("last_exit_code") or 2)
-        if snapshot.get("status") in {"stopping", "stopped"}:
-            return 2
-        time.sleep(0.05)
-    with _state_lock():
-        _record_service_fields(
-            state_path,
-            service_id,
-            expected_statuses=("launching", "starting"),
-            status="stopping",
-            stop_requested=True,
-        )
-    sys.stderr.write("Click managed service did not start within its bounded timeout.\n")
-    return 2
+    return click_service.run_service_start(
+        arguments,
+        validate_argv=_validate_argv,
+        protocol_version=CAPABILITY_PROTOCOL_VERSION,
+        runner_script=Path(__file__).resolve(),
+    )
 
 
 def _run_service_stop(arguments: list[str]) -> int:
-    if len(arguments) != 2:
-        sys.stderr.write("usage: click_gate.py run-service-stop <state> <id>\n")
-        return 2
-    state_path = Path(arguments[0])
-    service_id = arguments[1]
-    deadline = time.monotonic() + SERVICE_STOP_TIMEOUT_SECONDS
-    while time.monotonic() < deadline:
-        snapshot = _service_snapshot(state_path, service_id)
-        if snapshot is not None and snapshot.get("status") in {
-            "failed",
-            "idle",
-            "stopped",
-        }:
-            sys.stdout.write("Click managed service stopped\n")
-            return 0
-        time.sleep(0.05)
-    sys.stderr.write("Click managed service did not stop within its bounded timeout.\n")
-    return 2
+    return click_service.run_service_stop(
+        arguments,
+        snapshot_reader=_service_snapshot,
+    )
 
 
 def _git_capture(cwd: Path, arguments: list[str]) -> bytes | None:

--- a/hooks/click_service.py
+++ b/hooks/click_service.py
@@ -1,0 +1,698 @@
+#!/usr/bin/env python3
+"""Managed local-service admission, state, and runner lifecycle for Click.
+
+This module owns only the recognizable development-service capability. It may
+depend on the state and shell-free process leaves, but it must not import the
+gate, contract lifecycle, evidence, observation, Browser, or verification
+layers. The caller supplies the one cross-domain transition that marks an
+approved contract mutated before a service starts.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Callable
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+import subprocess
+import sys
+import time
+from typing import Any
+
+if __package__:
+    from . import click_process, click_state
+else:  # Executed from the bundled hooks directory.
+    import click_process
+    import click_state
+
+
+SERVICE_REQUEST_FIELDS = {"version", "action", "argv"}
+MANAGED_SERVICE_EXECUTABLES = {
+    "flask",
+    "gunicorn",
+    "http-server",
+    "next",
+    "serve",
+    "uvicorn",
+    "vite",
+    "webpack-dev-server",
+}
+MANAGED_SERVICE_ACTIONS = {"start", "stop"}
+MANAGED_SERVICE_SCRIPT_MARKERS = {
+    "dev",
+    "preview",
+    "runserver",
+    "serve",
+    "start",
+}
+SERVICE_START_TIMEOUT_SECONDS = 8
+SERVICE_STOP_TIMEOUT_SECONDS = 8
+MANAGED_SERVICE_MAX_SECONDS = 2 * 60 * 60
+
+
+ValidateArgv = Callable[[Any, str], tuple[list[str] | None, str]]
+MarkContractMutated = Callable[[dict[str, Any]], str]
+RenderRunnerCommand = Callable[[list[str]], str]
+ExecutionArgv = Callable[[list[str]], list[str]]
+SnapshotReader = Callable[[Path, str], dict[str, Any] | None]
+
+
+def fresh_state() -> dict[str, Any]:
+    return {
+        "status": "idle",
+        "service_id": "",
+        "request_digest": "",
+        "runner_token_digest": "",
+        "runner_claimed_at": 0,
+        "supervisor_claimed_at": 0,
+        "stop_requested": False,
+        "supervisor_pid": 0,
+        "child_pid": 0,
+        "started_at": 0,
+        "last_exit_code": None,
+    }
+
+
+def looks_like_managed_service(argv: list[str]) -> bool:
+    executable = Path(argv[0]).name.lower()
+    if executable.endswith(".exe"):
+        executable = executable[:-4]
+    arguments = [argument.lower() for argument in argv[1:]]
+    if executable in MANAGED_SERVICE_EXECUTABLES:
+        return True
+    if executable == "py" or re.fullmatch(r"(?:python|pypy)\d*(?:\.\d+)?", executable):
+        if executable == "py" and arguments and re.fullmatch(
+            r"-\d+(?:\.\d+)?(?:-\d+)?", arguments[0]
+        ):
+            arguments = arguments[1:]
+        if len(arguments) >= 2 and arguments[:2] == ["-m", "http.server"]:
+            return True
+        return any(marker in arguments for marker in {"runserver"})
+    if executable in {"npm", "pnpm", "yarn", "bun"}:
+        meaningful = {
+            argument
+            for argument in arguments
+            if argument not in {"run", "exec", "x", "--"}
+            and not argument.startswith("-")
+        }
+        return bool(meaningful & MANAGED_SERVICE_SCRIPT_MARKERS)
+    if executable in {"npx", "pnpx", "bunx"}:
+        return any(
+            Path(argument).name.lower() in MANAGED_SERVICE_EXECUTABLES
+            for argument in arguments
+            if not argument.startswith("-")
+        )
+    return any(marker in arguments for marker in {"runserver"})
+
+
+def _decode_request(
+    raw: str, *, protocol_version: int
+) -> tuple[dict[str, Any] | None, str]:
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError:
+        return None, "Managed service request must be valid JSON."
+    if not isinstance(value, dict):
+        return None, "Managed service request must be a JSON object."
+    if value.get("version") != protocol_version:
+        return (
+            None,
+            f"Managed service request `version` must be {protocol_version}.",
+        )
+    return value, ""
+
+
+def validate_request(
+    raw: str,
+    *,
+    validate_argv: ValidateArgv,
+    protocol_version: int,
+) -> tuple[dict[str, Any] | None, str]:
+    value, error = _decode_request(raw, protocol_version=protocol_version)
+    if error:
+        return None, error
+    assert value is not None
+    unknown = sorted(set(value) - SERVICE_REQUEST_FIELDS)
+    if unknown:
+        rendered = ", ".join(f"`{field}`" for field in unknown)
+        return None, f"Managed service request contains unsupported field(s): {rendered}."
+    action = value.get("action")
+    if action not in MANAGED_SERVICE_ACTIONS:
+        allowed = ", ".join(sorted(MANAGED_SERVICE_ACTIONS))
+        return None, f"Managed service `action` must be one of: {allowed}."
+    if action == "stop":
+        if "argv" in value:
+            return None, "Managed service stop must omit `argv`."
+        return {"version": protocol_version, "action": "stop"}, ""
+    argv, argv_error = validate_argv(value.get("argv"), "Managed service")
+    if argv_error:
+        return None, argv_error
+    assert argv is not None
+    if not looks_like_managed_service(argv):
+        return (
+            None,
+            "Managed service start accepts a recognizable local development server, "
+            "not an arbitrary detached command.",
+        )
+    return {
+        "version": protocol_version,
+        "action": "start",
+        "argv": argv,
+    }, ""
+
+
+def _capability_digest(request: dict[str, Any]) -> str:
+    canonical = json.dumps(request, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def _encoded_request(request: dict[str, Any]) -> str:
+    return base64.urlsafe_b64encode(
+        json.dumps(request, ensure_ascii=False, separators=(",", ":")).encode()
+    ).decode()
+
+
+def _decode_encoded_request(encoded: str) -> tuple[str, str]:
+    try:
+        return base64.urlsafe_b64decode(encoded.encode()).decode(), ""
+    except (ValueError, UnicodeDecodeError):
+        return "", "Click managed service runner received an invalid request."
+
+
+def _read_contract_state(event: dict[str, Any]) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            click_state.contract_path(event).read_text(encoding="utf-8")
+        )
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {"status": "none", "contract_digest": ""}
+    return value if isinstance(value, dict) else {"status": "none", "contract_digest": ""}
+
+
+def _save_contract_state(event: dict[str, Any], state: dict[str, Any]) -> None:
+    state["updated_at"] = int(time.time())
+    click_state.write_json(click_state.contract_path(event), state)
+
+
+def _runner_prefix(action: str, runner_script: Path) -> list[str]:
+    return [
+        sys.executable,
+        str(runner_script.resolve()),
+        "--state-root",
+        str(click_state.state_root().resolve()),
+        action,
+    ]
+
+
+def service_runner_command(
+    event: dict[str, Any],
+    request: dict[str, Any],
+    service_id: str,
+    *,
+    runner_script: Path,
+    render_command: RenderRunnerCommand,
+    runner_token: str = "",
+) -> str:
+    arguments = [
+        *_runner_prefix(
+            "run-service-start" if request["action"] == "start" else "run-service-stop",
+            runner_script,
+        ),
+        str(click_state.contract_path(event).resolve()),
+        service_id,
+    ]
+    if request["action"] == "start":
+        arguments.extend(
+            [
+                runner_token,
+                str(Path(str(event.get("cwd", ""))).resolve()),
+                _encoded_request(request),
+            ]
+        )
+    return render_command(arguments)
+
+
+def request_stop(event: dict[str, Any]) -> bool:
+    state = _read_contract_state(event)
+    service = state.get("service")
+    if not isinstance(service, dict) or service.get("status") not in {
+        "starting",
+        "launching",
+        "running",
+        "stopping",
+    }:
+        return False
+    service["status"] = "stopping"
+    service["stop_requested"] = True
+    state["service"] = service
+    _save_contract_state(event, state)
+    return True
+
+
+def prepare_service(
+    event: dict[str, Any],
+    raw: str,
+    *,
+    validate_argv: ValidateArgv,
+    protocol_version: int,
+    mark_contract_mutated: MarkContractMutated,
+    runner_script: Path,
+    render_command: RenderRunnerCommand,
+) -> tuple[str, str]:
+    request, error = validate_request(
+        raw,
+        validate_argv=validate_argv,
+        protocol_version=protocol_version,
+    )
+    if error:
+        return "", error
+    assert request is not None
+    state = _read_contract_state(event)
+    if state.get("status") != "approved":
+        return "", "Approve the staged Click execution contract before managing a service."
+    service = state.get("service")
+    if not isinstance(service, dict):
+        service = fresh_state()
+    if request["action"] == "stop":
+        if service.get("status") not in {
+            "starting",
+            "launching",
+            "running",
+            "stopping",
+        }:
+            return "echo Click managed service already stopped", ""
+        service["status"] = "stopping"
+        service["stop_requested"] = True
+        state["service"] = service
+        _save_contract_state(event, state)
+        return (
+            service_runner_command(
+                event,
+                request,
+                str(service["service_id"]),
+                runner_script=runner_script,
+                render_command=render_command,
+            ),
+            "",
+        )
+
+    if service.get("status") in {"starting", "launching", "running", "stopping"}:
+        started_at = int(service.get("started_at", 0))
+        if not (
+            service.get("status") == "starting"
+            and started_at
+            and time.time() - started_at > SERVICE_START_TIMEOUT_SECONDS * 2
+        ):
+            return "", "One Click-managed local service is already active. Stop it first."
+    mutation_error = mark_contract_mutated(event)
+    if mutation_error:
+        return "", mutation_error
+    state = _read_contract_state(event)
+    service_id = secrets.token_urlsafe(24)
+    runner_token = secrets.token_urlsafe(24)
+    cwd_raw = str(Path(str(event.get("cwd", ""))).resolve())
+    request_digest = _capability_digest({"request": request, "cwd": cwd_raw})
+    state["service"] = {
+        "status": "starting",
+        "service_id": service_id,
+        "request_digest": request_digest,
+        "runner_token_digest": hashlib.sha256(runner_token.encode()).hexdigest(),
+        "runner_claimed_at": 0,
+        "supervisor_claimed_at": 0,
+        "stop_requested": False,
+        "supervisor_pid": 0,
+        "child_pid": 0,
+        "started_at": int(time.time()),
+        "last_exit_code": None,
+    }
+    _save_contract_state(event, state)
+    return (
+        service_runner_command(
+            event,
+            request,
+            service_id,
+            runner_token=runner_token,
+            runner_script=runner_script,
+            render_command=render_command,
+        ),
+        "",
+    )
+
+
+def _managed_contract_path(path: Path) -> bool:
+    return click_state.managed_state_path(path, ("session-contract-",))
+
+
+def service_snapshot(path: Path, service_id: str) -> dict[str, Any] | None:
+    if not _managed_contract_path(path):
+        return None
+    state: Any = None
+    for attempt in range(5):
+        try:
+            state = json.loads(path.read_text(encoding="utf-8"))
+            break
+        except PermissionError:
+            # Windows may briefly deny a reader while another process replaces
+            # the state file. Do not mistake that sharing collision for a
+            # missing or stopped managed service.
+            if attempt == 4:
+                return None
+            time.sleep(0.02)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return None
+    if not isinstance(state, dict) or state.get("status") != "approved":
+        return None
+    service = state.get("service")
+    if not isinstance(service, dict) or service.get("service_id") != service_id:
+        return None
+    return dict(service)
+
+
+def record_service_fields(
+    path: Path,
+    service_id: str,
+    *,
+    expected_statuses: tuple[str, ...] | None = None,
+    **fields: Any,
+) -> bool:
+    if not _managed_contract_path(path):
+        return False
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return False
+    if not isinstance(state, dict) or state.get("status") != "approved":
+        return False
+    service = state.get("service")
+    if not isinstance(service, dict) or service.get("service_id") != service_id:
+        return False
+    if expected_statuses is not None and service.get("status") not in expected_statuses:
+        return False
+    service.update(fields)
+    state["service"] = service
+    state["updated_at"] = int(time.time())
+    click_state.write_json(path, state)
+    return True
+
+
+def claim_service_runner(
+    path: Path,
+    service_id: str,
+    request: dict[str, Any],
+    cwd_raw: str,
+    runner_token: str,
+    *,
+    supervisor: bool,
+) -> str:
+    if not _managed_contract_path(path):
+        return "Click managed service runner received an unmanaged state path."
+    try:
+        state = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return "Click managed service runner could not read its contract state."
+    if not isinstance(state, dict) or state.get("status") != "approved":
+        return "Click managed service runner is no longer authorized to execute."
+    service = state.get("service")
+    expected_status = "launching" if supervisor else "starting"
+    if (
+        not isinstance(service, dict)
+        or service.get("service_id") != service_id
+        or service.get("status") != expected_status
+        or service.get("stop_requested") is True
+    ):
+        return "Click managed service runner is no longer authorized to execute."
+    request_digest = _capability_digest({"request": request, "cwd": cwd_raw})
+    if service.get("request_digest") != request_digest:
+        return "Click managed service runner request digest did not match active state."
+    token_digest = hashlib.sha256(runner_token.encode()).hexdigest()
+    if not secrets.compare_digest(
+        str(service.get("runner_token_digest", "")), token_digest
+    ):
+        return "Click managed service runner token did not match active state."
+    runner_claimed_at = service.get("runner_claimed_at", 0)
+    supervisor_claimed_at = service.get("supervisor_claimed_at", 0)
+    for claimed_at in (runner_claimed_at, supervisor_claimed_at):
+        if not isinstance(claimed_at, int) or isinstance(claimed_at, bool):
+            return "Click managed service runner claim state is malformed."
+    if supervisor:
+        if runner_claimed_at <= 0 or supervisor_claimed_at > 0:
+            return "Click managed service supervisor was already claimed or not launched."
+        if not _unclaimed_reservation_is_fresh(
+            runner_claimed_at, SERVICE_START_TIMEOUT_SECONDS * 2
+        ):
+            return "Click managed service supervisor authorization expired before launch."
+        service["supervisor_claimed_at"] = int(time.time()) or 1
+    else:
+        if runner_claimed_at > 0 or supervisor_claimed_at > 0:
+            return "Click managed service start runner was already claimed."
+        if not _unclaimed_reservation_is_fresh(
+            service.get("started_at", 0), SERVICE_START_TIMEOUT_SECONDS * 2
+        ):
+            return "Click managed service start authorization expired before launch."
+        service["runner_claimed_at"] = int(time.time()) or 1
+        service["status"] = "launching"
+    state["service"] = service
+    state["updated_at"] = int(time.time())
+    click_state.write_json(path, state)
+    return ""
+
+
+def _unclaimed_reservation_is_fresh(value: Any, ttl_seconds: int) -> bool:
+    return bool(
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and value > 0
+        and 0 <= time.time() - value <= ttl_seconds
+    )
+
+
+def run_service_supervisor(
+    arguments: list[str],
+    *,
+    validate_argv: ValidateArgv,
+    protocol_version: int,
+    execution_argv: ExecutionArgv,
+) -> int:
+    if len(arguments) != 5:
+        return 2
+    state_path = Path(arguments[0])
+    service_id, runner_token, cwd_raw, encoded = arguments[1:]
+    raw, error = _decode_encoded_request(encoded)
+    if error:
+        return 2
+    request, error = validate_request(
+        raw,
+        validate_argv=validate_argv,
+        protocol_version=protocol_version,
+    )
+    if error or request is None or request.get("action") != "start":
+        return 2
+    with click_state.state_lock():
+        claim_error = claim_service_runner(
+            state_path,
+            service_id,
+            request,
+            cwd_raw,
+            runner_token,
+            supervisor=True,
+        )
+    if claim_error:
+        return 2
+    cwd = Path(cwd_raw)
+    if not cwd.is_dir():
+        with click_state.state_lock():
+            record_service_fields(
+                state_path,
+                service_id,
+                expected_statuses=("launching",),
+                status="failed",
+                last_exit_code=2,
+            )
+        return 2
+    try:
+        child = click_process.spawn_argv(
+            execution_argv(request["argv"]),
+            cwd=cwd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+        )
+    except OSError:
+        with click_state.state_lock():
+            record_service_fields(
+                state_path,
+                service_id,
+                expected_statuses=("launching",),
+                status="failed",
+                last_exit_code=127,
+                stop_requested=False,
+            )
+        return 127
+
+    time.sleep(0.2)
+    early_exit = child.poll()
+    with click_state.state_lock():
+        recorded = record_service_fields(
+            state_path,
+            service_id,
+            expected_statuses=("launching",),
+            status="failed" if early_exit is not None else "running",
+            supervisor_pid=os.getpid(),
+            child_pid=child.pid,
+            last_exit_code=int(early_exit) if early_exit is not None else None,
+        )
+    if early_exit is not None or not recorded:
+        if early_exit is None:
+            click_process.terminate_process_group(child)
+        return int(early_exit or 2)
+
+    started = time.monotonic()
+    stop_requested = False
+    while True:
+        exit_code = child.poll()
+        if exit_code is not None:
+            break
+        snapshot = service_snapshot(state_path, service_id)
+        if snapshot is None or snapshot.get("stop_requested") is True:
+            stop_requested = True
+            exit_code = click_process.terminate_process_group(child)
+            break
+        if time.monotonic() - started >= MANAGED_SERVICE_MAX_SECONDS:
+            stop_requested = True
+            exit_code = click_process.terminate_process_group(child)
+            break
+        time.sleep(0.2)
+
+    with click_state.state_lock():
+        record_service_fields(
+            state_path,
+            service_id,
+            expected_statuses=("running", "stopping", "launching"),
+            status="stopped" if stop_requested else "failed",
+            stop_requested=False,
+            child_pid=0,
+            supervisor_pid=0,
+            last_exit_code=int(exit_code or 0),
+        )
+    return int(exit_code or 0)
+
+
+def run_service_start(
+    arguments: list[str],
+    *,
+    validate_argv: ValidateArgv,
+    protocol_version: int,
+    runner_script: Path,
+) -> int:
+    if len(arguments) != 5:
+        sys.stderr.write(
+            "usage: click_gate.py run-service-start "
+            "<state> <id> <token> <cwd> <request>\n"
+        )
+        return 2
+    state_path = Path(arguments[0])
+    service_id, runner_token, cwd_raw, encoded = arguments[1:]
+    raw, error = _decode_encoded_request(encoded)
+    if error:
+        sys.stderr.write(f"{error}\n")
+        return 2
+    request, error = validate_request(
+        raw,
+        validate_argv=validate_argv,
+        protocol_version=protocol_version,
+    )
+    if error or request is None or request.get("action") != "start":
+        sys.stderr.write(f"{error or 'Managed service start request is invalid.'}\n")
+        return 2
+    with click_state.state_lock():
+        claim_error = claim_service_runner(
+            state_path,
+            service_id,
+            request,
+            cwd_raw,
+            runner_token,
+            supervisor=False,
+        )
+    if claim_error:
+        sys.stderr.write(f"{claim_error}\n")
+        return 2
+    supervisor = [
+        *_runner_prefix("run-service-supervisor", runner_script),
+        str(state_path.resolve()),
+        service_id,
+        runner_token,
+        cwd_raw,
+        encoded,
+    ]
+    try:
+        click_process.spawn_argv(
+            supervisor,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+        )
+    except OSError as exc:
+        with click_state.state_lock():
+            record_service_fields(
+                state_path,
+                service_id,
+                expected_statuses=("launching",),
+                status="failed",
+                last_exit_code=127,
+            )
+        sys.stderr.write(f"Click could not start the managed service supervisor: {exc}\n")
+        return 127
+    deadline = time.monotonic() + SERVICE_START_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        snapshot = service_snapshot(state_path, service_id)
+        if snapshot is None:
+            return 2
+        if snapshot.get("status") == "running":
+            sys.stdout.write("Click managed service started\n")
+            return 0
+        if snapshot.get("status") == "failed":
+            sys.stderr.write("Click managed service exited during startup.\n")
+            return int(snapshot.get("last_exit_code") or 2)
+        if snapshot.get("status") in {"stopping", "stopped"}:
+            return 2
+        time.sleep(0.05)
+    with click_state.state_lock():
+        record_service_fields(
+            state_path,
+            service_id,
+            expected_statuses=("launching", "starting"),
+            status="stopping",
+            stop_requested=True,
+        )
+    sys.stderr.write("Click managed service did not start within its bounded timeout.\n")
+    return 2
+
+
+def run_service_stop(
+    arguments: list[str], *, snapshot_reader: SnapshotReader | None = None
+) -> int:
+    if len(arguments) != 2:
+        sys.stderr.write("usage: click_gate.py run-service-stop <state> <id>\n")
+        return 2
+    state_path = Path(arguments[0])
+    service_id = arguments[1]
+    reader = snapshot_reader or service_snapshot
+    deadline = time.monotonic() + SERVICE_STOP_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        snapshot = reader(state_path, service_id)
+        if snapshot is not None and snapshot.get("status") in {
+            "failed",
+            "idle",
+            "stopped",
+        }:
+            sys.stdout.write("Click managed service stopped\n")
+            return 0
+        time.sleep(0.05)
+    sys.stderr.write("Click managed service did not stop within its bounded timeout.\n")
+    return 2

--- a/scripts/build_antigravity_distribution.py
+++ b/scripts/build_antigravity_distribution.py
@@ -21,6 +21,7 @@ HOOK_FILES = (
     "click_evidence.py",
     "click_host_coverage.py",
     "click_process.py",
+    "click_service.py",
     "click_state.py",
     "click_gate.py",
     "platform_protocol.py",

--- a/tests/repository_policy_core.py
+++ b/tests/repository_policy_core.py
@@ -511,6 +511,7 @@ class RepositoryPolicyTests(unittest.TestCase):
                 "click_host_coverage.py",
                 "click_gate.py",
                 "click_process.py",
+                "click_service.py",
                 "click_state.py",
                 "click_verification_meter.py",
                 "click_verification_policy.py",
@@ -534,6 +535,36 @@ class RepositoryPolicyTests(unittest.TestCase):
             with self.subTest(forbidden=forbidden):
                 self.assertNotIn(f"import {forbidden}", process)
                 self.assertNotIn(f"from {forbidden}", process)
+
+    def test_managed_service_lifecycle_is_isolated_from_gate_policy(self) -> None:
+        gate = (ROOT / "hooks" / "click_gate.py").read_text(encoding="utf-8")
+        service = (ROOT / "hooks" / "click_service.py").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("click_service", gate)
+        for required in (
+            "def prepare_service(",
+            "def claim_service_runner(",
+            "def run_service_supervisor(",
+            "def run_service_start(",
+            "def run_service_stop(",
+        ):
+            with self.subTest(required=required):
+                self.assertIn(required, service)
+        for forbidden in (
+            "click_browser_advisory",
+            "click_contract",
+            "click_dependency_cache",
+            "click_evidence",
+            "click_gate",
+            "click_host_coverage",
+            "click_verification_meter",
+            "click_verification_policy",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(f"import {forbidden}", service)
+                self.assertNotIn(f"from {forbidden}", service)
 
     def test_evidence_ledger_is_isolated_from_gate_state_and_process(self) -> None:
         gate = (ROOT / "hooks" / "click_gate.py").read_text(encoding="utf-8")

--- a/tests/test_click_service.py
+++ b/tests/test_click_service.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+import unittest
+
+from hooks import click_gate, click_service
+
+
+class ClickServiceTests(unittest.TestCase):
+    def test_service_module_depends_only_on_state_and_process_runtime_leaves(self) -> None:
+        source = Path(click_service.__file__).read_text(encoding="utf-8")
+        imported: set[str] = set()
+        for node in ast.walk(ast.parse(source)):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                imported.add(module)
+                imported.update(
+                    f"{module}.{alias.name}".strip(".") for alias in node.names
+                )
+
+        for forbidden in (
+            "click_browser_advisory",
+            "click_contract",
+            "click_dependency_cache",
+            "click_evidence",
+            "click_gate",
+            "click_host_coverage",
+            "click_verification_meter",
+            "click_verification_policy",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertFalse(
+                    any(forbidden in name.split(".") for name in imported),
+                    imported,
+                )
+        self.assertIn("click_process", imported)
+        self.assertIn("click_state", imported)
+
+    def test_gate_keeps_service_compatibility_aliases(self) -> None:
+        aliases = {
+            "_fresh_service_state": click_service.fresh_state,
+            "_looks_like_managed_service": click_service.looks_like_managed_service,
+            "_request_service_stop": click_service.request_stop,
+            "_service_snapshot": click_service.service_snapshot,
+            "_record_service_fields": click_service.record_service_fields,
+            "_claim_service_runner": click_service.claim_service_runner,
+        }
+        for name, expected in aliases.items():
+            with self.subTest(name=name):
+                self.assertIs(getattr(click_gate, name), expected)
+
+        self.assertIs(
+            click_gate.SERVICE_REQUEST_FIELDS,
+            click_service.SERVICE_REQUEST_FIELDS,
+        )
+        self.assertEqual(
+            click_gate.SERVICE_START_TIMEOUT_SECONDS,
+            click_service.SERVICE_START_TIMEOUT_SECONDS,
+        )
+        self.assertEqual(
+            click_gate.SERVICE_STOP_TIMEOUT_SECONDS,
+            click_service.SERVICE_STOP_TIMEOUT_SECONDS,
+        )
+        self.assertEqual(
+            click_gate.MANAGED_SERVICE_MAX_SECONDS,
+            click_service.MANAGED_SERVICE_MAX_SECONDS,
+        )
+
+    def test_service_validation_preserves_exact_errors_and_normalization(self) -> None:
+        cases = (
+            ("{", "Managed service request must be valid JSON."),
+            ("[]", "Managed service request must be a JSON object."),
+            (
+                json.dumps({"version": 2, "action": "stop"}),
+                "Managed service request `version` must be 1.",
+            ),
+            (
+                json.dumps(
+                    {"version": 1, "action": "stop", "z": 1, "a": 2}
+                ),
+                "Managed service request contains unsupported field(s): `a`, `z`.",
+            ),
+            (
+                json.dumps({"version": 1, "action": "restart"}),
+                "Managed service `action` must be one of: start, stop.",
+            ),
+            (
+                json.dumps({"version": 1, "action": "stop", "argv": ["vite"]}),
+                "Managed service stop must omit `argv`.",
+            ),
+            (
+                json.dumps({"version": 1, "action": "start", "argv": ["echo"]}),
+                "Managed service start accepts a recognizable local development "
+                "server, not an arbitrary detached command.",
+            ),
+        )
+        for raw, expected in cases:
+            with self.subTest(expected=expected):
+                value, error = click_gate._validate_service_request(raw)
+                self.assertIsNone(value)
+                self.assertEqual(error, expected)
+
+        stop, error = click_gate._validate_service_request(
+            json.dumps({"version": 1, "action": "stop"})
+        )
+        self.assertEqual(error, "")
+        self.assertEqual(stop, {"version": 1, "action": "stop"})
+
+        start, error = click_gate._validate_service_request(
+            json.dumps({"version": 1, "action": "start", "argv": ["vite"]})
+        )
+        self.assertEqual(error, "")
+        self.assertEqual(
+            start,
+            {"version": 1, "action": "start", "argv": ["vite"]},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Extract managed local-service validation, state transitions, one-use claims, and supervisor lifecycle into hooks/click_service.py.
- Keep hooks/click_gate.py routing wrappers and compatibility aliases unchanged for callers.
- Bundle the new runtime in Antigravity and enforce the downward-only dependency boundary.

## Verification
- Full unittest suite: 363 tests passed, 3 platform-specific tests skipped.
- Distribution validation passed.
- Git diff whitespace validation passed.