### PR TITLE
Release Click v0.33.0

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/grapefruit0205/click.git",
-        "ref": "v0.32.0"
+        "ref": "v0.33.0"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "click",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "Choose Always ON or @Click Manual. Click binds a software change to one compact plain-language execution contract, waits for approval, then uses structured runners to return revision-bound evidence for the authorized execution.",
   "author": {
     "name": "Junseok Pak",

--- a/GUARD_CLASSIFICATION.md
+++ b/GUARD_CLASSIFICATION.md
@@ -1,6 +1,6 @@
 # Click Guard Classification
 
-Status: **Living inventory; v0.30 policy migrations complete; dependency-aware receipt reuse completed for v0.31.0; host coverage identity completed for v0.32.0**
+Status: **Living inventory; v0.30 policy migrations complete; dependency-aware receipt reuse completed for v0.31.0; host coverage identity completed for v0.32.0; runtime domain boundaries completed for v0.33.0**
 
 Baseline: **v0.24.6 plus the canonical product-boundary change at `73072a9`**
 
@@ -132,6 +132,10 @@ stronger guarantee than the runtime can observe.
 10. **Complete in v0.32.0:** Centralize the known Codex and Antigravity Hook
     surface, test pre/post symmetry, and bind that limited coverage identity to
     argv verification runners and receipts.
+11. **Complete in v0.33.0:** Extract service, Browser admission, mutation,
+    capability, inspection, observation, verification and approval lifecycle
+    domains while retaining `click_gate.py` as host routing and compatibility
+    facade with unchanged Core behavior.
 
 Each migration is a separate behavior-preserving-for-Core change. It must retain
 approval, side-effect authority, one-use runner, revision, receipt, cancellation,

--- a/README.ko.md
+++ b/README.ko.md
@@ -242,16 +242,16 @@ Antigravity IDE에서는 `dist/antigravity`를 워크스페이스의 `.agents/pl
 
 Antigravity의 Hook contract는 Codex와 다릅니다. native file/search와 별도 MCP·Skill 도구는 계속 사용할 수 있지만 cross-tool 중복 제거와 Browser evidence는 아직 지원하지 않습니다. 정확한 제한은 [`platforms/antigravity/README.md`](platforms/antigravity/README.md)를 확인하세요.
 
-## 기존 설치 업데이트 — v0.32.0
+## 기존 설치 업데이트 — v0.33.0
 
-현재 릴리스는 **v0.32.0**입니다.
+현재 릴리스는 **v0.33.0**입니다.
 
 ```bash
 codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-ChatGPT 데스크톱 앱을 다시 시작하고 갱신된 Hook을 검토해 신뢰하세요. v0.32.0은 각 verification runner와 성공한 argv receipt를 현재 host 및 결정론적인 known-surface Hook coverage digest에 추가로 결속합니다. 정확한 재사용과 dependency-aware 재사용은 이 coverage identity, 승인된 dependency 집합, 정확한 check, 환경, 실행 파일, mutation receipt가 모두 일치할 때만 허용되며, 하나라도 달라지면 Click이 check를 다시 실행합니다. Hook event가 발생하지 않는 host 경로까지 관찰했다고 주장하지는 않습니다. 이전 설치의 대기 중 runner를 재사용하지 말고 업그레이드 후 새 계약을 시작하세요.
+ChatGPT 데스크톱 앱을 다시 시작하고 갱신된 Hook을 검토해 신뢰하세요. v0.33.0은 service, Browser admission, mutation, capability, inspection, observation, verification, approval lifecycle 책임을 명시적인 단방향 runtime domain으로 분리합니다. `click_gate.py`는 host event router와 호환 facade 역할만 맡으면서 기존 계약 schema, 정확한 오류, one-use authorization, replay 방지, revision-bound receipt 동작을 그대로 유지합니다. Codex와 번들 Antigravity 배포본은 같은 추출 모듈을 사용합니다. 이전 설치의 대기 중 runner를 재사용하지 말고 업그레이드 후 새 계약을 시작하세요.
 
 자세한 릴리스 이력은 [RELEASE_NOTES.md](RELEASE_NOTES.md)에 있습니다.
 

--- a/README.md
+++ b/README.md
@@ -243,16 +243,16 @@ Antigravity IDE users may also copy `dist/antigravity` into `.agents/plugins/cli
 
 Antigravity's Hook contract differs from Codex. Native file/search and unrelated MCP or Skill tools remain available, but cross-tool deduplication and Browser evidence are not currently supported. See [`platforms/antigravity/README.md`](platforms/antigravity/README.md) for the exact limits.
 
-## Update an existing installation — v0.32.0
+## Update an existing installation — v0.33.0
 
-The current release is **v0.32.0**.
+The current release is **v0.33.0**.
 
 ```bash
 codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-Restart the ChatGPT desktop app and review/trust the updated Hook. v0.32.0 also binds each verification runner and successful argv receipt to the current host and its deterministic known-surface Hook coverage digest. Exact and dependency-aware reuse now require that coverage identity, the approved dependency set, exact check, environment, executable, and mutation receipt to match; otherwise Click runs the check again. The receipt makes no claim about host paths that emit no Hook event. Begin a fresh contract after upgrading instead of reusing a pending runner from an older installation.
+Restart the ChatGPT desktop app and review/trust the updated Hook. v0.33.0 separates service, Browser admission, mutation, capability, inspection, observation, verification, and approval lifecycle responsibilities into explicit one-way runtime domains. `click_gate.py` now serves as the host event router and compatibility facade while retaining the existing contract schema, exact errors, one-use authorization, replay protection, and revision-bound receipt behavior. Codex and the bundled Antigravity distribution use the same extracted modules. Begin a fresh contract after upgrading instead of reusing a pending runner from an older installation.
 
 Detailed release history is in [RELEASE_NOTES.md](RELEASE_NOTES.md).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -241,16 +241,16 @@ Antigravity IDE 用户也可以把 `dist/antigravity` 复制到工作区的 `.ag
 
 Antigravity 的 Hook contract 与 Codex 不同。native file/search 和其他 MCP、Skill 工具仍可使用，但目前还不支持 cross-tool 去重和 Browser evidence。准确限制请参阅 [`platforms/antigravity/README.md`](platforms/antigravity/README.md)。
 
-## 更新现有安装 — v0.32.0
+## 更新现有安装 — v0.33.0
 
-当前版本是 **v0.32.0**。
+当前版本是 **v0.33.0**。
 
 ```bash
 codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-重启 ChatGPT 桌面应用并检查、信任更新后的 Hook。v0.32.0 还会把每个 verification runner 和成功的 argv receipt 绑定到当前 host 及其确定性的 known-surface Hook coverage digest。精确复用和 dependency-aware 复用只有在该 coverage identity、已批准的 dependency 集、精确 check、环境、可执行文件和 mutation receipt 全部匹配时才会发生；任一项变化时 Click 都会重新运行 check。该 receipt 不会声称观察到了 host 中不产生 Hook event 的路径。升级后请开始新 contract，不要复用旧安装留下的待执行 runner。
+重启 ChatGPT 桌面应用并检查、信任更新后的 Hook。v0.33.0 将 service、Browser admission、mutation、capability、inspection、observation、verification 和 approval lifecycle 职责拆分为明确的单向 runtime domain。`click_gate.py` 仅保留 host event routing 和兼容 facade，同时保持既有 contract schema、精确错误信息、one-use authorization、replay 防护以及 revision-bound receipt 行为不变。Codex 与内置的 Antigravity 发行版使用相同的拆分模块。升级后请开始新 contract，不要复用旧安装留下的待执行 runner。
 
 详细发布历史见 [RELEASE_NOTES.md](RELEASE_NOTES.md)。
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Release notes
 
-## Unreleased v0.33 candidate — runtime domain boundaries
+## v0.33.0 — 2026-09-01
 
 - Managed local-service validation, admission, one-use start and supervisor
   claims, stop polling, process ownership, and exact state updates now live in

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -26,7 +26,7 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
             (ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
         )
         self.assertEqual(manifest["name"], "click")
-        self.assertEqual(manifest["version"], "0.32.0")
+        self.assertEqual(manifest["version"], "0.33.0")
         self.assertEqual(manifest["license"], "MIT")
         self.assertIn("always on", manifest["description"].lower())
         self.assertIn("manual", manifest["description"].lower())
@@ -98,7 +98,7 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
         self.assertEqual(marketplace["name"], "click")
         self.assertEqual(marketplace["plugins"][0]["name"], "click")
         self.assertEqual(
-            marketplace["plugins"][0]["source"]["ref"], "v0.32.0"
+            marketplace["plugins"][0]["source"]["ref"], "v0.33.0"
         )
 
     def test_readmes_lead_with_hook_enforced_state_machine_positioning(self) -> None:
@@ -225,11 +225,12 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
 
     def test_release_documents_identify_current_and_preserve_release_history(self) -> None:
         for readme in _readmes().values():
-            self.assertIn("v0.32.0", readme)
+            self.assertIn("v0.33.0", readme)
             self.assertIn("codex plugin marketplace upgrade click", readme)
             self.assertIn("codex plugin add click@click", readme)
         notes = (ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8")
         for marker in (
+            "## v0.33.0",
             "## v0.32.0",
             "## v0.31.0",
             "## v0.30.0",


### PR DESCRIPTION
## Summary

- publish the merged runtime-domain boundary refactor as v0.33.0
- pin the marketplace source to the immutable v0.33.0 tag
- document click_gate.py as the host-event router and compatibility facade
- preserve contract schema, exact errors, one-use authorization, replay protection, and revision-bound receipts

## Verification

- 387 tests passed, 3 skipped
- Antigravity distribution validation passed
- Codex plugin validation passed
- Python compileall passed
- repository policy tests: 33 passed
- git diff --check passed