### PR TITLE
refactor: extract runner transport boundary

### DIFF
--- a/COMPATIBILITY_SURFACE.md
+++ b/COMPATIBILITY_SURFACE.md
@@ -21,11 +21,11 @@ The current host adapters still call a small, explicit set of gate symbols:
 - `hooks/click_hook.py`: `main`
 - `hooks/antigravity_gate.py`: `SHELL_CONTROL_PUNCTUATION`, `_emit`,
   `_handle_post_tool`, `_handle_pre_tool`, `_handle_prompt_submit`,
-  `_handle_session_end`, `_is_read_only_bash`, `_set_output_adapter`, and
-  `_windows_launcher_path_is_safe`
-- `hooks/click_windows.py`: `WINDOWS_COMMAND_LINE_LIMIT`,
-  `_encode_runner_transport`, `_runner_shell_command`,
-  `_windows_launcher_path_is_safe`, and `_windows_shell_quote`
+  `_handle_session_end`, `_is_read_only_bash`, and `_set_output_adapter`
+
+`hooks/click_windows.py` and the Antigravity launcher-path check use the formal
+`click_runner_transport` boundary. They no longer reach through private gate
+symbols to configure or decode runner commands.
 
 This bridge is compatibility state, not the desired final host API. A later
 refactor should replace it with named host-routing and runner-transport

--- a/dist/antigravity/hooks/antigravity_gate.py
+++ b/dist/antigravity/hooks/antigravity_gate.py
@@ -19,11 +19,17 @@ import time
 from typing import Any, Callable
 
 if __package__:
-    from . import click_gate, click_host_coverage, click_state
+    from . import (
+        click_gate,
+        click_host_coverage,
+        click_runner_transport,
+        click_state,
+    )
     from .platform_protocol import AntigravityOutputAdapter, CodexOutputAdapter
 else:  # Executed directly from the bundled hooks directory.
     import click_gate
     import click_host_coverage
+    import click_runner_transport
     import click_state
     from platform_protocol import AntigravityOutputAdapter, CodexOutputAdapter
 
@@ -263,7 +269,7 @@ def _control_launcher_prefix() -> list[str]:
     interpreter = Path(sys.executable).resolve(strict=True)
     script = Path(__file__).resolve(strict=True)
     if os.name == "nt" and not all(
-        click_gate._windows_launcher_path_is_safe(str(path))
+        click_runner_transport.windows_launcher_path_is_safe(str(path))
         for path in (interpreter, script)
     ):
         raise ValueError(

--- a/dist/antigravity/hooks/click_gate.py
+++ b/dist/antigravity/hooks/click_gate.py
@@ -10,17 +10,14 @@ sufficiency. Structured argv requests execute without a shell.
 
 from __future__ import annotations
 
-import base64
 import json
 import os
 from pathlib import Path
 import secrets
-import shlex
 import shutil
 import subprocess
 import sys
 import time
-import zlib
 from typing import Any
 
 if __package__:
@@ -37,6 +34,7 @@ if __package__:
         click_observation,
         click_process,
         click_receipt_runtime,
+        click_runner_transport,
         click_service,
         click_verification,
         click_verification_policy,
@@ -70,6 +68,7 @@ else:  # Executed directly from the bundled hooks directory.
     import click_observation
     import click_process
     import click_receipt_runtime
+    import click_runner_transport
     import click_service
     import click_verification
     import click_verification_policy
@@ -442,97 +441,6 @@ _validate_evidence_result = click_lifecycle.validate_evidence_result
 _control_request = click_lifecycle.control_request
 
 
-def _windows_shell_quote(argument: str) -> str:
-    """Quote one argv item for cmd.exe while preserving CRT argv decoding."""
-    if any(character in argument for character in ("\0", "\r", "\n")):
-        raise ValueError("Click runner arguments cannot contain control characters.")
-    result = ['"']
-    backslashes = 0
-    for character in argument:
-        if character == "\\":
-            backslashes += 1
-            continue
-        if character == '"':
-            result.append("\\" * (backslashes * 2 + 1))
-            result.append('"')
-            backslashes = 0
-            continue
-        if backslashes:
-            result.append("\\" * backslashes)
-            backslashes = 0
-        result.append(character)
-    if backslashes:
-        result.append("\\" * (backslashes * 2))
-    result.append('"')
-    return "".join(result)
-
-
-MAX_RUNNER_TRANSPORT_BYTES = 24_000
-WINDOWS_COMMAND_LINE_LIMIT = 8_191
-
-
-def _encode_runner_transport(arguments: list[str]) -> str:
-    raw = json.dumps(arguments, ensure_ascii=False, separators=(",", ":")).encode()
-    return base64.urlsafe_b64encode(zlib.compress(raw, level=9)).decode()
-
-
-def _decode_runner_transport(encoded: str) -> tuple[list[str] | None, str]:
-    try:
-        compressed = base64.b64decode(
-            encoded.encode(), altchars=b"-_", validate=True
-        )
-        decompressor = zlib.decompressobj()
-        raw = decompressor.decompress(compressed, MAX_RUNNER_TRANSPORT_BYTES + 1)
-        if (
-            len(raw) > MAX_RUNNER_TRANSPORT_BYTES
-            or not decompressor.eof
-            or decompressor.unconsumed_tail
-            or decompressor.unused_data
-        ):
-            return None, "Click runner transport exceeded its bounded payload."
-        value = json.loads(raw.decode())
-    except (UnicodeDecodeError, ValueError, json.JSONDecodeError, zlib.error):
-        return None, "Click runner transport was malformed."
-    if (
-        not isinstance(value, list)
-        or not value
-        or any(not isinstance(item, str) or "\x00" in item for item in value)
-    ):
-        return None, "Click runner transport did not contain a valid argv list."
-    return value, ""
-
-
-def _windows_launcher_path_is_safe(value: str) -> bool:
-    # Arguments after the launcher are encoded. These characters remain unsafe
-    # in the two launcher paths because cmd.exe and PowerShell expand them even
-    # inside double quotes under some configurations.
-    return not any(character in value for character in ("%", "!", "$", "`"))
-
-
-def _runner_shell_command(arguments: list[str]) -> str:
-    if os.name == "nt":
-        if len(arguments) < 3 or not all(
-            _windows_launcher_path_is_safe(argument) for argument in arguments[:2]
-        ):
-            return "exit 2"
-        transported = [
-            arguments[1],
-            "--encoded-runner",
-            _encode_runner_transport(arguments[2:]),
-        ]
-        # hooks.json already requires the Windows py launcher. Reuse its bare
-        # command form here so the rewritten runner is valid in both cmd.exe
-        # and PowerShell; a quoted executable path in command position is only
-        # an expression in PowerShell unless prefixed with its call operator.
-        command = "py -3 " + " ".join(
-            _windows_shell_quote(argument) for argument in transported
-        )
-        if len(command) > WINDOWS_COMMAND_LINE_LIMIT:
-            return "exit 2"
-        return command
-    return shlex.join(arguments)
-
-
 def _stateful_runner_prefix(action: str) -> list[str]:
     """Bind a rewritten runner to the state root selected by the Hook process."""
     return [
@@ -553,7 +461,7 @@ def _observation_runner_command(
         request_digest,
         runner_token,
         runner_script=Path(__file__).resolve(),
-        render_command=_runner_shell_command,
+        render_command=click_runner_transport.render_runner_shell_command,
     )
 
 
@@ -572,7 +480,7 @@ def _prepare_observation(
         mutation_is_running=_mutation_is_running,
         fresh_mutation_state=_fresh_mutation_state,
         runner_script=Path(__file__).resolve(),
-        render_command=_runner_shell_command,
+        render_command=click_runner_transport.render_runner_shell_command,
     )
 
 
@@ -580,7 +488,7 @@ def _inspection_once_runner_command(request: dict[str, Any]) -> str:
     return click_inspection.runner_command(
         request,
         runner_script=Path(__file__).resolve(),
-        render_command=_runner_shell_command,
+        render_command=click_runner_transport.render_runner_shell_command,
     )
 
 
@@ -593,7 +501,7 @@ def _mutation_runner_command(
         request_digest,
         runner_token,
         runner_script=Path(__file__).resolve(),
-        render_command=_runner_shell_command,
+        render_command=click_runner_transport.render_runner_shell_command,
     )
 
 
@@ -608,8 +516,9 @@ def _prepare_mutation(event: dict[str, Any], raw: str) -> tuple[str, str]:
         observation_is_running=_observation_is_running,
         workspace_snapshot=_git_workspace_snapshot,
         runner_script=Path(__file__).resolve(),
-        render_command=_runner_shell_command,
+        render_command=click_runner_transport.render_runner_shell_command,
     )
+
 
 def _service_runner_command(
     event: dict[str, Any],
@@ -623,7 +532,7 @@ def _service_runner_command(
         service_id,
         runner_token=runner_token,
         runner_script=Path(__file__).resolve(),
-        render_command=_runner_shell_command,
+        render_command=click_runner_transport.render_runner_shell_command,
     )
 
 
@@ -637,7 +546,7 @@ def _prepare_service(event: dict[str, Any], raw: str) -> tuple[str, str]:
             value, host_tool_use=False
         ),
         runner_script=Path(__file__).resolve(),
-        render_command=_runner_shell_command,
+        render_command=click_runner_transport.render_runner_shell_command,
     )
 
 
@@ -650,7 +559,7 @@ def _verification_runner_command(
         batch_digest,
         runner_token,
         runner_script=Path(__file__).resolve(),
-        render_command=_runner_shell_command,
+        render_command=click_runner_transport.render_runner_shell_command,
     )
 
 
@@ -668,7 +577,7 @@ def _tool_working_directory(event: dict[str, Any]) -> Path:
 
 def _receipt_export_runner_command(event: dict[str, Any]) -> str:
     host_id = click_host_coverage.host_id_from_event(event)
-    return _runner_shell_command(
+    return click_runner_transport.render_runner_shell_command(
         [
             *_stateful_runner_prefix("run-receipt-export"),
             str(_contract_path(event).resolve()),
@@ -679,7 +588,7 @@ def _receipt_export_runner_command(event: dict[str, Any]) -> str:
 
 
 def _receipt_verify_runner_command(path: str) -> str:
-    return _runner_shell_command(
+    return click_runner_transport.render_runner_shell_command(
         [
             sys.executable,
             str(Path(__file__).resolve()),
@@ -700,7 +609,7 @@ def _prepare_verification(
         event,
         raw,
         runner_script=Path(__file__).resolve(),
-        render_command=_runner_shell_command,
+        render_command=click_runner_transport.render_runner_shell_command,
         git_workspace_snapshot=_git_workspace_snapshot,
         git_capture=_git_capture,
     )
@@ -1457,7 +1366,9 @@ def main() -> int:
         if len(arguments) != 2:
             sys.stderr.write("Click runner transport was malformed.\n")
             return 2
-        decoded, transport_error = _decode_runner_transport(arguments[1])
+        decoded, transport_error = click_runner_transport.decode_runner_transport(
+            arguments[1]
+        )
         if transport_error or decoded is None:
             sys.stderr.write(f"{transport_error}\n")
             return 2

--- a/dist/antigravity/hooks/click_runner_transport.py
+++ b/dist/antigravity/hooks/click_runner_transport.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Bounded runner argv transport and host shell rendering.
+
+This leaf module knows how to serialize runner argv and render the one command
+that launches Click again. It deliberately knows nothing about contracts,
+state, evidence, or host event routing. Host adapters may install a process-local
+renderer without reaching into ``click_gate`` private globals.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Callable
+import json
+import os
+import shlex
+import zlib
+
+
+MAX_RUNNER_TRANSPORT_BYTES = 24_000
+WINDOWS_COMMAND_LINE_LIMIT = 8_191
+
+RunnerShellRenderer = Callable[[list[str]], str]
+
+
+def windows_shell_quote(argument: str) -> str:
+    """Quote one argv item for cmd.exe while preserving CRT argv decoding."""
+    if any(character in argument for character in ("\0", "\r", "\n")):
+        raise ValueError("Click runner arguments cannot contain control characters.")
+    result = ['"']
+    backslashes = 0
+    for character in argument:
+        if character == "\\":
+            backslashes += 1
+            continue
+        if character == '"':
+            result.append("\\" * (backslashes * 2 + 1))
+            result.append('"')
+            backslashes = 0
+            continue
+        if backslashes:
+            result.append("\\" * backslashes)
+            backslashes = 0
+        result.append(character)
+    if backslashes:
+        result.append("\\" * (backslashes * 2))
+    result.append('"')
+    return "".join(result)
+
+
+def encode_runner_transport(arguments: list[str]) -> str:
+    raw = json.dumps(arguments, ensure_ascii=False, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(zlib.compress(raw, level=9)).decode()
+
+
+def decode_runner_transport(encoded: str) -> tuple[list[str] | None, str]:
+    try:
+        compressed = base64.b64decode(
+            encoded.encode(), altchars=b"-_", validate=True
+        )
+        decompressor = zlib.decompressobj()
+        raw = decompressor.decompress(compressed, MAX_RUNNER_TRANSPORT_BYTES + 1)
+        if (
+            len(raw) > MAX_RUNNER_TRANSPORT_BYTES
+            or not decompressor.eof
+            or decompressor.unconsumed_tail
+            or decompressor.unused_data
+        ):
+            return None, "Click runner transport exceeded its bounded payload."
+        value = json.loads(raw.decode())
+    except (UnicodeDecodeError, ValueError, json.JSONDecodeError, zlib.error):
+        return None, "Click runner transport was malformed."
+    if (
+        not isinstance(value, list)
+        or not value
+        or any(not isinstance(item, str) or "\x00" in item for item in value)
+    ):
+        return None, "Click runner transport did not contain a valid argv list."
+    return value, ""
+
+
+def windows_launcher_path_is_safe(value: str) -> bool:
+    # Arguments after the launcher are encoded. These characters remain unsafe
+    # in the two launcher paths because cmd.exe and PowerShell expand them even
+    # inside double quotes under some configurations.
+    return not any(character in value for character in ("%", "!", "$", "`"))
+
+
+def default_runner_shell_command(arguments: list[str]) -> str:
+    if os.name == "nt":
+        if len(arguments) < 3 or not all(
+            windows_launcher_path_is_safe(argument) for argument in arguments[:2]
+        ):
+            return "exit 2"
+        transported = [
+            arguments[1],
+            "--encoded-runner",
+            encode_runner_transport(arguments[2:]),
+        ]
+        # hooks.json already requires the Windows py launcher. Reuse its bare
+        # command form here so the rewritten runner is valid in both cmd.exe
+        # and PowerShell; a quoted executable path in command position is only
+        # an expression in PowerShell unless prefixed with its call operator.
+        command = "py -3 " + " ".join(
+            windows_shell_quote(argument) for argument in transported
+        )
+        if len(command) > WINDOWS_COMMAND_LINE_LIMIT:
+            return "exit 2"
+        return command
+    return shlex.join(arguments)
+
+
+_runner_shell_renderer: RunnerShellRenderer = default_runner_shell_command
+
+
+def install_runner_shell_renderer(
+    renderer: RunnerShellRenderer,
+) -> RunnerShellRenderer:
+    """Install one host renderer for this Hook process and return its predecessor."""
+    if not callable(renderer):
+        raise TypeError("Click runner shell renderer must be callable.")
+    global _runner_shell_renderer
+    previous = _runner_shell_renderer
+    _runner_shell_renderer = renderer
+    return previous
+
+
+def render_runner_shell_command(arguments: list[str]) -> str:
+    return _runner_shell_renderer(arguments)

--- a/hooks/antigravity_gate.py
+++ b/hooks/antigravity_gate.py
@@ -19,11 +19,17 @@ import time
 from typing import Any, Callable
 
 if __package__:
-    from . import click_gate, click_host_coverage, click_state
+    from . import (
+        click_gate,
+        click_host_coverage,
+        click_runner_transport,
+        click_state,
+    )
     from .platform_protocol import AntigravityOutputAdapter, CodexOutputAdapter
 else:  # Executed directly from the bundled hooks directory.
     import click_gate
     import click_host_coverage
+    import click_runner_transport
     import click_state
     from platform_protocol import AntigravityOutputAdapter, CodexOutputAdapter
 
@@ -263,7 +269,7 @@ def _control_launcher_prefix() -> list[str]:
     interpreter = Path(sys.executable).resolve(strict=True)
     script = Path(__file__).resolve(strict=True)
     if os.name == "nt" and not all(
-        click_gate._windows_launcher_path_is_safe(str(path))
+        click_runner_transport.windows_launcher_path_is_safe(str(path))
         for path in (interpreter, script)
     ):
         raise ValueError(

--- a/hooks/click_gate.py
+++ b/hooks/click_gate.py
@@ -10,17 +10,14 @@ sufficiency. Structured argv requests execute without a shell.
 
 from __future__ import annotations
 
-import base64
 import json
 import os
 from pathlib import Path
 import secrets
-import shlex
 import shutil
 import subprocess
 import sys
 import time
-import zlib
 from typing import Any
 
 if __package__:
@@ -37,6 +34,7 @@ if __package__:
         click_observation,
         click_process,
         click_receipt_runtime,
+        click_runner_transport,
         click_service,
         click_verification,
         click_verification_policy,
@@ -70,6 +68,7 @@ else:  # Executed directly from the bundled hooks directory.
     import click_observation
     import click_process
     import click_receipt_runtime
+    import click_runner_transport
     import click_service
     import click_verification
     import click_verification_policy
@@ -442,97 +441,6 @@ _validate_evidence_result = click_lifecycle.validate_evidence_result
 _control_request = click_lifecycle.control_request
 
 
-def _windows_shell_quote(argument: str) -> str:
-    """Quote one argv item for cmd.exe while preserving CRT argv decoding."""
-    if any(character in argument for character in ("\0", "\r", "\n")):
-        raise ValueError("Click runner arguments cannot contain control characters.")
-    result = ['"']
-    backslashes = 0
-    for character in argument:
-        if character == "\\":
-            backslashes += 1
-            continue
-        if character == '"':
-            result.append("\\" * (backslashes * 2 + 1))
-            result.append('"')
-            backslashes = 0
-            continue
-        if backslashes:
-            result.append("\\" * backslashes)
-            backslashes = 0
-        result.append(character)
-    if backslashes:
-        result.append("\\" * (backslashes * 2))
-    result.append('"')
-    return "".join(result)
-
-
-MAX_RUNNER_TRANSPORT_BYTES = 24_000
-WINDOWS_COMMAND_LINE_LIMIT = 8_191
-
-
-def _encode_runner_transport(arguments: list[str]) -> str:
-    raw = json.dumps(arguments, ensure_ascii=False, separators=(",", ":")).encode()
-    return base64.urlsafe_b64encode(zlib.compress(raw, level=9)).decode()
-
-
-def _decode_runner_transport(encoded: str) -> tuple[list[str] | None, str]:
-    try:
-        compressed = base64.b64decode(
-            encoded.encode(), altchars=b"-_", validate=True
-        )
-        decompressor = zlib.decompressobj()
-        raw = decompressor.decompress(compressed, MAX_RUNNER_TRANSPORT_BYTES + 1)
-        if (
-            len(raw) > MAX_RUNNER_TRANSPORT_BYTES
-            or not decompressor.eof
-            or decompressor.unconsumed_tail
-            or decompressor.unused_data
-        ):
-            return None, "Click runner transport exceeded its bounded payload."
-        value = json.loads(raw.decode())
-    except (UnicodeDecodeError, ValueError, json.JSONDecodeError, zlib.error):
-        return None, "Click runner transport was malformed."
-    if (
-        not isinstance(value, list)
-        or not value
-        or any(not isinstance(item, str) or "\x00" in item for item in value)
-    ):
-        return None, "Click runner transport did not contain a valid argv list."
-    return value, ""
-
-
-def _windows_launcher_path_is_safe(value: str) -> bool:
-    # Arguments after the launcher are encoded. These characters remain unsafe
-    # in the two launcher paths because cmd.exe and PowerShell expand them even
-    # inside double quotes under some configurations.
-    return not any(character in value for character in ("%", "!", "$", "`"))
-
-
-def _runner_shell_command(arguments: list[str]) -> str:
-    if os.name == "nt":
-        if len(arguments) < 3 or not all(
-            _windows_launcher_path_is_safe(argument) for argument in arguments[:2]
-        ):
-            return "exit 2"
-        transported = [
-            arguments[1],
-            "--encoded-runner",
-            _encode_runner_transport(arguments[2:]),
-        ]
-        # hooks.json already requires the Windows py launcher. Reuse its bare
-        # command form here so the rewritten runner is valid in both cmd.exe
-        # and PowerShell; a quoted executable path in command position is only
-        # an expression in PowerShell unless prefixed with its call operator.
-        command = "py -3 " + " ".join(
-            _windows_shell_quote(argument) for argument in transported
-        )
-        if len(command) > WINDOWS_COMMAND_LINE_LIMIT:
-            return "exit 2"
-        return command
-    return shlex.join(arguments)
-
-
 def _stateful_runner_prefix(action: str) -> list[str]:
     """Bind a rewritten runner to the state root selected by the Hook process."""
     return [
@@ -553,7 +461,7 @@ def _observation_runner_command(
         request_digest,
         runner_token,
         runner_script=Path(__file__).resolve(),
-        render_command=_runner_shell_command,
+        render_command=click_runner_transport.render_runner_shell_command,
     )
 
 
@@ -572,7 +480,7 @@ def _prepare_observation(
         mutation_is_running=_mutation_is_running,
         fresh_mutation_state=_fresh_mutation_state,
         runner_script=Path(__file__).resolve(),
-        render_command=_runner_shell_command,
+        render_command=click_runner_transport.render_runner_shell_command,
     )
 
 
@@ -580,7 +488,7 @@ def _inspection_once_runner_command(request: dict[str, Any]) -> str:
     return click_inspection.runner_command(
         request,
         runner_script=Path(__file__).resolve(),
-        render_command=_runner_shell_command,
+        render_command=click_runner_transport.render_runner_shell_command,
     )
 
 
@@ -593,7 +501,7 @@ def _mutation_runner_command(
         request_digest,
         runner_token,
         runner_script=Path(__file__).resolve(),
-        render_command=_runner_shell_command,
+        render_command=click_runner_transport.render_runner_shell_command,
     )
 
 
@@ -608,8 +516,9 @@ def _prepare_mutation(event: dict[str, Any], raw: str) -> tuple[str, str]:
         observation_is_running=_observation_is_running,
         workspace_snapshot=_git_workspace_snapshot,
         runner_script=Path(__file__).resolve(),
-        render_command=_runner_shell_command,
+        render_command=click_runner_transport.render_runner_shell_command,
     )
+
 
 def _service_runner_command(
     event: dict[str, Any],
@@ -623,7 +532,7 @@ def _service_runner_command(
         service_id,
         runner_token=runner_token,
         runner_script=Path(__file__).resolve(),
-        render_command=_runner_shell_command,
+        render_command=click_runner_transport.render_runner_shell_command,
     )
 
 
@@ -637,7 +546,7 @@ def _prepare_service(event: dict[str, Any], raw: str) -> tuple[str, str]:
             value, host_tool_use=False
         ),
         runner_script=Path(__file__).resolve(),
-        render_command=_runner_shell_command,
+        render_command=click_runner_transport.render_runner_shell_command,
     )
 
 
@@ -650,7 +559,7 @@ def _verification_runner_command(
         batch_digest,
         runner_token,
         runner_script=Path(__file__).resolve(),
-        render_command=_runner_shell_command,
+        render_command=click_runner_transport.render_runner_shell_command,
     )
 
 
@@ -668,7 +577,7 @@ def _tool_working_directory(event: dict[str, Any]) -> Path:
 
 def _receipt_export_runner_command(event: dict[str, Any]) -> str:
     host_id = click_host_coverage.host_id_from_event(event)
-    return _runner_shell_command(
+    return click_runner_transport.render_runner_shell_command(
         [
             *_stateful_runner_prefix("run-receipt-export"),
             str(_contract_path(event).resolve()),
@@ -679,7 +588,7 @@ def _receipt_export_runner_command(event: dict[str, Any]) -> str:
 
 
 def _receipt_verify_runner_command(path: str) -> str:
-    return _runner_shell_command(
+    return click_runner_transport.render_runner_shell_command(
         [
             sys.executable,
             str(Path(__file__).resolve()),
@@ -700,7 +609,7 @@ def _prepare_verification(
         event,
         raw,
         runner_script=Path(__file__).resolve(),
-        render_command=_runner_shell_command,
+        render_command=click_runner_transport.render_runner_shell_command,
         git_workspace_snapshot=_git_workspace_snapshot,
         git_capture=_git_capture,
     )
@@ -1457,7 +1366,9 @@ def main() -> int:
         if len(arguments) != 2:
             sys.stderr.write("Click runner transport was malformed.\n")
             return 2
-        decoded, transport_error = _decode_runner_transport(arguments[1])
+        decoded, transport_error = click_runner_transport.decode_runner_transport(
+            arguments[1]
+        )
         if transport_error or decoded is None:
             sys.stderr.write(f"{transport_error}\n")
             return 2

--- a/hooks/click_runner_transport.py
+++ b/hooks/click_runner_transport.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Bounded runner argv transport and host shell rendering.
+
+This leaf module knows how to serialize runner argv and render the one command
+that launches Click again. It deliberately knows nothing about contracts,
+state, evidence, or host event routing. Host adapters may install a process-local
+renderer without reaching into ``click_gate`` private globals.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Callable
+import json
+import os
+import shlex
+import zlib
+
+
+MAX_RUNNER_TRANSPORT_BYTES = 24_000
+WINDOWS_COMMAND_LINE_LIMIT = 8_191
+
+RunnerShellRenderer = Callable[[list[str]], str]
+
+
+def windows_shell_quote(argument: str) -> str:
+    """Quote one argv item for cmd.exe while preserving CRT argv decoding."""
+    if any(character in argument for character in ("\0", "\r", "\n")):
+        raise ValueError("Click runner arguments cannot contain control characters.")
+    result = ['"']
+    backslashes = 0
+    for character in argument:
+        if character == "\\":
+            backslashes += 1
+            continue
+        if character == '"':
+            result.append("\\" * (backslashes * 2 + 1))
+            result.append('"')
+            backslashes = 0
+            continue
+        if backslashes:
+            result.append("\\" * backslashes)
+            backslashes = 0
+        result.append(character)
+    if backslashes:
+        result.append("\\" * (backslashes * 2))
+    result.append('"')
+    return "".join(result)
+
+
+def encode_runner_transport(arguments: list[str]) -> str:
+    raw = json.dumps(arguments, ensure_ascii=False, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(zlib.compress(raw, level=9)).decode()
+
+
+def decode_runner_transport(encoded: str) -> tuple[list[str] | None, str]:
+    try:
+        compressed = base64.b64decode(
+            encoded.encode(), altchars=b"-_", validate=True
+        )
+        decompressor = zlib.decompressobj()
+        raw = decompressor.decompress(compressed, MAX_RUNNER_TRANSPORT_BYTES + 1)
+        if (
+            len(raw) > MAX_RUNNER_TRANSPORT_BYTES
+            or not decompressor.eof
+            or decompressor.unconsumed_tail
+            or decompressor.unused_data
+        ):
+            return None, "Click runner transport exceeded its bounded payload."
+        value = json.loads(raw.decode())
+    except (UnicodeDecodeError, ValueError, json.JSONDecodeError, zlib.error):
+        return None, "Click runner transport was malformed."
+    if (
+        not isinstance(value, list)
+        or not value
+        or any(not isinstance(item, str) or "\x00" in item for item in value)
+    ):
+        return None, "Click runner transport did not contain a valid argv list."
+    return value, ""
+
+
+def windows_launcher_path_is_safe(value: str) -> bool:
+    # Arguments after the launcher are encoded. These characters remain unsafe
+    # in the two launcher paths because cmd.exe and PowerShell expand them even
+    # inside double quotes under some configurations.
+    return not any(character in value for character in ("%", "!", "$", "`"))
+
+
+def default_runner_shell_command(arguments: list[str]) -> str:
+    if os.name == "nt":
+        if len(arguments) < 3 or not all(
+            windows_launcher_path_is_safe(argument) for argument in arguments[:2]
+        ):
+            return "exit 2"
+        transported = [
+            arguments[1],
+            "--encoded-runner",
+            encode_runner_transport(arguments[2:]),
+        ]
+        # hooks.json already requires the Windows py launcher. Reuse its bare
+        # command form here so the rewritten runner is valid in both cmd.exe
+        # and PowerShell; a quoted executable path in command position is only
+        # an expression in PowerShell unless prefixed with its call operator.
+        command = "py -3 " + " ".join(
+            windows_shell_quote(argument) for argument in transported
+        )
+        if len(command) > WINDOWS_COMMAND_LINE_LIMIT:
+            return "exit 2"
+        return command
+    return shlex.join(arguments)
+
+
+_runner_shell_renderer: RunnerShellRenderer = default_runner_shell_command
+
+
+def install_runner_shell_renderer(
+    renderer: RunnerShellRenderer,
+) -> RunnerShellRenderer:
+    """Install one host renderer for this Hook process and return its predecessor."""
+    if not callable(renderer):
+        raise TypeError("Click runner shell renderer must be callable.")
+    global _runner_shell_renderer
+    previous = _runner_shell_renderer
+    _runner_shell_renderer = renderer
+    return previous
+
+
+def render_runner_shell_command(arguments: list[str]) -> str:
+    return _runner_shell_renderer(arguments)

--- a/hooks/click_windows.py
+++ b/hooks/click_windows.py
@@ -11,11 +11,11 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-import click_gate
-import click_hook
-
-
-_ORIGINAL_RUNNER_SHELL_COMMAND = click_gate._runner_shell_command
+if __package__:
+    from . import click_hook, click_runner_transport
+else:  # Executed directly from the bundled hooks directory.
+    import click_hook
+    import click_runner_transport
 
 
 def _powershell_single_quote(value: str) -> str:
@@ -24,7 +24,7 @@ def _powershell_single_quote(value: str) -> str:
 
 def _runner_shell_command(arguments: list[str]) -> str:
     if os.name != "nt":
-        return _ORIGINAL_RUNNER_SHELL_COMMAND(arguments)
+        return click_runner_transport.default_runner_shell_command(arguments)
     if len(arguments) < 3:
         return "exit 2"
     try:
@@ -35,12 +35,12 @@ def _runner_shell_command(arguments: list[str]) -> str:
     if not interpreter.is_file() or not script_path.is_file():
         return "exit 2"
     if not all(
-        click_gate._windows_launcher_path_is_safe(value)
+        click_runner_transport.windows_launcher_path_is_safe(value)
         for value in (str(interpreter), str(script_path))
     ):
         return "exit 2"
 
-    encoded = click_gate._encode_runner_transport(arguments[2:])
+    encoded = click_runner_transport.encode_runner_transport(arguments[2:])
     script = " ".join(
         (
             "&",
@@ -52,16 +52,16 @@ def _runner_shell_command(arguments: list[str]) -> str:
     )
     command = (
         "powershell.exe -NoProfile -NonInteractive -Command "
-        + click_gate._windows_shell_quote(script)
+        + click_runner_transport.windows_shell_quote(script)
     )
-    if len(command) > click_gate.WINDOWS_COMMAND_LINE_LIMIT:
+    if len(command) > click_runner_transport.WINDOWS_COMMAND_LINE_LIMIT:
         return "exit 2"
     return command
 
 
 def main() -> int:
     if os.name == "nt":
-        click_gate._runner_shell_command = _runner_shell_command
+        click_runner_transport.install_runner_shell_renderer(_runner_shell_command)
     return click_hook.main()
 
 

--- a/scripts/build_antigravity_distribution.py
+++ b/scripts/build_antigravity_distribution.py
@@ -30,6 +30,7 @@ HOOK_FILES = (
     "click_mutation.py",
     "click_observation.py",
     "click_process.py",
+    "click_runner_transport.py",
     "click_service.py",
     "click_state.py",
     "click_verification.py",

--- a/tests/click_gate_compatibility_baseline.py
+++ b/tests/click_gate_compatibility_baseline.py
@@ -20,19 +20,9 @@ HOST_ADAPTER_SURFACE: dict[str, frozenset[str]] = {
             "_handle_session_end",
             "_is_read_only_bash",
             "_set_output_adapter",
-            "_windows_launcher_path_is_safe",
         }
     ),
     "hooks/click_hook.py": frozenset({"main"}),
-    "hooks/click_windows.py": frozenset(
-        {
-            "WINDOWS_COMMAND_LINE_LIMIT",
-            "_encode_runner_transport",
-            "_runner_shell_command",
-            "_windows_launcher_path_is_safe",
-            "_windows_shell_quote",
-        }
-    ),
 }
 
 PRIVATE_FORWARDERS: dict[str, str] = {

--- a/tests/click_gate_test_support.py
+++ b/tests/click_gate_test_support.py
@@ -73,7 +73,7 @@ def split_runner_command(command: str) -> list[str]:
         len(parsed) == encoded_index + 2
         and parsed[encoded_index] == "--encoded-runner"
     ):
-        decoded, error = CLICK_GATE._decode_runner_transport(
+        decoded, error = CLICK_GATE.click_runner_transport.decode_runner_transport(
             parsed[encoded_index + 1]
         )
         if error or decoded is None:

--- a/tests/repository_policy_core.py
+++ b/tests/repository_policy_core.py
@@ -529,6 +529,7 @@ class RepositoryPolicyTests(unittest.TestCase):
                 "click_evidence.py",
                 "click_receipt.py",
                 "click_receipt_runtime.py",
+                "click_runner_transport.py",
                 "click_host_coverage.py",
                 "click_inspection.py",
                 "click_lifecycle.py",

--- a/tests/test_antigravity_adapter.py
+++ b/tests/test_antigravity_adapter.py
@@ -449,7 +449,7 @@ class AntigravityAdapterTests(unittest.TestCase):
 
     @unittest.skipUnless(os.name == "nt", "Windows argv parser regression")
     def test_windows_encoded_runner_round_trips_without_shell_expansion(self) -> None:
-        from hooks import antigravity_gate, click_gate
+        from hooks import antigravity_gate, click_runner_transport
 
         arguments = [
             str(Path(sys.executable).resolve()),
@@ -459,18 +459,18 @@ class AntigravityAdapterTests(unittest.TestCase):
             "run-verification",
             "encoded-payload",
         ]
-        command = click_gate._runner_shell_command(arguments)
+        command = click_runner_transport.default_runner_shell_command(arguments)
         parsed = antigravity_gate._command_argv(command)
         self.assertEqual(parsed[:3], ["py", "-3", arguments[1]])
         self.assertEqual(parsed[3], "--encoded-runner")
-        decoded, error = click_gate._decode_runner_transport(parsed[4])
+        decoded, error = click_runner_transport.decode_runner_transport(parsed[4])
         self.assertEqual(error, "")
         self.assertEqual(decoded, arguments[2:])
 
         direct = antigravity_gate._runner_command_argv(command)
         self.assertEqual(direct[:2], arguments[:2])
         self.assertEqual(direct[2], "--encoded-runner")
-        decoded, error = click_gate._decode_runner_transport(direct[3])
+        decoded, error = click_runner_transport.decode_runner_transport(direct[3])
         self.assertEqual(error, "")
         self.assertEqual(decoded, arguments[2:])
 

--- a/tests/test_click_gate_inspection.py
+++ b/tests/test_click_gate_inspection.py
@@ -20,6 +20,9 @@ from click_gate_test_support import (
 )
 
 
+CLICK_RUNNER_TRANSPORT = CLICK_GATE.click_runner_transport
+
+
 class ClickGateInspectionTests(ClickGateTestCase):
     def test_hook_config_loads_mode_for_each_prompt(self) -> None:
         config = json.loads(HOOK_CONFIG.read_text(encoding="utf-8"))
@@ -322,7 +325,9 @@ class ClickGateInspectionTests(ClickGateTestCase):
             ["Get-Content", "-LiteralPath", r"C:\Program Files\README.md"],
         )
         self.assertEqual(
-            CLICK_GATE._windows_shell_quote(r"C:\plugin&data\gate-state"),
+            CLICK_RUNNER_TRANSPORT.windows_shell_quote(
+                r"C:\plugin&data\gate-state"
+            ),
             r'"C:\plugin&data\gate-state"',
         )
 
@@ -338,20 +343,20 @@ class ClickGateInspectionTests(ClickGateTestCase):
             "token",
             "encoded-request",
         ]
-        with mock.patch.object(CLICK_GATE.os, "name", "nt"):
-            command = CLICK_GATE._runner_shell_command(arguments)
+        with mock.patch.object(CLICK_RUNNER_TRANSPORT.os, "name", "nt"):
+            command = CLICK_RUNNER_TRANSPORT.default_runner_shell_command(arguments)
         self.assertTrue(command.startswith('py -3 "C:\\Users\\safe user'))
         self.assertNotIn(arguments[0], command)
         self.assertIn('"--encoded-runner"', command)
         self.assertNotIn("%PATH%", command)
         self.assertNotIn("!CLICK!", command)
         encoded = command.rsplit('"', 2)[1]
-        decoded, error = CLICK_GATE._decode_runner_transport(encoded)
+        decoded, error = CLICK_RUNNER_TRANSPORT.decode_runner_transport(encoded)
         self.assertEqual(error, "")
         self.assertEqual(decoded, arguments[2:])
 
     def test_windows_runner_refuses_expandable_launcher_paths(self) -> None:
-        with mock.patch.object(CLICK_GATE.os, "name", "nt"):
+        with mock.patch.object(CLICK_RUNNER_TRANSPORT.os, "name", "nt"):
             for launcher in (
                 r"C:\%PATH%\python.exe",
                 r"C:\!CLICK!\python.exe",
@@ -360,23 +365,26 @@ class ClickGateInspectionTests(ClickGateTestCase):
             ):
                 with self.subTest(launcher=launcher):
                     self.assertEqual(
-                        CLICK_GATE._runner_shell_command(
+                        CLICK_RUNNER_TRANSPORT.default_runner_shell_command(
                             [launcher, r"C:\click_gate.py", "run-inspection-once", "x"]
                         ),
                         "exit 2",
                     )
 
     def test_runner_transport_rejects_malformed_or_oversized_payloads(self) -> None:
-        for encoded in ("not-base64%", CLICK_GATE._encode_runner_transport([])):
+        for encoded in (
+            "not-base64%",
+            CLICK_RUNNER_TRANSPORT.encode_runner_transport([]),
+        ):
             with self.subTest(encoded=encoded):
-                decoded, error = CLICK_GATE._decode_runner_transport(encoded)
+                decoded, error = CLICK_RUNNER_TRANSPORT.decode_runner_transport(encoded)
                 self.assertIsNone(decoded)
                 self.assertTrue(error)
 
-        bomb = CLICK_GATE.base64.urlsafe_b64encode(
-            CLICK_GATE.zlib.compress(b'"' + b"x" * 30_000 + b'"')
+        bomb = CLICK_RUNNER_TRANSPORT.base64.urlsafe_b64encode(
+            CLICK_RUNNER_TRANSPORT.zlib.compress(b'"' + b"x" * 30_000 + b'"')
         ).decode()
-        decoded, error = CLICK_GATE._decode_runner_transport(bomb)
+        decoded, error = CLICK_RUNNER_TRANSPORT.decode_runner_transport(bomb)
         self.assertIsNone(decoded)
         self.assertIn("bounded payload", error)
 

--- a/tests/test_click_runner_transport.py
+++ b/tests/test_click_runner_transport.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+import shlex
+import unittest
+from unittest import mock
+
+from hooks import click_gate, click_runner_transport, click_windows
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ClickRunnerTransportTests(unittest.TestCase):
+    def test_transport_is_a_leaf_runtime_boundary(self) -> None:
+        source = (ROOT / "hooks" / "click_runner_transport.py").read_text(
+            encoding="utf-8"
+        )
+
+        for forbidden in (
+            "click_contract",
+            "click_evidence",
+            "click_gate",
+            "click_state",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(f"import {forbidden}", source)
+                self.assertNotIn(f"from {forbidden}", source)
+
+    def test_default_posix_renderer_preserves_argv(self) -> None:
+        arguments = ["python3", "click gate.py", "value with spaces", "$literal"]
+
+        with mock.patch.object(click_runner_transport.os, "name", "posix"):
+            rendered = click_runner_transport.default_runner_shell_command(arguments)
+
+        self.assertEqual(shlex.split(rendered), arguments)
+
+    def test_host_renderer_installation_is_explicit_and_reversible(self) -> None:
+        def sentinel(arguments: list[str]) -> str:
+            return "host:" + "|".join(arguments)
+
+        previous = click_runner_transport.install_runner_shell_renderer(sentinel)
+        self.addCleanup(click_runner_transport.install_runner_shell_renderer, previous)
+
+        self.assertEqual(
+            click_runner_transport.render_runner_shell_command(["one", "two"]),
+            "host:one|two",
+        )
+
+    def test_windows_bridge_configures_transport_without_gate_monkeypatch(self) -> None:
+        source = (ROOT / "hooks" / "click_windows.py").read_text(encoding="utf-8")
+        self.assertNotIn("import click_gate", source)
+
+        with (
+            mock.patch.object(click_windows.os, "name", "nt"),
+            mock.patch.object(
+                click_windows.click_runner_transport,
+                "install_runner_shell_renderer",
+            ) as install,
+            mock.patch.object(click_windows.click_hook, "main", return_value=17),
+        ):
+            self.assertEqual(click_windows.main(), 17)
+
+        install.assert_called_once_with(click_windows._runner_shell_command)
+
+    def test_gate_no_longer_exposes_runner_transport_privates(self) -> None:
+        for name in (
+            "MAX_RUNNER_TRANSPORT_BYTES",
+            "WINDOWS_COMMAND_LINE_LIMIT",
+            "_decode_runner_transport",
+            "_encode_runner_transport",
+            "_runner_shell_command",
+            "_windows_launcher_path_is_safe",
+            "_windows_shell_quote",
+        ):
+            with self.subTest(name=name):
+                self.assertFalse(hasattr(click_gate, name))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- extract bounded runner argv encoding, decoding, Windows quoting, and shell rendering into a stdlib-only `click_runner_transport` leaf
- let Windows install its process-local renderer through the transport boundary instead of monkeypatching `click_gate`
- move the Antigravity launcher-path check to the same boundary and shrink direct host dependencies on gate-private symbols from 14 to 8
- sync the Antigravity distribution and add focused architecture/transport tests

## Scope

- behavior-preserving runtime refactor
- no mode, contract, receipt, evidence-cache, or release behavior changes
- stacked on #66 so the compatibility-surface baseline shrinks explicitly

## Verification

- full local suite: 432 tests passed, 3 skipped on Linux
- runner transport tests: 5 passed
- compatibility-surface tests: 4 passed
- gate inspection: 48 passed
- Antigravity adapter: 13 passed, 1 skipped on Linux
- Windows hook tests: 1 passed, 2 skipped on Linux; Windows CI is the cross-platform verdict
- distribution validation: passed
- Python compilation and `git diff --check`: passed