### PR TITLE
Refactor Browser evidence runtime boundary

### DIFF
--- a/GUARD_CLASSIFICATION.md
+++ b/GUARD_CLASSIFICATION.md
@@ -19,7 +19,7 @@ not claim that every hard gate has already been moved to its target layer.
 | Canonical state paths, locks, atomic writes and authorized state-root recovery | `hooks/click_state.py` | Preserves approval state across failure without weakening identity checks |
 | Cancellation, expiry, consumed-runner and tampering revocation | `hooks/click_state.py`; lifecycle branches in `hooks/click_gate.py` | Prevents stale authority from becoming executable again |
 | Evidence registry identity, current-revision state and receipt matching | `hooks/click_evidence.py`; verification claim/result paths in `hooks/click_gate.py` | Prevents evidence from a different request or revision from completing work |
-| Browser source admission, serial-call interlock, stable host-call/result mapping, current revision and finalization replay | Browser receipt transitions in `hooks/click_gate.py` | Prevents an unassigned, parallel, mismatched, stale or replayed Browser result from completing evidence without judging the model's interaction strategy |
+| Browser source admission, serial-call interlock, stable host-call/result mapping, current revision and finalization replay | `hooks/click_browser.py`; host routing in `hooks/click_gate.py` | Prevents an unassigned, parallel, mismatched, stale or replayed Browser result from completing evidence without judging the model's interaction strategy |
 | Protected Git-tree, environment and executable fingerprints for argv verification; verification-time mutation detection | verification receipt helpers and runners in `hooks/click_gate.py` | Preserves the identity of the code and environment actually checked by Click's argv runner |
 | Opt-in dependency provider, relevant-entry and resolved-path receipts, plus approved mutation pre/post binding | `hooks/click_dependency_cache.py`; mutation-boundary and receipt transitions in `hooks/click_gate.py` | Allows cross-revision reuse without treating a model's post-approval assertion, unrelated manifest content, or later workspace drift as proof |
 | Direct-argv capability safety, executable/path/environment checks, process-control rejection and read-only side-effect defenses | capability constants and validators in `hooks/click_gate.py` | Prevents an admitted inspect, verify or service request from gaining unapproved effects |
@@ -67,8 +67,9 @@ not claim that every hard gate has already been moved to its target layer.
 - A verification command that observably changes protected repository content
   violates the read-only evidence boundary and remains `CORE`; limiting fresh
   retries of an ordinary failing argv check is `HEURISTIC`.
-- Browser source and current-revision accounting are `CORE` when the host event
-  is observable; duplicate-input and call-count tuning are `HEURISTIC`.
+- Browser source and current-revision accounting in `hooks/click_browser.py` are
+  `CORE` when the host event is observable; duplicate-input and call-count
+  tuning in `hooks/click_browser_advisory.py` are `HEURISTIC`.
 - The contract digest and approval identity are `CORE`; required planning prose
   and judgments about whether a contract is concise are not.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,14 @@
 - Service request schema, error text, runner argv transport, digest and
   constant-time token bindings, timeout behavior, and public/private compatibility
   symbols remain unchanged. Antigravity bundles the same extracted runtime.
+- Browser source admission, serial `tool_use_id` interlocks, bounded attempt
+  receipts, PostToolUse result mapping, current-revision observation, and final
+  evidence transition now live in `click_browser.py`. The gate retains host
+  event routing and injects only cross-domain lifecycle predicates.
+- Browser timing and repeat suggestions remain non-authoritative in
+  `click_browser_advisory.py`; the extracted receipt runtime cannot emit a host
+  allow/deny decision. Existing state fields, exact error text, compatibility
+  helpers, retry compaction, and legacy running-entry handling are preserved.
 
 ## v0.32.0 — 2026-09-01
 

--- a/dist/antigravity/hooks/click_browser.py
+++ b/dist/antigravity/hooks/click_browser.py
@@ -1,0 +1,469 @@
+"""Browser evidence admission and result-receipt transitions for Click.
+
+This module owns observable Browser authorization: the assigned evidence source,
+serial tool_use_id binding, bounded receipt history, current revision, and
+PostToolUse result accounting. Workflow suggestions remain in the independent
+``click_browser_advisory`` leaf and cannot grant or deny Browser authority.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import hashlib
+import json
+import time
+from typing import Any
+
+if __package__:
+    from . import click_browser_advisory, click_evidence, click_state
+else:  # Executed directly from the bundled hooks directory.
+    import click_browser_advisory
+    import click_evidence
+    import click_state
+
+
+MAX_UNIQUE_INPUTS = 256
+RUNNING_TTL_SECONDS = 40
+
+
+ContractCompleted = Callable[[dict[str, Any]], bool]
+MutationRunning = Callable[[Any], bool]
+
+
+def _read_contract_state(event: dict[str, Any]) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            click_state.contract_path(event).read_text(encoding="utf-8")
+        )
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {"status": "none", "contract_digest": ""}
+    return value if isinstance(value, dict) else {"status": "none", "contract_digest": ""}
+
+
+def _read_turn_state(event: dict[str, Any]) -> dict[str, Any]:
+    try:
+        value = json.loads(click_state.state_path(event).read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {"status": "idle"}
+    return value if isinstance(value, dict) else {"status": "idle"}
+
+
+def _save_contract_state(event: dict[str, Any], state: dict[str, Any]) -> None:
+    state["updated_at"] = int(time.time())
+    click_state.write_json(click_state.contract_path(event), state)
+
+
+def _sources(
+    state: dict[str, Any], *, expected_contract_schema_version: int
+) -> dict[str, Any] | None:
+    return click_evidence.sources_from_state(
+        state,
+        expected_contract_schema_version=expected_contract_schema_version,
+    )
+
+
+def input_error(tool_input: Any) -> str:
+    if not isinstance(tool_input, dict):
+        return "Browser evidence requires an object tool input."
+    return ""
+
+
+def running_expires_at(tool_input: Any, started_at: float) -> float:
+    declared_seconds = (
+        click_browser_advisory.longest_declared_runtime_ms(tool_input) / 1000.0
+    )
+    return started_at + max(RUNNING_TTL_SECONDS, declared_seconds + 10.0)
+
+
+def running_entry_is_active(entry: Any, now: float) -> bool:
+    if isinstance(entry, (int, float)) and not isinstance(entry, bool):
+        return now - float(entry) <= RUNNING_TTL_SECONDS
+    if not isinstance(entry, dict):
+        return False
+    expires_at = entry.get("expires_at")
+    if isinstance(expires_at, (int, float)) and not isinstance(expires_at, bool):
+        return now <= float(expires_at)
+    started_at = entry.get("started_at")
+    return bool(
+        isinstance(started_at, (int, float))
+        and not isinstance(started_at, bool)
+        and now - float(started_at) <= RUNNING_TTL_SECONDS
+    )
+
+
+def _capability_digest(request: dict[str, Any]) -> str:
+    canonical = json.dumps(request, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def attempt_digest(tool_input: Any) -> str:
+    if isinstance(tool_input, dict) and isinstance(tool_input.get("code"), str):
+        code = str(tool_input["code"]).replace("\r\n", "\n").strip()
+        return _capability_digest({"code": code})
+    if isinstance(tool_input, dict):
+        semantic = {
+            key: value
+            for key, value in tool_input.items()
+            if key not in {"_meta", "annotations", "timeout", "timeout_ms"}
+        }
+        return _capability_digest({"tool_input": semantic})
+    return _capability_digest({"tool_input": tool_input})
+
+
+def response_failed(response: Any) -> bool:
+    if not isinstance(response, dict):
+        return True
+    if response.get("isError") is True or response.get("is_error") is True:
+        return True
+    if "status" in response:
+        status = str(response.get("status", "")).lower()
+        return status not in {
+            "complete",
+            "completed",
+            "ok",
+            "pass",
+            "passed",
+            "success",
+            "succeeded",
+        }
+
+    # MCP responses may omit a status while still returning structured content.
+    # Empty containers, empty strings, and null acknowledgements prove nothing.
+    def meaningful(value: Any) -> bool:
+        if value is None:
+            return False
+        if isinstance(value, str):
+            return bool(value.strip())
+        if isinstance(value, (bytes, bytearray)):
+            return bool(value)
+        if isinstance(value, dict):
+            metadata_keys = {
+                "_meta",
+                "annotations",
+                "mimeType",
+                "mime_type",
+                "role",
+                "type",
+            }
+            return any(
+                meaningful(item)
+                for key, item in value.items()
+                if key not in metadata_keys
+            )
+        if isinstance(value, (list, tuple, set)):
+            return any(meaningful(item) for item in value)
+        return True
+
+    return not any(
+        meaningful(response.get(key)) for key in {"content", "output", "result"}
+    )
+
+
+def prepare(
+    event: dict[str, Any],
+    *,
+    expected_contract_schema_version: int,
+    contract_is_completed: ContractCompleted,
+    mutation_is_running: MutationRunning,
+) -> tuple[bool, str, str]:
+    state = _read_contract_state(event)
+    if state.get("status") not in {"staged", "approved"}:
+        return False, "", ""
+    if state.get("status") != "approved":
+        return (
+            True,
+            "Approve the staged Click contract before collecting browser evidence.",
+            "",
+        )
+    if contract_is_completed(state):
+        if _read_turn_state(event).get("status") != "passed":
+            return False, "", ""
+        return (
+            True,
+            "The approved Click contract is complete. Reuse its evidence instead of "
+            "starting a shadow browser verification session.",
+            "",
+        )
+    external = state.get("external_evidence")
+    if not isinstance(external, dict) or external.get("browser_required") is not True:
+        return (
+            True,
+            "Browser work has no referenced verification evidence source with kind "
+            "`browser` in this contract. Use the cheaper assigned source instead of "
+            "adding shadow verification.",
+            "",
+        )
+    sources = _sources(
+        state,
+        expected_contract_schema_version=expected_contract_schema_version,
+    )
+    if sources is None:
+        return (
+            True,
+            "This active contract predates evidence-id completion tracking. Cancel it, "
+            "stage the proposal again, and obtain fresh approval.",
+            "",
+        )
+    source_key = str(external.get("browser_source_key", ""))
+    source = sources.get(source_key) if sources else None
+    if not isinstance(source, dict) or source.get("kind") != "browser":
+        return True, "Click Browser evidence state is unavailable or malformed.", ""
+    mutation = state.get("mutation")
+    if mutation_is_running(mutation):
+        return (
+            True,
+            "Wait for the structured mutation to finish before browser evidence.",
+            "",
+        )
+    verification = state.get("verification")
+    if isinstance(verification, dict) and verification.get("status") == "running":
+        return (
+            True,
+            "Wait for the final argv verification batch before browser evidence.",
+            "",
+        )
+    revision = (
+        int(verification.get("mutation_revision", 0))
+        if isinstance(verification, dict)
+        else 0
+    )
+    if click_evidence.is_current(source, revision):
+        return (
+            True,
+            "The assigned Browser evidence already completed for the current revision. "
+            "Reuse it instead of replaying the session.",
+            "",
+        )
+    running = external.get("browser_running")
+    if isinstance(running, dict) and running:
+        already_observed = bool(
+            external.get("browser_status") == "observed"
+            or source.get("status") == "observed"
+        )
+        now = time.time()
+        if any(
+            running_entry_is_active(running_entry, now)
+            for running_entry in running.values()
+        ):
+            return (
+                True,
+                "One browser evidence call is already running; keep the session serial.",
+                "",
+            )
+        attempts = external.get("browser_attempts")
+        if not isinstance(attempts, dict):
+            attempts = {}
+        for running_entry in running.values():
+            if not isinstance(running_entry, dict):
+                continue
+            digest = str(running_entry.get("attempt_digest", ""))
+            attempt = attempts.get(digest)
+            if isinstance(attempt, dict) and attempt.get("status") == "running":
+                attempt["status"] = "failed"
+                attempt["failed_attempts"] = int(
+                    attempt.get("failed_attempts", 0)
+                ) + 1
+        external["browser_running"] = {}
+        external["browser_attempts"] = attempts
+        external["browser_status"] = "observed" if already_observed else "failed"
+        external["last_browser_error"] = "post-tool-timeout"
+        if not already_observed:
+            source["status"] = "failed"
+            source["verified_revision"] = -1
+            source["last_exit_code"] = 124
+        state["external_evidence"] = external
+        _save_contract_state(event, state)
+    tool_input_error = input_error(event.get("tool_input"))
+    if tool_input_error:
+        return True, tool_input_error, ""
+    advisories = list(
+        click_browser_advisory.input_advisories(event.get("tool_input"))
+    )
+    tool_use_id = str(event.get("tool_use_id", ""))
+    if not tool_use_id:
+        return (
+            True,
+            "Browser evidence requires a stable tool_use_id for PostToolUse accounting.",
+            "",
+        )
+    digest = attempt_digest(event.get("tool_input"))
+    attempts = external.get("browser_attempts")
+    if not isinstance(attempts, dict):
+        attempts = {}
+    prior_attempt = attempts.get(digest)
+    repeat_advisory = click_browser_advisory.repeat_advisory(prior_attempt)
+    if repeat_advisory:
+        advisories.append(repeat_advisory)
+    unchanged_retries = 0
+    if isinstance(prior_attempt, dict):
+        prior_status = str(prior_attempt.get("status", ""))
+        unchanged_retries = int(prior_attempt.get("unchanged_retries", 0))
+        if prior_status in {"failed", "incomplete"}:
+            unchanged_retries += 1
+    previous_successes = (
+        int(prior_attempt.get("successful_attempts", 0))
+        if isinstance(prior_attempt, dict)
+        else 0
+    )
+    if (
+        isinstance(prior_attempt, dict)
+        and prior_attempt.get("status") == "success"
+        and previous_successes == 0
+    ):
+        previous_successes = 1
+    previous_failures = (
+        int(prior_attempt.get("failed_attempts", 0))
+        if isinstance(prior_attempt, dict)
+        else 0
+    )
+    if isinstance(prior_attempt, dict):
+        attempts.pop(digest, None)
+    compacted = False
+    while len(attempts) >= MAX_UNIQUE_INPUTS:
+        attempts.pop(next(iter(attempts)))
+        compacted = True
+    if compacted:
+        advisories.append(
+            "Click advisory: older Browser attempt guidance was compacted to keep "
+            "receipt state bounded. This call remains tracked, and the current source "
+            "and revision receipt are unchanged."
+        )
+    already_observed = bool(
+        external.get("browser_status") == "observed"
+        or source.get("status") == "observed"
+    )
+    attempts[digest] = {
+        "status": "running",
+        "attempts": int(prior_attempt.get("attempts", 0)) + 1
+        if isinstance(prior_attempt, dict)
+        else 1,
+        "unchanged_retries": unchanged_retries,
+        "successful_attempts": previous_successes,
+        "failed_attempts": previous_failures,
+    }
+    calls = int(external.get("browser_calls", 0))
+    external["browser_calls"] = calls + 1
+    external["browser_status"] = "observed" if already_observed else "running"
+    started_at = time.time()
+    external["browser_running"] = {
+        tool_use_id: {
+            "started_at": started_at,
+            "expires_at": running_expires_at(event.get("tool_input"), started_at),
+            "attempt_digest": digest,
+        }
+    }
+    external["browser_attempts"] = attempts
+    external["last_browser_error"] = ""
+    if not already_observed:
+        source["status"] = "running"
+    state["external_evidence"] = external
+    _save_contract_state(event, state)
+    return True, "", "\n".join(advisories)
+
+
+def record_result(
+    event: dict[str, Any], *, expected_contract_schema_version: int
+) -> None:
+    state = _read_contract_state(event)
+    if state.get("status") != "approved":
+        return
+    external = state.get("external_evidence")
+    if not isinstance(external, dict):
+        return
+    running = external.get("browser_running")
+    tool_use_id = str(event.get("tool_use_id", ""))
+    if not isinstance(running, dict) or tool_use_id not in running:
+        return
+    running_entry = running.pop(tool_use_id)
+    if isinstance(running_entry, dict):
+        started_at = float(running_entry.get("started_at", 0.0))
+        digest = str(running_entry.get("attempt_digest", ""))
+    else:
+        started_at = float(running_entry)
+        digest = attempt_digest(event.get("tool_input"))
+    duration = max(0.0, time.time() - started_at)
+    total = float(external.get("browser_seconds", 0.0)) + duration
+    external["browser_seconds"] = round(total, 3)
+    external["browser_running"] = running
+    sources = _sources(
+        state,
+        expected_contract_schema_version=expected_contract_schema_version,
+    )
+    source_key = str(external.get("browser_source_key", ""))
+    source = sources.get(source_key) if sources else None
+    verification = state.get("verification")
+    revision = (
+        int(verification.get("mutation_revision", 0))
+        if isinstance(verification, dict)
+        else 0
+    )
+    attempts = external.get("browser_attempts")
+    if not isinstance(attempts, dict):
+        attempts = {}
+    attempt = attempts.get(digest)
+    if not isinstance(attempt, dict):
+        attempt = {
+            "attempts": 1,
+            "unchanged_retries": 0,
+            "successful_attempts": 0,
+            "failed_attempts": 0,
+        }
+        attempts[digest] = attempt
+    if response_failed(event.get("tool_response")):
+        attempt["status"] = "failed"
+        attempt["failed_attempts"] = int(attempt.get("failed_attempts", 0)) + 1
+        already_observed = bool(
+            external.get("browser_status") == "observed"
+            or isinstance(source, dict)
+            and source.get("status") == "observed"
+        )
+        external["browser_status"] = "observed" if already_observed else "failed"
+        external["last_browser_error"] = "tool-error"
+        if isinstance(source, dict) and not already_observed:
+            source["status"] = "failed"
+            source["verified_revision"] = -1
+            source["last_exit_code"] = 1
+    else:
+        attempt["status"] = "success"
+        attempt["successful_attempts"] = int(
+            attempt.get("successful_attempts", 0)
+        ) + 1
+        external["browser_status"] = "observed"
+        external["last_browser_error"] = ""
+        if isinstance(source, dict):
+            source["status"] = "observed"
+            source["verified_revision"] = revision
+            source["last_exit_code"] = 0
+    external["browser_attempts"] = attempts
+    state["external_evidence"] = external
+    _save_contract_state(event, state)
+
+
+def finalize_evidence(
+    state: dict[str, Any],
+    *,
+    evidence_id: str,
+    source_key: str,
+    source: dict[str, Any],
+    revision: int,
+) -> str:
+    external = state.get("external_evidence")
+    browser_running = (
+        external.get("browser_running") if isinstance(external, dict) else None
+    )
+    if isinstance(browser_running, dict) and browser_running:
+        return "Wait for the running Browser interaction before finalizing evidence."
+    if (
+        not isinstance(external, dict)
+        or external.get("browser_source_key") != source_key
+        or external.get("browser_status") != "observed"
+        or source.get("status") != "observed"
+        or int(source.get("verified_revision", -1)) != revision
+    ):
+        return (
+            f"Browser evidence `{evidence_id}` can complete only after a successful "
+            "current-revision Browser call in its metered session."
+        )
+    external["browser_status"] = "passed"
+    state["external_evidence"] = external
+    return ""

--- a/dist/antigravity/hooks/click_gate.py
+++ b/dist/antigravity/hooks/click_gate.py
@@ -33,6 +33,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 if __package__:
     from . import (
+        click_browser,
         click_browser_advisory,
         click_contract,
         click_dependency_cache,
@@ -60,6 +61,7 @@ if __package__:
     )
     from .platform_protocol import CodexOutputAdapter, HookOutputAdapter
 else:  # Executed directly from the bundled hooks directory.
+    import click_browser
     import click_browser_advisory
     import click_contract
     import click_dependency_cache
@@ -118,6 +120,15 @@ _request_service_stop = click_service.request_stop
 _service_snapshot = click_service.service_snapshot
 _record_service_fields = click_service.record_service_fields
 _claim_service_runner = click_service.claim_service_runner
+
+# Compatibility aliases for Browser receipt helpers. Admission and PostToolUse
+# state transitions live in click_browser; the gate keeps only host routing and
+# supplies cross-domain lifecycle predicates.
+_browser_input_error = click_browser.input_error
+_browser_running_expires_at = click_browser.running_expires_at
+_browser_running_entry_is_active = click_browser.running_entry_is_active
+_browser_attempt_digest = click_browser.attempt_digest
+_tool_response_failed = click_browser.response_failed
 
 
 CONTROL_COMMAND = "click-gate"
@@ -182,14 +193,14 @@ MAX_INSPECTION_COMMANDS = 8
 MAX_ARGV_ITEMS = 128
 MAX_OBSERVATION_OUTPUT_BYTES = 48_000
 MAX_OBSERVATION_ENTRIES = 64
-MAX_BROWSER_UNIQUE_INPUTS = 256
+MAX_BROWSER_UNIQUE_INPUTS = click_browser.MAX_UNIQUE_INPUTS
 # Compatibility names for callers that previously treated these advisory
 # thresholds as hard maxima.
 MAX_BROWSER_TOOL_TIMEOUT_MS = (
     click_browser_advisory.RECOMMENDED_BROWSER_TOOL_TIMEOUT_MS
 )
 MAX_BROWSER_WAIT_MS = click_browser_advisory.RECOMMENDED_BROWSER_WAIT_MS
-BROWSER_RUNNING_TTL_SECONDS = 40
+BROWSER_RUNNING_TTL_SECONDS = click_browser.RUNNING_TTL_SECONDS
 OBSERVATION_RESERVATION_TTL_SECONDS = 30
 MUTATION_RUNNING_TTL_SECONDS = 10 * 60
 VERIFY_RUNNING_TTL_SECONDS = 60 * 60
@@ -2779,28 +2790,15 @@ def _record_evidence_completion(event: dict[str, Any], raw: str) -> tuple[str, s
             "reuse it instead of recording it twice.",
         )
     if kind == "browser":
-        external = state.get("external_evidence")
-        browser_running = (
-            external.get("browser_running")
-            if isinstance(external, dict)
-            else None
+        browser_error = click_browser.finalize_evidence(
+            state,
+            evidence_id=evidence_id,
+            source_key=source_key,
+            source=source,
+            revision=revision,
         )
-        if isinstance(browser_running, dict) and browser_running:
-            return "", "Wait for the running Browser interaction before finalizing evidence."
-        if (
-            not isinstance(external, dict)
-            or external.get("browser_source_key") != source_key
-            or external.get("browser_status") != "observed"
-            or source.get("status") != "observed"
-            or int(source.get("verified_revision", -1)) != revision
-        ):
-            return (
-                "",
-                f"Browser evidence `{evidence_id}` can complete only after a successful "
-                "current-revision Browser call in its metered session.",
-            )
-        external["browser_status"] = "passed"
-        state["external_evidence"] = external
+        if browser_error:
+            return "", browser_error
     elif kind not in {"hosted", "manual", "existing"}:
         return "", f"Evidence `{evidence_id}` has unsupported completion kind `{kind}`."
 
@@ -3509,291 +3507,13 @@ def _is_plan_tool(tool_name: str) -> bool:
     return normalized.split("__")[-1] == "update_plan"
 
 
-def _browser_input_error(tool_input: Any) -> str:
-    if not isinstance(tool_input, dict):
-        return "Browser evidence requires an object tool input."
-    return ""
-
-
-def _browser_running_expires_at(tool_input: Any, started_at: float) -> float:
-    declared_seconds = (
-        click_browser_advisory.longest_declared_runtime_ms(tool_input) / 1000.0
-    )
-    return started_at + max(BROWSER_RUNNING_TTL_SECONDS, declared_seconds + 10.0)
-
-
-def _browser_running_entry_is_active(entry: Any, now: float) -> bool:
-    if isinstance(entry, (int, float)) and not isinstance(entry, bool):
-        return now - float(entry) <= BROWSER_RUNNING_TTL_SECONDS
-    if not isinstance(entry, dict):
-        return False
-    expires_at = entry.get("expires_at")
-    if isinstance(expires_at, (int, float)) and not isinstance(expires_at, bool):
-        return now <= float(expires_at)
-    started_at = entry.get("started_at")
-    return bool(
-        isinstance(started_at, (int, float))
-        and not isinstance(started_at, bool)
-        and now - float(started_at) <= BROWSER_RUNNING_TTL_SECONDS
-    )
-
-
-def _browser_attempt_digest(tool_input: Any) -> str:
-    if isinstance(tool_input, dict) and isinstance(tool_input.get("code"), str):
-        code = str(tool_input["code"]).replace("\r\n", "\n").strip()
-        return _capability_digest({"code": code})
-    if isinstance(tool_input, dict):
-        semantic = {
-            key: value
-            for key, value in tool_input.items()
-            if key not in {"_meta", "annotations", "timeout", "timeout_ms"}
-        }
-        return _capability_digest({"tool_input": semantic})
-    return _capability_digest({"tool_input": tool_input})
-
-
-def _tool_response_failed(response: Any) -> bool:
-    if not isinstance(response, dict):
-        return True
-    if response.get("isError") is True or response.get("is_error") is True:
-        return True
-    if "status" in response:
-        status = str(response.get("status", "")).lower()
-        return status not in {
-            "complete",
-            "completed",
-            "ok",
-            "pass",
-            "passed",
-            "success",
-            "succeeded",
-        }
-    # MCP responses may omit a status while still returning structured content.
-    # Empty containers, empty strings, and null acknowledgements prove nothing.
-    def meaningful(value: Any) -> bool:
-        if value is None:
-            return False
-        if isinstance(value, str):
-            return bool(value.strip())
-        if isinstance(value, (bytes, bytearray)):
-            return bool(value)
-        if isinstance(value, dict):
-            metadata_keys = {
-                "_meta",
-                "annotations",
-                "mimeType",
-                "mime_type",
-                "role",
-                "type",
-            }
-            return any(
-                meaningful(item)
-                for key, item in value.items()
-                if key not in metadata_keys
-            )
-        if isinstance(value, (list, tuple, set)):
-            return any(meaningful(item) for item in value)
-        return True
-
-    return not any(
-        meaningful(response.get(key)) for key in {"content", "output", "result"}
-    )
-
-
 def _prepare_browser_evidence(event: dict[str, Any]) -> tuple[bool, str, str]:
-    state = _read_contract_state(event)
-    if state.get("status") not in {"staged", "approved"}:
-        return False, "", ""
-    if state.get("status") != "approved":
-        return (
-            True,
-            "Approve the staged Click contract before collecting browser evidence.",
-            "",
-        )
-    if _contract_is_completed(state):
-        if _read_state(event).get("status") != "passed":
-            return False, "", ""
-        return (
-            True,
-            "The approved Click contract is complete. Reuse its evidence instead of "
-            "starting a shadow browser verification session.",
-            "",
-        )
-    external = state.get("external_evidence")
-    if not isinstance(external, dict) or external.get("browser_required") is not True:
-        return (
-            True,
-            "Browser work has no referenced verification evidence source with kind "
-            "`browser` in this contract. Use the cheaper assigned source instead of "
-            "adding shadow verification.",
-            "",
-        )
-    sources = _evidence_sources(state)
-    if sources is None:
-        return (
-            True,
-            "This active contract predates evidence-id completion tracking. Cancel it, "
-            "stage the proposal again, and obtain fresh approval.",
-            "",
-        )
-    source_key = str(external.get("browser_source_key", ""))
-    source = sources.get(source_key) if sources else None
-    if not isinstance(source, dict) or source.get("kind") != "browser":
-        return True, "Click Browser evidence state is unavailable or malformed.", ""
-    mutation = state.get("mutation")
-    if _mutation_is_running(mutation):
-        return (
-            True,
-            "Wait for the structured mutation to finish before browser evidence.",
-            "",
-        )
-    verification = state.get("verification")
-    if isinstance(verification, dict) and verification.get("status") == "running":
-        return (
-            True,
-            "Wait for the final argv verification batch before browser evidence.",
-            "",
-        )
-    revision = (
-        int(verification.get("mutation_revision", 0))
-        if isinstance(verification, dict)
-        else 0
+    return click_browser.prepare(
+        event,
+        expected_contract_schema_version=CONTRACT_STATE_SCHEMA_VERSION,
+        contract_is_completed=_contract_is_completed,
+        mutation_is_running=_mutation_is_running,
     )
-    if _evidence_is_current(source, revision):
-        return (
-            True,
-            "The assigned Browser evidence already completed for the current revision. "
-            "Reuse it instead of replaying the session.",
-            "",
-        )
-    running = external.get("browser_running")
-    if isinstance(running, dict) and running:
-        already_observed = bool(
-            external.get("browser_status") == "observed"
-            or source.get("status") == "observed"
-        )
-        now = time.time()
-        if any(
-            _browser_running_entry_is_active(running_entry, now)
-            for running_entry in running.values()
-        ):
-            return (
-                True,
-                "One browser evidence call is already running; keep the session serial.",
-                "",
-            )
-        attempts = external.get("browser_attempts")
-        if not isinstance(attempts, dict):
-            attempts = {}
-        for running_entry in running.values():
-            if not isinstance(running_entry, dict):
-                continue
-            attempt_digest = str(running_entry.get("attempt_digest", ""))
-            attempt = attempts.get(attempt_digest)
-            if isinstance(attempt, dict) and attempt.get("status") == "running":
-                attempt["status"] = "failed"
-                attempt["failed_attempts"] = int(
-                    attempt.get("failed_attempts", 0)
-                ) + 1
-        external["browser_running"] = {}
-        external["browser_attempts"] = attempts
-        external["browser_status"] = "observed" if already_observed else "failed"
-        external["last_browser_error"] = "post-tool-timeout"
-        if not already_observed:
-            source["status"] = "failed"
-            source["verified_revision"] = -1
-            source["last_exit_code"] = 124
-        state["external_evidence"] = external
-        _save_contract_state(event, state)
-    input_error = _browser_input_error(event.get("tool_input"))
-    if input_error:
-        return True, input_error, ""
-    advisories = list(
-        click_browser_advisory.input_advisories(event.get("tool_input"))
-    )
-    tool_use_id = str(event.get("tool_use_id", ""))
-    if not tool_use_id:
-        return (
-            True,
-            "Browser evidence requires a stable tool_use_id for PostToolUse accounting.",
-            "",
-        )
-    attempt_digest = _browser_attempt_digest(event.get("tool_input"))
-    attempts = external.get("browser_attempts")
-    if not isinstance(attempts, dict):
-        attempts = {}
-    prior_attempt = attempts.get(attempt_digest)
-    repeat_advisory = click_browser_advisory.repeat_advisory(prior_attempt)
-    if repeat_advisory:
-        advisories.append(repeat_advisory)
-    unchanged_retries = 0
-    if isinstance(prior_attempt, dict):
-        prior_status = str(prior_attempt.get("status", ""))
-        unchanged_retries = int(prior_attempt.get("unchanged_retries", 0))
-        if prior_status in {"failed", "incomplete"}:
-            unchanged_retries += 1
-    previous_successes = (
-        int(prior_attempt.get("successful_attempts", 0))
-        if isinstance(prior_attempt, dict)
-        else 0
-    )
-    if (
-        isinstance(prior_attempt, dict)
-        and prior_attempt.get("status") == "success"
-        and previous_successes == 0
-    ):
-        previous_successes = 1
-    previous_failures = (
-        int(prior_attempt.get("failed_attempts", 0))
-        if isinstance(prior_attempt, dict)
-        else 0
-    )
-    if isinstance(prior_attempt, dict):
-        attempts.pop(attempt_digest, None)
-    compacted = False
-    while len(attempts) >= MAX_BROWSER_UNIQUE_INPUTS:
-        attempts.pop(next(iter(attempts)))
-        compacted = True
-    if compacted:
-        advisories.append(
-            "Click advisory: older Browser attempt guidance was compacted to keep "
-            "receipt state bounded. This call remains tracked, and the current source "
-            "and revision receipt are unchanged."
-        )
-    already_observed = bool(
-        external.get("browser_status") == "observed"
-        or source.get("status") == "observed"
-    )
-    attempts[attempt_digest] = {
-        "status": "running",
-        "attempts": int(prior_attempt.get("attempts", 0)) + 1
-        if isinstance(prior_attempt, dict)
-        else 1,
-        "unchanged_retries": unchanged_retries,
-        "successful_attempts": previous_successes,
-        "failed_attempts": previous_failures,
-    }
-    calls = int(external.get("browser_calls", 0))
-    external["browser_calls"] = calls + 1
-    external["browser_status"] = "observed" if already_observed else "running"
-    started_at = time.time()
-    external["browser_running"] = {
-        tool_use_id: {
-            "started_at": started_at,
-            "expires_at": _browser_running_expires_at(
-                event.get("tool_input"), started_at
-            ),
-            "attempt_digest": attempt_digest,
-        }
-    }
-    external["browser_attempts"] = attempts
-    external["last_browser_error"] = ""
-    if not already_observed:
-        source["status"] = "running"
-    state["external_evidence"] = external
-    _save_contract_state(event, state)
-    return True, "", "\n".join(advisories)
-
 
 def _record_mutation_boundary(event: dict[str, Any]) -> None:
     state = _read_contract_state(event)
@@ -3829,77 +3549,10 @@ def _handle_post_tool(event: dict[str, Any]) -> None:
     if str(event.get("tool_name", "")) not in BROWSER_TOOL_NAMES:
         _record_mutation_boundary(event)
         return
-    state = _read_contract_state(event)
-    if state.get("status") != "approved":
-        return
-    external = state.get("external_evidence")
-    if not isinstance(external, dict):
-        return
-    running = external.get("browser_running")
-    tool_use_id = str(event.get("tool_use_id", ""))
-    if not isinstance(running, dict) or tool_use_id not in running:
-        return
-    running_entry = running.pop(tool_use_id)
-    if isinstance(running_entry, dict):
-        started_at = float(running_entry.get("started_at", 0.0))
-        attempt_digest = str(running_entry.get("attempt_digest", ""))
-    else:
-        started_at = float(running_entry)
-        attempt_digest = _browser_attempt_digest(event.get("tool_input"))
-    duration = max(0.0, time.time() - started_at)
-    total = float(external.get("browser_seconds", 0.0)) + duration
-    external["browser_seconds"] = round(total, 3)
-    external["browser_running"] = running
-    sources = _evidence_sources(state)
-    source_key = str(external.get("browser_source_key", ""))
-    source = sources.get(source_key) if sources else None
-    verification = state.get("verification")
-    revision = (
-        int(verification.get("mutation_revision", 0))
-        if isinstance(verification, dict)
-        else 0
+    click_browser.record_result(
+        event,
+        expected_contract_schema_version=CONTRACT_STATE_SCHEMA_VERSION,
     )
-    attempts = external.get("browser_attempts")
-    if not isinstance(attempts, dict):
-        attempts = {}
-    attempt = attempts.get(attempt_digest)
-    if not isinstance(attempt, dict):
-        attempt = {
-            "attempts": 1,
-            "unchanged_retries": 0,
-            "successful_attempts": 0,
-            "failed_attempts": 0,
-        }
-        attempts[attempt_digest] = attempt
-    if _tool_response_failed(event.get("tool_response")):
-        attempt["status"] = "failed"
-        attempt["failed_attempts"] = int(attempt.get("failed_attempts", 0)) + 1
-        already_observed = bool(
-            external.get("browser_status") == "observed"
-            or isinstance(source, dict)
-            and source.get("status") == "observed"
-        )
-        external["browser_status"] = "observed" if already_observed else "failed"
-        external["last_browser_error"] = "tool-error"
-        if isinstance(source, dict) and not already_observed:
-            source["status"] = "failed"
-            source["verified_revision"] = -1
-            source["last_exit_code"] = 1
-    else:
-        attempt["status"] = "success"
-        attempt["successful_attempts"] = int(
-            attempt.get("successful_attempts", 0)
-        ) + 1
-        external["browser_status"] = "observed"
-        external["last_browser_error"] = ""
-        if isinstance(source, dict):
-            source["status"] = "observed"
-            source["verified_revision"] = revision
-            source["last_exit_code"] = 0
-    external["browser_attempts"] = attempts
-    state["external_evidence"] = external
-    _save_contract_state(event, state)
-
 
 def _handle_prompt_submit(event: dict[str, Any]) -> None:
     _prune_state()

--- a/hooks/click_browser.py
+++ b/hooks/click_browser.py
@@ -1,0 +1,469 @@
+"""Browser evidence admission and result-receipt transitions for Click.
+
+This module owns observable Browser authorization: the assigned evidence source,
+serial tool_use_id binding, bounded receipt history, current revision, and
+PostToolUse result accounting. Workflow suggestions remain in the independent
+``click_browser_advisory`` leaf and cannot grant or deny Browser authority.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+import hashlib
+import json
+import time
+from typing import Any
+
+if __package__:
+    from . import click_browser_advisory, click_evidence, click_state
+else:  # Executed directly from the bundled hooks directory.
+    import click_browser_advisory
+    import click_evidence
+    import click_state
+
+
+MAX_UNIQUE_INPUTS = 256
+RUNNING_TTL_SECONDS = 40
+
+
+ContractCompleted = Callable[[dict[str, Any]], bool]
+MutationRunning = Callable[[Any], bool]
+
+
+def _read_contract_state(event: dict[str, Any]) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            click_state.contract_path(event).read_text(encoding="utf-8")
+        )
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {"status": "none", "contract_digest": ""}
+    return value if isinstance(value, dict) else {"status": "none", "contract_digest": ""}
+
+
+def _read_turn_state(event: dict[str, Any]) -> dict[str, Any]:
+    try:
+        value = json.loads(click_state.state_path(event).read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {"status": "idle"}
+    return value if isinstance(value, dict) else {"status": "idle"}
+
+
+def _save_contract_state(event: dict[str, Any], state: dict[str, Any]) -> None:
+    state["updated_at"] = int(time.time())
+    click_state.write_json(click_state.contract_path(event), state)
+
+
+def _sources(
+    state: dict[str, Any], *, expected_contract_schema_version: int
+) -> dict[str, Any] | None:
+    return click_evidence.sources_from_state(
+        state,
+        expected_contract_schema_version=expected_contract_schema_version,
+    )
+
+
+def input_error(tool_input: Any) -> str:
+    if not isinstance(tool_input, dict):
+        return "Browser evidence requires an object tool input."
+    return ""
+
+
+def running_expires_at(tool_input: Any, started_at: float) -> float:
+    declared_seconds = (
+        click_browser_advisory.longest_declared_runtime_ms(tool_input) / 1000.0
+    )
+    return started_at + max(RUNNING_TTL_SECONDS, declared_seconds + 10.0)
+
+
+def running_entry_is_active(entry: Any, now: float) -> bool:
+    if isinstance(entry, (int, float)) and not isinstance(entry, bool):
+        return now - float(entry) <= RUNNING_TTL_SECONDS
+    if not isinstance(entry, dict):
+        return False
+    expires_at = entry.get("expires_at")
+    if isinstance(expires_at, (int, float)) and not isinstance(expires_at, bool):
+        return now <= float(expires_at)
+    started_at = entry.get("started_at")
+    return bool(
+        isinstance(started_at, (int, float))
+        and not isinstance(started_at, bool)
+        and now - float(started_at) <= RUNNING_TTL_SECONDS
+    )
+
+
+def _capability_digest(request: dict[str, Any]) -> str:
+    canonical = json.dumps(request, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+def attempt_digest(tool_input: Any) -> str:
+    if isinstance(tool_input, dict) and isinstance(tool_input.get("code"), str):
+        code = str(tool_input["code"]).replace("\r\n", "\n").strip()
+        return _capability_digest({"code": code})
+    if isinstance(tool_input, dict):
+        semantic = {
+            key: value
+            for key, value in tool_input.items()
+            if key not in {"_meta", "annotations", "timeout", "timeout_ms"}
+        }
+        return _capability_digest({"tool_input": semantic})
+    return _capability_digest({"tool_input": tool_input})
+
+
+def response_failed(response: Any) -> bool:
+    if not isinstance(response, dict):
+        return True
+    if response.get("isError") is True or response.get("is_error") is True:
+        return True
+    if "status" in response:
+        status = str(response.get("status", "")).lower()
+        return status not in {
+            "complete",
+            "completed",
+            "ok",
+            "pass",
+            "passed",
+            "success",
+            "succeeded",
+        }
+
+    # MCP responses may omit a status while still returning structured content.
+    # Empty containers, empty strings, and null acknowledgements prove nothing.
+    def meaningful(value: Any) -> bool:
+        if value is None:
+            return False
+        if isinstance(value, str):
+            return bool(value.strip())
+        if isinstance(value, (bytes, bytearray)):
+            return bool(value)
+        if isinstance(value, dict):
+            metadata_keys = {
+                "_meta",
+                "annotations",
+                "mimeType",
+                "mime_type",
+                "role",
+                "type",
+            }
+            return any(
+                meaningful(item)
+                for key, item in value.items()
+                if key not in metadata_keys
+            )
+        if isinstance(value, (list, tuple, set)):
+            return any(meaningful(item) for item in value)
+        return True
+
+    return not any(
+        meaningful(response.get(key)) for key in {"content", "output", "result"}
+    )
+
+
+def prepare(
+    event: dict[str, Any],
+    *,
+    expected_contract_schema_version: int,
+    contract_is_completed: ContractCompleted,
+    mutation_is_running: MutationRunning,
+) -> tuple[bool, str, str]:
+    state = _read_contract_state(event)
+    if state.get("status") not in {"staged", "approved"}:
+        return False, "", ""
+    if state.get("status") != "approved":
+        return (
+            True,
+            "Approve the staged Click contract before collecting browser evidence.",
+            "",
+        )
+    if contract_is_completed(state):
+        if _read_turn_state(event).get("status") != "passed":
+            return False, "", ""
+        return (
+            True,
+            "The approved Click contract is complete. Reuse its evidence instead of "
+            "starting a shadow browser verification session.",
+            "",
+        )
+    external = state.get("external_evidence")
+    if not isinstance(external, dict) or external.get("browser_required") is not True:
+        return (
+            True,
+            "Browser work has no referenced verification evidence source with kind "
+            "`browser` in this contract. Use the cheaper assigned source instead of "
+            "adding shadow verification.",
+            "",
+        )
+    sources = _sources(
+        state,
+        expected_contract_schema_version=expected_contract_schema_version,
+    )
+    if sources is None:
+        return (
+            True,
+            "This active contract predates evidence-id completion tracking. Cancel it, "
+            "stage the proposal again, and obtain fresh approval.",
+            "",
+        )
+    source_key = str(external.get("browser_source_key", ""))
+    source = sources.get(source_key) if sources else None
+    if not isinstance(source, dict) or source.get("kind") != "browser":
+        return True, "Click Browser evidence state is unavailable or malformed.", ""
+    mutation = state.get("mutation")
+    if mutation_is_running(mutation):
+        return (
+            True,
+            "Wait for the structured mutation to finish before browser evidence.",
+            "",
+        )
+    verification = state.get("verification")
+    if isinstance(verification, dict) and verification.get("status") == "running":
+        return (
+            True,
+            "Wait for the final argv verification batch before browser evidence.",
+            "",
+        )
+    revision = (
+        int(verification.get("mutation_revision", 0))
+        if isinstance(verification, dict)
+        else 0
+    )
+    if click_evidence.is_current(source, revision):
+        return (
+            True,
+            "The assigned Browser evidence already completed for the current revision. "
+            "Reuse it instead of replaying the session.",
+            "",
+        )
+    running = external.get("browser_running")
+    if isinstance(running, dict) and running:
+        already_observed = bool(
+            external.get("browser_status") == "observed"
+            or source.get("status") == "observed"
+        )
+        now = time.time()
+        if any(
+            running_entry_is_active(running_entry, now)
+            for running_entry in running.values()
+        ):
+            return (
+                True,
+                "One browser evidence call is already running; keep the session serial.",
+                "",
+            )
+        attempts = external.get("browser_attempts")
+        if not isinstance(attempts, dict):
+            attempts = {}
+        for running_entry in running.values():
+            if not isinstance(running_entry, dict):
+                continue
+            digest = str(running_entry.get("attempt_digest", ""))
+            attempt = attempts.get(digest)
+            if isinstance(attempt, dict) and attempt.get("status") == "running":
+                attempt["status"] = "failed"
+                attempt["failed_attempts"] = int(
+                    attempt.get("failed_attempts", 0)
+                ) + 1
+        external["browser_running"] = {}
+        external["browser_attempts"] = attempts
+        external["browser_status"] = "observed" if already_observed else "failed"
+        external["last_browser_error"] = "post-tool-timeout"
+        if not already_observed:
+            source["status"] = "failed"
+            source["verified_revision"] = -1
+            source["last_exit_code"] = 124
+        state["external_evidence"] = external
+        _save_contract_state(event, state)
+    tool_input_error = input_error(event.get("tool_input"))
+    if tool_input_error:
+        return True, tool_input_error, ""
+    advisories = list(
+        click_browser_advisory.input_advisories(event.get("tool_input"))
+    )
+    tool_use_id = str(event.get("tool_use_id", ""))
+    if not tool_use_id:
+        return (
+            True,
+            "Browser evidence requires a stable tool_use_id for PostToolUse accounting.",
+            "",
+        )
+    digest = attempt_digest(event.get("tool_input"))
+    attempts = external.get("browser_attempts")
+    if not isinstance(attempts, dict):
+        attempts = {}
+    prior_attempt = attempts.get(digest)
+    repeat_advisory = click_browser_advisory.repeat_advisory(prior_attempt)
+    if repeat_advisory:
+        advisories.append(repeat_advisory)
+    unchanged_retries = 0
+    if isinstance(prior_attempt, dict):
+        prior_status = str(prior_attempt.get("status", ""))
+        unchanged_retries = int(prior_attempt.get("unchanged_retries", 0))
+        if prior_status in {"failed", "incomplete"}:
+            unchanged_retries += 1
+    previous_successes = (
+        int(prior_attempt.get("successful_attempts", 0))
+        if isinstance(prior_attempt, dict)
+        else 0
+    )
+    if (
+        isinstance(prior_attempt, dict)
+        and prior_attempt.get("status") == "success"
+        and previous_successes == 0
+    ):
+        previous_successes = 1
+    previous_failures = (
+        int(prior_attempt.get("failed_attempts", 0))
+        if isinstance(prior_attempt, dict)
+        else 0
+    )
+    if isinstance(prior_attempt, dict):
+        attempts.pop(digest, None)
+    compacted = False
+    while len(attempts) >= MAX_UNIQUE_INPUTS:
+        attempts.pop(next(iter(attempts)))
+        compacted = True
+    if compacted:
+        advisories.append(
+            "Click advisory: older Browser attempt guidance was compacted to keep "
+            "receipt state bounded. This call remains tracked, and the current source "
+            "and revision receipt are unchanged."
+        )
+    already_observed = bool(
+        external.get("browser_status") == "observed"
+        or source.get("status") == "observed"
+    )
+    attempts[digest] = {
+        "status": "running",
+        "attempts": int(prior_attempt.get("attempts", 0)) + 1
+        if isinstance(prior_attempt, dict)
+        else 1,
+        "unchanged_retries": unchanged_retries,
+        "successful_attempts": previous_successes,
+        "failed_attempts": previous_failures,
+    }
+    calls = int(external.get("browser_calls", 0))
+    external["browser_calls"] = calls + 1
+    external["browser_status"] = "observed" if already_observed else "running"
+    started_at = time.time()
+    external["browser_running"] = {
+        tool_use_id: {
+            "started_at": started_at,
+            "expires_at": running_expires_at(event.get("tool_input"), started_at),
+            "attempt_digest": digest,
+        }
+    }
+    external["browser_attempts"] = attempts
+    external["last_browser_error"] = ""
+    if not already_observed:
+        source["status"] = "running"
+    state["external_evidence"] = external
+    _save_contract_state(event, state)
+    return True, "", "\n".join(advisories)
+
+
+def record_result(
+    event: dict[str, Any], *, expected_contract_schema_version: int
+) -> None:
+    state = _read_contract_state(event)
+    if state.get("status") != "approved":
+        return
+    external = state.get("external_evidence")
+    if not isinstance(external, dict):
+        return
+    running = external.get("browser_running")
+    tool_use_id = str(event.get("tool_use_id", ""))
+    if not isinstance(running, dict) or tool_use_id not in running:
+        return
+    running_entry = running.pop(tool_use_id)
+    if isinstance(running_entry, dict):
+        started_at = float(running_entry.get("started_at", 0.0))
+        digest = str(running_entry.get("attempt_digest", ""))
+    else:
+        started_at = float(running_entry)
+        digest = attempt_digest(event.get("tool_input"))
+    duration = max(0.0, time.time() - started_at)
+    total = float(external.get("browser_seconds", 0.0)) + duration
+    external["browser_seconds"] = round(total, 3)
+    external["browser_running"] = running
+    sources = _sources(
+        state,
+        expected_contract_schema_version=expected_contract_schema_version,
+    )
+    source_key = str(external.get("browser_source_key", ""))
+    source = sources.get(source_key) if sources else None
+    verification = state.get("verification")
+    revision = (
+        int(verification.get("mutation_revision", 0))
+        if isinstance(verification, dict)
+        else 0
+    )
+    attempts = external.get("browser_attempts")
+    if not isinstance(attempts, dict):
+        attempts = {}
+    attempt = attempts.get(digest)
+    if not isinstance(attempt, dict):
+        attempt = {
+            "attempts": 1,
+            "unchanged_retries": 0,
+            "successful_attempts": 0,
+            "failed_attempts": 0,
+        }
+        attempts[digest] = attempt
+    if response_failed(event.get("tool_response")):
+        attempt["status"] = "failed"
+        attempt["failed_attempts"] = int(attempt.get("failed_attempts", 0)) + 1
+        already_observed = bool(
+            external.get("browser_status") == "observed"
+            or isinstance(source, dict)
+            and source.get("status") == "observed"
+        )
+        external["browser_status"] = "observed" if already_observed else "failed"
+        external["last_browser_error"] = "tool-error"
+        if isinstance(source, dict) and not already_observed:
+            source["status"] = "failed"
+            source["verified_revision"] = -1
+            source["last_exit_code"] = 1
+    else:
+        attempt["status"] = "success"
+        attempt["successful_attempts"] = int(
+            attempt.get("successful_attempts", 0)
+        ) + 1
+        external["browser_status"] = "observed"
+        external["last_browser_error"] = ""
+        if isinstance(source, dict):
+            source["status"] = "observed"
+            source["verified_revision"] = revision
+            source["last_exit_code"] = 0
+    external["browser_attempts"] = attempts
+    state["external_evidence"] = external
+    _save_contract_state(event, state)
+
+
+def finalize_evidence(
+    state: dict[str, Any],
+    *,
+    evidence_id: str,
+    source_key: str,
+    source: dict[str, Any],
+    revision: int,
+) -> str:
+    external = state.get("external_evidence")
+    browser_running = (
+        external.get("browser_running") if isinstance(external, dict) else None
+    )
+    if isinstance(browser_running, dict) and browser_running:
+        return "Wait for the running Browser interaction before finalizing evidence."
+    if (
+        not isinstance(external, dict)
+        or external.get("browser_source_key") != source_key
+        or external.get("browser_status") != "observed"
+        or source.get("status") != "observed"
+        or int(source.get("verified_revision", -1)) != revision
+    ):
+        return (
+            f"Browser evidence `{evidence_id}` can complete only after a successful "
+            "current-revision Browser call in its metered session."
+        )
+    external["browser_status"] = "passed"
+    state["external_evidence"] = external
+    return ""

--- a/hooks/click_gate.py
+++ b/hooks/click_gate.py
@@ -33,6 +33,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 if __package__:
     from . import (
+        click_browser,
         click_browser_advisory,
         click_contract,
         click_dependency_cache,
@@ -60,6 +61,7 @@ if __package__:
     )
     from .platform_protocol import CodexOutputAdapter, HookOutputAdapter
 else:  # Executed directly from the bundled hooks directory.
+    import click_browser
     import click_browser_advisory
     import click_contract
     import click_dependency_cache
@@ -118,6 +120,15 @@ _request_service_stop = click_service.request_stop
 _service_snapshot = click_service.service_snapshot
 _record_service_fields = click_service.record_service_fields
 _claim_service_runner = click_service.claim_service_runner
+
+# Compatibility aliases for Browser receipt helpers. Admission and PostToolUse
+# state transitions live in click_browser; the gate keeps only host routing and
+# supplies cross-domain lifecycle predicates.
+_browser_input_error = click_browser.input_error
+_browser_running_expires_at = click_browser.running_expires_at
+_browser_running_entry_is_active = click_browser.running_entry_is_active
+_browser_attempt_digest = click_browser.attempt_digest
+_tool_response_failed = click_browser.response_failed
 
 
 CONTROL_COMMAND = "click-gate"
@@ -182,14 +193,14 @@ MAX_INSPECTION_COMMANDS = 8
 MAX_ARGV_ITEMS = 128
 MAX_OBSERVATION_OUTPUT_BYTES = 48_000
 MAX_OBSERVATION_ENTRIES = 64
-MAX_BROWSER_UNIQUE_INPUTS = 256
+MAX_BROWSER_UNIQUE_INPUTS = click_browser.MAX_UNIQUE_INPUTS
 # Compatibility names for callers that previously treated these advisory
 # thresholds as hard maxima.
 MAX_BROWSER_TOOL_TIMEOUT_MS = (
     click_browser_advisory.RECOMMENDED_BROWSER_TOOL_TIMEOUT_MS
 )
 MAX_BROWSER_WAIT_MS = click_browser_advisory.RECOMMENDED_BROWSER_WAIT_MS
-BROWSER_RUNNING_TTL_SECONDS = 40
+BROWSER_RUNNING_TTL_SECONDS = click_browser.RUNNING_TTL_SECONDS
 OBSERVATION_RESERVATION_TTL_SECONDS = 30
 MUTATION_RUNNING_TTL_SECONDS = 10 * 60
 VERIFY_RUNNING_TTL_SECONDS = 60 * 60
@@ -2779,28 +2790,15 @@ def _record_evidence_completion(event: dict[str, Any], raw: str) -> tuple[str, s
             "reuse it instead of recording it twice.",
         )
     if kind == "browser":
-        external = state.get("external_evidence")
-        browser_running = (
-            external.get("browser_running")
-            if isinstance(external, dict)
-            else None
+        browser_error = click_browser.finalize_evidence(
+            state,
+            evidence_id=evidence_id,
+            source_key=source_key,
+            source=source,
+            revision=revision,
         )
-        if isinstance(browser_running, dict) and browser_running:
-            return "", "Wait for the running Browser interaction before finalizing evidence."
-        if (
-            not isinstance(external, dict)
-            or external.get("browser_source_key") != source_key
-            or external.get("browser_status") != "observed"
-            or source.get("status") != "observed"
-            or int(source.get("verified_revision", -1)) != revision
-        ):
-            return (
-                "",
-                f"Browser evidence `{evidence_id}` can complete only after a successful "
-                "current-revision Browser call in its metered session.",
-            )
-        external["browser_status"] = "passed"
-        state["external_evidence"] = external
+        if browser_error:
+            return "", browser_error
     elif kind not in {"hosted", "manual", "existing"}:
         return "", f"Evidence `{evidence_id}` has unsupported completion kind `{kind}`."
 
@@ -3509,291 +3507,13 @@ def _is_plan_tool(tool_name: str) -> bool:
     return normalized.split("__")[-1] == "update_plan"
 
 
-def _browser_input_error(tool_input: Any) -> str:
-    if not isinstance(tool_input, dict):
-        return "Browser evidence requires an object tool input."
-    return ""
-
-
-def _browser_running_expires_at(tool_input: Any, started_at: float) -> float:
-    declared_seconds = (
-        click_browser_advisory.longest_declared_runtime_ms(tool_input) / 1000.0
-    )
-    return started_at + max(BROWSER_RUNNING_TTL_SECONDS, declared_seconds + 10.0)
-
-
-def _browser_running_entry_is_active(entry: Any, now: float) -> bool:
-    if isinstance(entry, (int, float)) and not isinstance(entry, bool):
-        return now - float(entry) <= BROWSER_RUNNING_TTL_SECONDS
-    if not isinstance(entry, dict):
-        return False
-    expires_at = entry.get("expires_at")
-    if isinstance(expires_at, (int, float)) and not isinstance(expires_at, bool):
-        return now <= float(expires_at)
-    started_at = entry.get("started_at")
-    return bool(
-        isinstance(started_at, (int, float))
-        and not isinstance(started_at, bool)
-        and now - float(started_at) <= BROWSER_RUNNING_TTL_SECONDS
-    )
-
-
-def _browser_attempt_digest(tool_input: Any) -> str:
-    if isinstance(tool_input, dict) and isinstance(tool_input.get("code"), str):
-        code = str(tool_input["code"]).replace("\r\n", "\n").strip()
-        return _capability_digest({"code": code})
-    if isinstance(tool_input, dict):
-        semantic = {
-            key: value
-            for key, value in tool_input.items()
-            if key not in {"_meta", "annotations", "timeout", "timeout_ms"}
-        }
-        return _capability_digest({"tool_input": semantic})
-    return _capability_digest({"tool_input": tool_input})
-
-
-def _tool_response_failed(response: Any) -> bool:
-    if not isinstance(response, dict):
-        return True
-    if response.get("isError") is True or response.get("is_error") is True:
-        return True
-    if "status" in response:
-        status = str(response.get("status", "")).lower()
-        return status not in {
-            "complete",
-            "completed",
-            "ok",
-            "pass",
-            "passed",
-            "success",
-            "succeeded",
-        }
-    # MCP responses may omit a status while still returning structured content.
-    # Empty containers, empty strings, and null acknowledgements prove nothing.
-    def meaningful(value: Any) -> bool:
-        if value is None:
-            return False
-        if isinstance(value, str):
-            return bool(value.strip())
-        if isinstance(value, (bytes, bytearray)):
-            return bool(value)
-        if isinstance(value, dict):
-            metadata_keys = {
-                "_meta",
-                "annotations",
-                "mimeType",
-                "mime_type",
-                "role",
-                "type",
-            }
-            return any(
-                meaningful(item)
-                for key, item in value.items()
-                if key not in metadata_keys
-            )
-        if isinstance(value, (list, tuple, set)):
-            return any(meaningful(item) for item in value)
-        return True
-
-    return not any(
-        meaningful(response.get(key)) for key in {"content", "output", "result"}
-    )
-
-
 def _prepare_browser_evidence(event: dict[str, Any]) -> tuple[bool, str, str]:
-    state = _read_contract_state(event)
-    if state.get("status") not in {"staged", "approved"}:
-        return False, "", ""
-    if state.get("status") != "approved":
-        return (
-            True,
-            "Approve the staged Click contract before collecting browser evidence.",
-            "",
-        )
-    if _contract_is_completed(state):
-        if _read_state(event).get("status") != "passed":
-            return False, "", ""
-        return (
-            True,
-            "The approved Click contract is complete. Reuse its evidence instead of "
-            "starting a shadow browser verification session.",
-            "",
-        )
-    external = state.get("external_evidence")
-    if not isinstance(external, dict) or external.get("browser_required") is not True:
-        return (
-            True,
-            "Browser work has no referenced verification evidence source with kind "
-            "`browser` in this contract. Use the cheaper assigned source instead of "
-            "adding shadow verification.",
-            "",
-        )
-    sources = _evidence_sources(state)
-    if sources is None:
-        return (
-            True,
-            "This active contract predates evidence-id completion tracking. Cancel it, "
-            "stage the proposal again, and obtain fresh approval.",
-            "",
-        )
-    source_key = str(external.get("browser_source_key", ""))
-    source = sources.get(source_key) if sources else None
-    if not isinstance(source, dict) or source.get("kind") != "browser":
-        return True, "Click Browser evidence state is unavailable or malformed.", ""
-    mutation = state.get("mutation")
-    if _mutation_is_running(mutation):
-        return (
-            True,
-            "Wait for the structured mutation to finish before browser evidence.",
-            "",
-        )
-    verification = state.get("verification")
-    if isinstance(verification, dict) and verification.get("status") == "running":
-        return (
-            True,
-            "Wait for the final argv verification batch before browser evidence.",
-            "",
-        )
-    revision = (
-        int(verification.get("mutation_revision", 0))
-        if isinstance(verification, dict)
-        else 0
+    return click_browser.prepare(
+        event,
+        expected_contract_schema_version=CONTRACT_STATE_SCHEMA_VERSION,
+        contract_is_completed=_contract_is_completed,
+        mutation_is_running=_mutation_is_running,
     )
-    if _evidence_is_current(source, revision):
-        return (
-            True,
-            "The assigned Browser evidence already completed for the current revision. "
-            "Reuse it instead of replaying the session.",
-            "",
-        )
-    running = external.get("browser_running")
-    if isinstance(running, dict) and running:
-        already_observed = bool(
-            external.get("browser_status") == "observed"
-            or source.get("status") == "observed"
-        )
-        now = time.time()
-        if any(
-            _browser_running_entry_is_active(running_entry, now)
-            for running_entry in running.values()
-        ):
-            return (
-                True,
-                "One browser evidence call is already running; keep the session serial.",
-                "",
-            )
-        attempts = external.get("browser_attempts")
-        if not isinstance(attempts, dict):
-            attempts = {}
-        for running_entry in running.values():
-            if not isinstance(running_entry, dict):
-                continue
-            attempt_digest = str(running_entry.get("attempt_digest", ""))
-            attempt = attempts.get(attempt_digest)
-            if isinstance(attempt, dict) and attempt.get("status") == "running":
-                attempt["status"] = "failed"
-                attempt["failed_attempts"] = int(
-                    attempt.get("failed_attempts", 0)
-                ) + 1
-        external["browser_running"] = {}
-        external["browser_attempts"] = attempts
-        external["browser_status"] = "observed" if already_observed else "failed"
-        external["last_browser_error"] = "post-tool-timeout"
-        if not already_observed:
-            source["status"] = "failed"
-            source["verified_revision"] = -1
-            source["last_exit_code"] = 124
-        state["external_evidence"] = external
-        _save_contract_state(event, state)
-    input_error = _browser_input_error(event.get("tool_input"))
-    if input_error:
-        return True, input_error, ""
-    advisories = list(
-        click_browser_advisory.input_advisories(event.get("tool_input"))
-    )
-    tool_use_id = str(event.get("tool_use_id", ""))
-    if not tool_use_id:
-        return (
-            True,
-            "Browser evidence requires a stable tool_use_id for PostToolUse accounting.",
-            "",
-        )
-    attempt_digest = _browser_attempt_digest(event.get("tool_input"))
-    attempts = external.get("browser_attempts")
-    if not isinstance(attempts, dict):
-        attempts = {}
-    prior_attempt = attempts.get(attempt_digest)
-    repeat_advisory = click_browser_advisory.repeat_advisory(prior_attempt)
-    if repeat_advisory:
-        advisories.append(repeat_advisory)
-    unchanged_retries = 0
-    if isinstance(prior_attempt, dict):
-        prior_status = str(prior_attempt.get("status", ""))
-        unchanged_retries = int(prior_attempt.get("unchanged_retries", 0))
-        if prior_status in {"failed", "incomplete"}:
-            unchanged_retries += 1
-    previous_successes = (
-        int(prior_attempt.get("successful_attempts", 0))
-        if isinstance(prior_attempt, dict)
-        else 0
-    )
-    if (
-        isinstance(prior_attempt, dict)
-        and prior_attempt.get("status") == "success"
-        and previous_successes == 0
-    ):
-        previous_successes = 1
-    previous_failures = (
-        int(prior_attempt.get("failed_attempts", 0))
-        if isinstance(prior_attempt, dict)
-        else 0
-    )
-    if isinstance(prior_attempt, dict):
-        attempts.pop(attempt_digest, None)
-    compacted = False
-    while len(attempts) >= MAX_BROWSER_UNIQUE_INPUTS:
-        attempts.pop(next(iter(attempts)))
-        compacted = True
-    if compacted:
-        advisories.append(
-            "Click advisory: older Browser attempt guidance was compacted to keep "
-            "receipt state bounded. This call remains tracked, and the current source "
-            "and revision receipt are unchanged."
-        )
-    already_observed = bool(
-        external.get("browser_status") == "observed"
-        or source.get("status") == "observed"
-    )
-    attempts[attempt_digest] = {
-        "status": "running",
-        "attempts": int(prior_attempt.get("attempts", 0)) + 1
-        if isinstance(prior_attempt, dict)
-        else 1,
-        "unchanged_retries": unchanged_retries,
-        "successful_attempts": previous_successes,
-        "failed_attempts": previous_failures,
-    }
-    calls = int(external.get("browser_calls", 0))
-    external["browser_calls"] = calls + 1
-    external["browser_status"] = "observed" if already_observed else "running"
-    started_at = time.time()
-    external["browser_running"] = {
-        tool_use_id: {
-            "started_at": started_at,
-            "expires_at": _browser_running_expires_at(
-                event.get("tool_input"), started_at
-            ),
-            "attempt_digest": attempt_digest,
-        }
-    }
-    external["browser_attempts"] = attempts
-    external["last_browser_error"] = ""
-    if not already_observed:
-        source["status"] = "running"
-    state["external_evidence"] = external
-    _save_contract_state(event, state)
-    return True, "", "\n".join(advisories)
-
 
 def _record_mutation_boundary(event: dict[str, Any]) -> None:
     state = _read_contract_state(event)
@@ -3829,77 +3549,10 @@ def _handle_post_tool(event: dict[str, Any]) -> None:
     if str(event.get("tool_name", "")) not in BROWSER_TOOL_NAMES:
         _record_mutation_boundary(event)
         return
-    state = _read_contract_state(event)
-    if state.get("status") != "approved":
-        return
-    external = state.get("external_evidence")
-    if not isinstance(external, dict):
-        return
-    running = external.get("browser_running")
-    tool_use_id = str(event.get("tool_use_id", ""))
-    if not isinstance(running, dict) or tool_use_id not in running:
-        return
-    running_entry = running.pop(tool_use_id)
-    if isinstance(running_entry, dict):
-        started_at = float(running_entry.get("started_at", 0.0))
-        attempt_digest = str(running_entry.get("attempt_digest", ""))
-    else:
-        started_at = float(running_entry)
-        attempt_digest = _browser_attempt_digest(event.get("tool_input"))
-    duration = max(0.0, time.time() - started_at)
-    total = float(external.get("browser_seconds", 0.0)) + duration
-    external["browser_seconds"] = round(total, 3)
-    external["browser_running"] = running
-    sources = _evidence_sources(state)
-    source_key = str(external.get("browser_source_key", ""))
-    source = sources.get(source_key) if sources else None
-    verification = state.get("verification")
-    revision = (
-        int(verification.get("mutation_revision", 0))
-        if isinstance(verification, dict)
-        else 0
+    click_browser.record_result(
+        event,
+        expected_contract_schema_version=CONTRACT_STATE_SCHEMA_VERSION,
     )
-    attempts = external.get("browser_attempts")
-    if not isinstance(attempts, dict):
-        attempts = {}
-    attempt = attempts.get(attempt_digest)
-    if not isinstance(attempt, dict):
-        attempt = {
-            "attempts": 1,
-            "unchanged_retries": 0,
-            "successful_attempts": 0,
-            "failed_attempts": 0,
-        }
-        attempts[attempt_digest] = attempt
-    if _tool_response_failed(event.get("tool_response")):
-        attempt["status"] = "failed"
-        attempt["failed_attempts"] = int(attempt.get("failed_attempts", 0)) + 1
-        already_observed = bool(
-            external.get("browser_status") == "observed"
-            or isinstance(source, dict)
-            and source.get("status") == "observed"
-        )
-        external["browser_status"] = "observed" if already_observed else "failed"
-        external["last_browser_error"] = "tool-error"
-        if isinstance(source, dict) and not already_observed:
-            source["status"] = "failed"
-            source["verified_revision"] = -1
-            source["last_exit_code"] = 1
-    else:
-        attempt["status"] = "success"
-        attempt["successful_attempts"] = int(
-            attempt.get("successful_attempts", 0)
-        ) + 1
-        external["browser_status"] = "observed"
-        external["last_browser_error"] = ""
-        if isinstance(source, dict):
-            source["status"] = "observed"
-            source["verified_revision"] = revision
-            source["last_exit_code"] = 0
-    external["browser_attempts"] = attempts
-    state["external_evidence"] = external
-    _save_contract_state(event, state)
-
 
 def _handle_prompt_submit(event: dict[str, Any]) -> None:
     _prune_state()

--- a/scripts/build_antigravity_distribution.py
+++ b/scripts/build_antigravity_distribution.py
@@ -13,6 +13,7 @@ DESTINATION = ROOT / "dist" / "antigravity"
 
 HOOK_FILES = (
     "__init__.py",
+    "click_browser.py",
     "click_browser_advisory.py",
     "click_verification_policy.py",
     "click_verification_meter.py",

--- a/tests/repository_policy_core.py
+++ b/tests/repository_policy_core.py
@@ -504,6 +504,7 @@ class RepositoryPolicyTests(unittest.TestCase):
         sources = {
             name: (ROOT / "hooks" / name).read_text(encoding="utf-8")
             for name in (
+                "click_browser.py",
                 "click_browser_advisory.py",
                 "click_contract.py",
                 "click_dependency_cache.py",
@@ -611,11 +612,24 @@ class RepositoryPolicyTests(unittest.TestCase):
 
     def test_browser_advisory_is_separate_from_receipt_integrity(self) -> None:
         gate = (ROOT / "hooks" / "click_gate.py").read_text(encoding="utf-8")
+        browser = (ROOT / "hooks" / "click_browser.py").read_text(
+            encoding="utf-8"
+        )
         advisory = (ROOT / "hooks" / "click_browser_advisory.py").read_text(
             encoding="utf-8"
         )
 
+        self.assertIn("click_browser", gate)
         self.assertIn("click_browser_advisory", gate)
+        for required in (
+            "def prepare(",
+            "def record_result(",
+            "def finalize_evidence(",
+        ):
+            with self.subTest(required=required):
+                self.assertIn(required, browser)
+        self.assertIn("Workflow suggestions remain", browser)
+        self.assertNotIn("permissionDecision", browser)
         self.assertIn("does not grant or deny Browser authority", advisory)
         self.assertNotIn("permissionDecision", advisory)
         self.assertNotIn("tool_use_id", advisory.split("def repeat_advisory", 1)[0])
@@ -629,6 +643,17 @@ class RepositoryPolicyTests(unittest.TestCase):
         ):
             with self.subTest(forbidden=forbidden):
                 self.assertNotIn(forbidden, advisory)
+        for forbidden in (
+            "import click_contract",
+            "import click_gate",
+            "import click_process",
+            "import click_service",
+            "import click_verification_meter",
+            "import click_verification_policy",
+            "import platform_protocol",
+        ):
+            with self.subTest(browser_forbidden=forbidden):
+                self.assertNotIn(forbidden, browser)
 
     def test_compact_contract_replaces_the_verbose_execution_fields(self) -> None:
         hook = (ROOT / "hooks" / "click_gate.py").read_text(encoding="utf-8")

--- a/tests/test_click_browser.py
+++ b/tests/test_click_browser.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import unittest
+
+from hooks import click_browser, click_gate
+
+
+class ClickBrowserTests(unittest.TestCase):
+    def test_browser_runtime_has_no_upward_policy_or_host_dependency(self) -> None:
+        source = Path(click_browser.__file__).read_text(encoding="utf-8")
+        imported: set[str] = set()
+        for node in ast.walk(ast.parse(source)):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                imported.add(module)
+                imported.update(
+                    f"{module}.{alias.name}".strip(".") for alias in node.names
+                )
+
+        for forbidden in (
+            "click_contract",
+            "click_gate",
+            "click_process",
+            "click_service",
+            "click_verification_meter",
+            "click_verification_policy",
+            "platform_protocol",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertFalse(
+                    any(forbidden in name.split(".") for name in imported),
+                    imported,
+                )
+        for required in ("click_browser_advisory", "click_evidence", "click_state"):
+            with self.subTest(required=required):
+                self.assertIn(required, imported)
+
+    def test_gate_keeps_browser_compatibility_aliases(self) -> None:
+        aliases = {
+            "_browser_input_error": click_browser.input_error,
+            "_browser_running_expires_at": click_browser.running_expires_at,
+            "_browser_running_entry_is_active": click_browser.running_entry_is_active,
+            "_browser_attempt_digest": click_browser.attempt_digest,
+            "_tool_response_failed": click_browser.response_failed,
+        }
+        for name, expected in aliases.items():
+            with self.subTest(name=name):
+                self.assertIs(getattr(click_gate, name), expected)
+
+        self.assertEqual(
+            click_gate.MAX_BROWSER_UNIQUE_INPUTS,
+            click_browser.MAX_UNIQUE_INPUTS,
+        )
+        self.assertEqual(
+            click_gate.BROWSER_RUNNING_TTL_SECONDS,
+            click_browser.RUNNING_TTL_SECONDS,
+        )
+
+    def test_browser_helper_behavior_preserves_legacy_and_structured_receipts(self) -> None:
+        self.assertEqual(
+            click_browser.input_error([]),
+            "Browser evidence requires an object tool input.",
+        )
+        self.assertEqual(click_browser.input_error({}), "")
+        self.assertTrue(click_browser.running_entry_is_active(90.0, 100.0))
+        self.assertFalse(click_browser.running_entry_is_active(10.0, 100.0))
+        self.assertTrue(
+            click_browser.running_entry_is_active({"expires_at": 101.0}, 100.0)
+        )
+        self.assertFalse(
+            click_browser.running_entry_is_active({"expires_at": 99.0}, 100.0)
+        )
+
+        semantic = {"code": "await page.title()", "timeout_ms": 5000}
+        bookkeeping_changed = {
+            "code": "  await page.title()\r\n",
+            "timeout_ms": 30000,
+            "_meta": {"trace": "different"},
+        }
+        self.assertEqual(
+            click_browser.attempt_digest(semantic),
+            click_browser.attempt_digest(bookkeeping_changed),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Extract Browser source admission, serial call binding, result receipts, and finalization into hooks/click_browser.py.
- Keep workflow tuning in the non-authoritative advisory leaf and host event routing in hooks/click_gate.py.
- Preserve compatibility helpers, exact errors, legacy receipt handling, and Antigravity distribution parity.

## Verification
- Full unittest suite: 366 tests passed, 3 platform-specific tests skipped.
- Browser integration, repository policy, and distribution validation passed.
- Git diff whitespace validation passed.