### PR TITLE
docs: clarify Click value proposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,13 @@ Community: [LINUX DO](https://linux.do/)
 
 > **Keep Codex inside the change you approved — and make “done” mean current evidence, not model confidence.**
 
+### Prompt-only coding workflows are over.
+
+> **Prompts can suggest behavior. Hooks can enforce the workflow.**
+
 **Click is a Codex plugin that turns a software-change request into one compact contract, binds later user approval to that exact intent, controls observable mutation authority at the supported Hook boundary, and ties completion evidence to the current code revision.**
+
+Click uses a **persistent Hook state machine** to mediate supported actions on the **observable execution path**. Workflow optimization stays advisory: exploration and planning receive **non-blocking guidance** rather than becoming execution authority.
 
 Click does not make the model smarter. It makes **approval, mutation authority, and completion evidence persistent and inspectable instead of relying on the model to remember them.**
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Click — Hook-enforced workflow for Codex coding agents
+# Click — Contract-driven execution control for Codex coding agents
 
 English | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)
 
@@ -7,34 +7,35 @@ Community: [LINUX DO](https://linux.do/)
 [![CI](https://github.com/grapefruit0205/click/actions/workflows/ci.yml/badge.svg)](https://github.com/grapefruit0205/click/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-### Prompt-only coding workflows are over.
+> **Keep Codex inside the change you approved — and make “done” mean current evidence, not model confidence.**
 
-> **Prompts can suggest behavior. Hooks can enforce the workflow.**
+**Click is a Codex plugin that turns a software-change request into one compact contract, binds later user approval to that exact intent, controls observable mutation authority at the supported Hook boundary, and ties completion evidence to the current code revision.**
 
-**Click is a Codex plugin that turns a software-change request into one compact contract, then uses a persistent Hook state machine to keep the observable execution path inside the boundary you approved.**
+Click does not make the model smarter. It makes **approval, mutation authority, and completion evidence persistent and inspectable instead of relying on the model to remember them.**
 
-Most coding-agent workflows still rely on the model remembering instructions such as:
+## Why Click?
 
-```text
-Plan once.
-Stay in scope.
-Do not rescan the repository.
-Do not keep rewriting the plan.
-Run only the checks that are actually needed.
-```
+Coding-agent sessions can lose a stable execution boundary as context grows. The agent may revisit broad repository context, rewrite its plan, widen the task, begin changing files before review, or repeat verification that is no longer necessary.
 
-That works until context grows, the task branches, or the agent decides to plan and prove the same thing again.
+Prompts can ask the model not to do those things. Click moves the parts that require real authority or trustworthy evidence into persistent runtime state.
 
-Click moves authority and evidence guarantees into the supported tool boundary.
-Exploration preferences remain non-blocking guidance there; they do not become
-execution authority.
+| Common problem | What Click changes |
+| --- | --- |
+| The plan gets rewritten as the session grows | The approved contract remains canonical; `update_plan` stays advisory and cannot alter contract authority |
+| The agent starts modifying files before review | Mutation stays locked until the exact staged `contract_id` is approved in a later user turn |
+| Repository context is repeatedly rediscovered | Broad and repeated reads remain available, but Click can provide non-blocking narrowing and reuse guidance |
+| The same proof is run again | Current structured evidence and exact receipts can be reused when they are still valid |
+| Code changes after verification | A mutation advances the revision and makes older completion evidence stale |
+| The agent says the work is done | Declared evidence must be current for the latest mutation revision |
+
+This design can **reduce unnecessary replanning, broad repository re-scans, and duplicate verification** by giving the agent a stable approved target and reusable current evidence. These are workflow benefits, not universal hard guarantees: Click intentionally keeps exploration and planning strategy advisory, and it does not claim project-wide improvements in tool calls, tokens, time, or success rate without independent measurements.
 
 ```text
 request
    ↓
 compact contract
    ↓
-Later user turn approval
+later user turn approval
    ↓
 implementation
    ↓
@@ -43,7 +44,7 @@ current-revision evidence
 done
 ```
 
-> **The model decides how to implement the change. The Hook decides whether the workflow is allowed to move forward.**
+> **The model decides how to implement the change. Click decides whether observable execution has the authority and evidence required to move forward.**
 
 **One contract. One approval. One implementation boundary. One evidence set.**
 
@@ -51,33 +52,13 @@ done
 
 > **Click binds AI execution to approved intent and returns verifiable evidence.**
 
-Click's stable product boundary is an authorization-and-evidence runtime, not a
-model workflow optimizer. The canonical admission test and policy layers are in
-the [Click Product Constitution](PRODUCT_CONSTITUTION.md); the current guard
-inventory and migration status are in [Click Guard Classification](GUARD_CLASSIFICATION.md).
+Click's stable product boundary is an authorization-and-evidence runtime, not a model workflow optimizer. The canonical admission test and policy layers are in the [Click Product Constitution](PRODUCT_CONSTITUTION.md); the current guard inventory and migration status are in [Click Guard Classification](GUARD_CLASSIFICATION.md).
 
-Click keeps authority and evidence integrity as hard runtime guarantees while
-treating model workflow strategy as non-authoritative guidance. In particular,
-`update_plan` remains available: it cannot approve, replace, or widen the active
-contract, and it does not change the contract digest or evidence state.
-
-## Why Click?
-
-A prompt can tell an agent what it *should* do. Click adds persistent state around what the agent is *allowed* to do on the observable tool path.
-
-| Prompt-only workflow | Click |
-| --- | --- |
-| Hope the model remembers the plan | Persist the approved workflow state |
-| Hope approval happens at the right time | Stage a digest-bound `contract_id` and require a later user turn |
-| Ask the agent not to rescan | Offer non-blocking narrowing guidance; inventory count does not alter authority |
-| Ask the agent not to replan | Offer non-blocking guidance; `update_plan` cannot alter contract authority |
-| Ask the agent not to rerun proof | Reuse current structured evidence and receipts |
-| Let verification drift away from the task | Bind each completion condition to revision-bound evidence and exact receipts |
-| Stop when the agent says it is done | Require declared evidence to be current for the latest mutation revision |
+Click keeps authority and evidence integrity as hard runtime guarantees while treating model workflow strategy as non-authoritative guidance. In particular, `update_plan` remains available: it cannot approve, replace, or widen the active contract, and it does not change the contract digest or evidence state.
 
 The core idea is simple:
 
-> **Do not keep asking the coding agent to remember the process. Put the process in the execution boundary.**
+> **Do not keep asking the coding agent to remember the process. Put authority and evidence in the execution boundary.**
 
 ## What the Hook actually enforces
 


### PR DESCRIPTION
## Summary

- lead with the user-facing reason to install Click instead of internal Hook terminology
- explain approval, mutation authority, and revision-bound evidence before protocol details
- describe reduced replanning, broad repository re-scans, and duplicate verification as workflow benefits rather than hard guarantees
- preserve Click's Product Constitution boundary: exploration and planning remain advisory
- add no benchmark or performance claims that have not been independently measured

This only restructures the top of `README.md`; the existing technical documentation remains intact.