### PR TITLE
Add HOL Guard verified badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Click — Revision-aware evidence and approval-bound execution for Codex
 
+[![HOL Guard](https://img.shields.io/endpoint?url=https%3A%2F%2Fhol.org%2Fapi%2Fregistry%2Fbadges%2Fplugin%3Fslug%3Djunseok-pak%252Fclick%26metric%3Dtrust)](https://hol.org/go/guard/pjseok1219?dest=%2Fguard%2Fbilling%3Fpromo%3DGUARD20-PJSEOK1219%23upgrade&link_id=351107f3-00d1-4b0f-8aac-1bb449193d84&utm_source=insights_share&utm_medium=affiliate_cta&utm_campaign=share20)
+
 English | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)
 
 Community: [LINUX DO](https://linux.do/)


### PR DESCRIPTION
Adds the HOL Guard verified badge to this repository README.

Listing: https://hol.org/registry/plugins/junseok-pak%2Fclick

Once merged, the registry listing scores +2% trust for displaying the verified badge.