### PR TITLE
refactor: add formal host routing interface

### DIFF
--- a/COMPATIBILITY_SURFACE.md
+++ b/COMPATIBILITY_SURFACE.md
@@ -19,17 +19,16 @@ an underscore are not a general public extension API.
 The current host adapters still call a small, explicit set of gate symbols:
 
 - `hooks/click_hook.py`: `main`
-- `hooks/antigravity_gate.py`: `SHELL_CONTROL_PUNCTUATION`, `_emit`,
-  `_handle_post_tool`, `_handle_pre_tool`, `_handle_prompt_submit`,
-  `_handle_session_end`, `_is_read_only_bash`, and `_set_output_adapter`
+- `hooks/antigravity_gate.py`: public `host_router`
 
 `hooks/click_windows.py` and the Antigravity launcher-path check use the formal
 `click_runner_transport` boundary. They no longer reach through private gate
 symbols to configure or decode runner commands.
 
-This bridge is compatibility state, not the desired final host API. A later
-refactor should replace it with named host-routing and runner-transport
-interfaces before removing the gate symbols.
+The named `click_host_router` and `click_runner_transport` interfaces now own
+adapter routing and runner transport. The remaining `click_gate.main` and
+`click_gate.host_router` entries are the explicit host-facing facade rather
+than private compatibility reach-through.
 
 ## Documented legacy symbol
 

--- a/dist/antigravity/hooks/antigravity_gate.py
+++ b/dist/antigravity/hooks/antigravity_gate.py
@@ -16,19 +16,23 @@ import shlex
 import subprocess
 import sys
 import time
-from typing import Any, Callable
+from typing import Any
 
 if __package__:
     from . import (
+        click_capability,
         click_gate,
         click_host_coverage,
+        click_inspection,
         click_runner_transport,
         click_state,
     )
     from .platform_protocol import AntigravityOutputAdapter, CodexOutputAdapter
 else:  # Executed directly from the bundled hooks directory.
+    import click_capability
     import click_gate
     import click_host_coverage
+    import click_inspection
     import click_runner_transport
     import click_state
     from platform_protocol import AntigravityOutputAdapter, CodexOutputAdapter
@@ -39,6 +43,7 @@ ANTIGRAVITY_MUTATION_TOOLS = (
     click_host_coverage.ANTIGRAVITY_MUTATION_TOOL_NAMES
 )
 MAX_TRANSCRIPT_BYTES = 1_000_000
+HOST_ROUTER = click_gate.host_router()
 
 
 def _configure_storage() -> None:
@@ -189,19 +194,10 @@ def _canonical_event(context: dict[str, Any], *, prompt: str = "") -> dict[str, 
 
 def _capture(
     adapter: Any,
-    handler: Callable[[dict[str, Any]], None],
+    action: str,
     event: dict[str, Any],
 ) -> dict[str, Any]:
-    outputs: list[dict[str, Any]] = []
-    previous_emit = click_gate._emit
-    previous_adapter = click_gate._set_output_adapter(adapter)
-    click_gate._emit = outputs.append
-    try:
-        handler(event)
-    finally:
-        click_gate._emit = previous_emit
-        click_gate._set_output_adapter(previous_adapter)
-    return outputs[-1] if outputs else {}
+    return HOST_ROUTER.capture(action, event, output_adapter=adapter)
 
 
 def _record_pre_invocation(raw: dict[str, Any]) -> dict[str, Any]:
@@ -239,7 +235,7 @@ def _record_pre_invocation(raw: dict[str, Any]) -> dict[str, Any]:
         click_state.write_json(_workspace_context_path(workspace), context)
         event = _canonical_event(context, prompt=prompt)
         payload = _capture(
-            AntigravityOutputAdapter(), click_gate._handle_prompt_submit, event
+            AntigravityOutputAdapter(), "prompt-submit", event
         )
         steps = payload.get("injectSteps") if isinstance(payload, dict) else None
         if isinstance(steps, list) and steps and isinstance(steps[0], dict):
@@ -366,7 +362,9 @@ def _antigravity_bash_tokens(command: str) -> list[str] | None:
         lexer = shlex.shlex(
             command,
             posix=True,
-            punctuation_chars="".join(sorted(click_gate.SHELL_CONTROL_PUNCTUATION)),
+            punctuation_chars="".join(
+                sorted(click_capability.SHELL_CONTROL_PUNCTUATION)
+            ),
         )
         lexer.whitespace_split = True
         lexer.commenters = ""
@@ -374,7 +372,7 @@ def _antigravity_bash_tokens(command: str) -> list[str] | None:
     except ValueError:
         return None
     if not tokens or any(
-        token and set(token).issubset(click_gate.SHELL_CONTROL_PUNCTUATION)
+        token and set(token).issubset(click_capability.SHELL_CONTROL_PUNCTUATION)
         for token in tokens
     ):
         return None
@@ -419,7 +417,7 @@ def _pre_tool(raw: dict[str, Any]) -> dict[str, Any]:
         if tool_name not in ANTIGRAVITY_MUTATION_TOOLS:
             return {"decision": "allow"}
         command = str(arguments.get("CommandLine", ""))
-        if tool_name == "run_command" and click_gate._is_read_only_bash(command):
+        if tool_name == "run_command" and click_inspection.is_read_only_bash(command):
             return _native_run_command_read_denial()
         return {
             "decision": "deny",
@@ -440,11 +438,11 @@ def _pre_tool(raw: dict[str, Any]) -> dict[str, Any]:
         event["tool_input"] = {"command": command}
         if _launcher_tokens(command, str(context["workspace"])) is not None:
             return {"decision": "allow"}
-        if click_gate._is_read_only_bash(command):
+        if click_inspection.is_read_only_bash(command):
             return _native_run_command_read_denial()
     with click_state.state_lock():
         payload = _capture(
-            AntigravityOutputAdapter(), click_gate._handle_pre_tool, event
+            AntigravityOutputAdapter(), "pre-tool", event
         )
     return payload or {"decision": "allow"}
 
@@ -472,7 +470,7 @@ def _post_tool(raw: dict[str, Any]) -> dict[str, Any]:
         }
     )
     with click_state.state_lock():
-        click_gate._handle_post_tool(event)
+        HOST_ROUTER.dispatch("post-tool", event)
     return {"decision": "allow"}
 
 
@@ -482,7 +480,7 @@ def _stop(raw: dict[str, Any]) -> dict[str, Any]:
         with click_state.state_lock():
             _capture(
                 AntigravityOutputAdapter(),
-                click_gate._handle_session_end,
+                "session-end",
                 _canonical_event(context),
             )
             if (
@@ -521,7 +519,7 @@ def _control(arguments: list[str]) -> int:
         }
     )
     with click_state.state_lock():
-        payload = _capture(CodexOutputAdapter(), click_gate._handle_pre_tool, event)
+        payload = _capture(CodexOutputAdapter(), "pre-tool", event)
     output = payload.get("hookSpecificOutput") if isinstance(payload, dict) else None
     if not isinstance(output, dict):
         return 0

--- a/dist/antigravity/hooks/click_gate.py
+++ b/dist/antigravity/hooks/click_gate.py
@@ -28,6 +28,7 @@ if __package__:
         click_contract,
         click_evidence,
         click_host_coverage,
+        click_host_router,
         click_inspection,
         click_lifecycle,
         click_mutation,
@@ -62,6 +63,7 @@ else:  # Executed directly from the bundled hooks directory.
     import click_contract
     import click_evidence
     import click_host_coverage
+    import click_host_router
     import click_inspection
     import click_lifecycle
     import click_mutation
@@ -334,11 +336,28 @@ SED_READ_SCRIPT = click_inspection.SED_READ_SCRIPT
 _OUTPUT_ADAPTER: HookOutputAdapter = CodexOutputAdapter()
 
 
+def _write_stdout_payload(payload: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(payload, ensure_ascii=False, separators=(",", ":")))
+
+
+_OUTPUT_SINK: click_host_router.OutputSink = _write_stdout_payload
+
+
 def _set_output_adapter(adapter: HookOutputAdapter) -> HookOutputAdapter:
     """Select a host serializer and return the previous serializer."""
     global _OUTPUT_ADAPTER
     previous = _OUTPUT_ADAPTER
     _OUTPUT_ADAPTER = adapter
+    return previous
+
+
+def _set_output_sink(
+    sink: click_host_router.OutputSink,
+) -> click_host_router.OutputSink:
+    """Select a host output sink and return the previous sink."""
+    global _OUTPUT_SINK
+    previous = _OUTPUT_SINK
+    _OUTPUT_SINK = sink
     return previous
 
 RG_OPTIONS_WITH_VALUES = click_inspection.RG_OPTIONS_WITH_VALUES
@@ -349,7 +368,7 @@ GIT_REMOTE_NAME = click_inspection.GIT_REMOTE_NAME
 
 
 def _emit(payload: dict[str, Any]) -> None:
-    sys.stdout.write(json.dumps(payload, ensure_ascii=False, separators=(",", ":")))
+    _OUTPUT_SINK(payload)
 
 
 def _deny(reason: str) -> None:
@@ -1102,6 +1121,23 @@ def _handle_pre_tool(event: dict[str, Any]) -> None:
         )
 
 
+_HOST_ROUTER = click_host_router.HostRouter(
+    click_host_router.HostHandlers(
+        pre_tool=_handle_pre_tool,
+        post_tool=_handle_post_tool,
+        prompt_submit=_handle_prompt_submit,
+        session_end=_handle_session_end,
+    ),
+    set_output_adapter=_set_output_adapter,
+    set_output_sink=_set_output_sink,
+)
+
+
+def host_router() -> click_host_router.HostRouter:
+    """Return the supported routing interface used by bundled host adapters."""
+    return _HOST_ROUTER
+
+
 def _record_verification_result(
     path: Path,
     batch: dict[str, Any],
@@ -1407,18 +1443,8 @@ def main() -> int:
         return 1
     try:
         event = _read_event()
-        if arguments[0] == "prompt-submit":
-            with _state_lock():
-                _handle_prompt_submit(event)
-        elif arguments[0] == "post-tool":
-            with _state_lock():
-                _handle_post_tool(event)
-        elif arguments[0] == "session-end":
-            with _state_lock():
-                _handle_session_end(event)
-        else:
-            with _state_lock():
-                _handle_pre_tool(event)
+        with _state_lock():
+            _HOST_ROUTER.dispatch(arguments[0], event)
     except (OSError, ValueError) as exc:
         sys.stderr.write(f"click hook error: {exc}\n")
         return 1

--- a/dist/antigravity/hooks/click_host_router.py
+++ b/dist/antigravity/hooks/click_host_router.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Named host-routing boundary for Click Hook adapters.
+
+The router owns no contract, state, evidence, or capability behavior. It binds
+the four canonical Hook events to their runtime handlers and provides a scoped
+output-capture mechanism for adapters such as Google Antigravity. This keeps
+host adapters from reaching through ``click_gate`` private globals.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+
+Event = dict[str, Any]
+EventHandler = Callable[[Event], None]
+OutputAdapterSetter = Callable[[Any], Any]
+OutputSink = Callable[[dict[str, Any]], None]
+OutputSinkSetter = Callable[[OutputSink], OutputSink]
+
+
+@dataclass(frozen=True)
+class HostHandlers:
+    pre_tool: EventHandler
+    post_tool: EventHandler
+    prompt_submit: EventHandler
+    session_end: EventHandler
+
+
+class HostRouter:
+    """Dispatch canonical host events through one explicit adapter boundary."""
+
+    def __init__(
+        self,
+        handlers: HostHandlers,
+        *,
+        set_output_adapter: OutputAdapterSetter,
+        set_output_sink: OutputSinkSetter,
+    ) -> None:
+        self._handlers = handlers
+        self._set_output_adapter = set_output_adapter
+        self._set_output_sink = set_output_sink
+
+    def dispatch(self, action: str, event: Event) -> None:
+        handlers = {
+            "pre-tool": self._handlers.pre_tool,
+            "post-tool": self._handlers.post_tool,
+            "prompt-submit": self._handlers.prompt_submit,
+            "session-end": self._handlers.session_end,
+        }
+        try:
+            handler = handlers[action]
+        except KeyError as exc:
+            raise ValueError(f"unsupported Click host action: {action}") from exc
+        handler(event)
+
+    def capture(
+        self, action: str, event: Event, *, output_adapter: Any
+    ) -> dict[str, Any]:
+        """Run one event with a temporary serializer and in-memory output sink."""
+
+        outputs: list[dict[str, Any]] = []
+        previous_adapter = self._set_output_adapter(output_adapter)
+        previous_sink = self._set_output_sink(outputs.append)
+        try:
+            self.dispatch(action, event)
+        finally:
+            self._set_output_sink(previous_sink)
+            self._set_output_adapter(previous_adapter)
+        return outputs[-1] if outputs else {}

--- a/hooks/antigravity_gate.py
+++ b/hooks/antigravity_gate.py
@@ -16,19 +16,23 @@ import shlex
 import subprocess
 import sys
 import time
-from typing import Any, Callable
+from typing import Any
 
 if __package__:
     from . import (
+        click_capability,
         click_gate,
         click_host_coverage,
+        click_inspection,
         click_runner_transport,
         click_state,
     )
     from .platform_protocol import AntigravityOutputAdapter, CodexOutputAdapter
 else:  # Executed directly from the bundled hooks directory.
+    import click_capability
     import click_gate
     import click_host_coverage
+    import click_inspection
     import click_runner_transport
     import click_state
     from platform_protocol import AntigravityOutputAdapter, CodexOutputAdapter
@@ -39,6 +43,7 @@ ANTIGRAVITY_MUTATION_TOOLS = (
     click_host_coverage.ANTIGRAVITY_MUTATION_TOOL_NAMES
 )
 MAX_TRANSCRIPT_BYTES = 1_000_000
+HOST_ROUTER = click_gate.host_router()
 
 
 def _configure_storage() -> None:
@@ -189,19 +194,10 @@ def _canonical_event(context: dict[str, Any], *, prompt: str = "") -> dict[str, 
 
 def _capture(
     adapter: Any,
-    handler: Callable[[dict[str, Any]], None],
+    action: str,
     event: dict[str, Any],
 ) -> dict[str, Any]:
-    outputs: list[dict[str, Any]] = []
-    previous_emit = click_gate._emit
-    previous_adapter = click_gate._set_output_adapter(adapter)
-    click_gate._emit = outputs.append
-    try:
-        handler(event)
-    finally:
-        click_gate._emit = previous_emit
-        click_gate._set_output_adapter(previous_adapter)
-    return outputs[-1] if outputs else {}
+    return HOST_ROUTER.capture(action, event, output_adapter=adapter)
 
 
 def _record_pre_invocation(raw: dict[str, Any]) -> dict[str, Any]:
@@ -239,7 +235,7 @@ def _record_pre_invocation(raw: dict[str, Any]) -> dict[str, Any]:
         click_state.write_json(_workspace_context_path(workspace), context)
         event = _canonical_event(context, prompt=prompt)
         payload = _capture(
-            AntigravityOutputAdapter(), click_gate._handle_prompt_submit, event
+            AntigravityOutputAdapter(), "prompt-submit", event
         )
         steps = payload.get("injectSteps") if isinstance(payload, dict) else None
         if isinstance(steps, list) and steps and isinstance(steps[0], dict):
@@ -366,7 +362,9 @@ def _antigravity_bash_tokens(command: str) -> list[str] | None:
         lexer = shlex.shlex(
             command,
             posix=True,
-            punctuation_chars="".join(sorted(click_gate.SHELL_CONTROL_PUNCTUATION)),
+            punctuation_chars="".join(
+                sorted(click_capability.SHELL_CONTROL_PUNCTUATION)
+            ),
         )
         lexer.whitespace_split = True
         lexer.commenters = ""
@@ -374,7 +372,7 @@ def _antigravity_bash_tokens(command: str) -> list[str] | None:
     except ValueError:
         return None
     if not tokens or any(
-        token and set(token).issubset(click_gate.SHELL_CONTROL_PUNCTUATION)
+        token and set(token).issubset(click_capability.SHELL_CONTROL_PUNCTUATION)
         for token in tokens
     ):
         return None
@@ -419,7 +417,7 @@ def _pre_tool(raw: dict[str, Any]) -> dict[str, Any]:
         if tool_name not in ANTIGRAVITY_MUTATION_TOOLS:
             return {"decision": "allow"}
         command = str(arguments.get("CommandLine", ""))
-        if tool_name == "run_command" and click_gate._is_read_only_bash(command):
+        if tool_name == "run_command" and click_inspection.is_read_only_bash(command):
             return _native_run_command_read_denial()
         return {
             "decision": "deny",
@@ -440,11 +438,11 @@ def _pre_tool(raw: dict[str, Any]) -> dict[str, Any]:
         event["tool_input"] = {"command": command}
         if _launcher_tokens(command, str(context["workspace"])) is not None:
             return {"decision": "allow"}
-        if click_gate._is_read_only_bash(command):
+        if click_inspection.is_read_only_bash(command):
             return _native_run_command_read_denial()
     with click_state.state_lock():
         payload = _capture(
-            AntigravityOutputAdapter(), click_gate._handle_pre_tool, event
+            AntigravityOutputAdapter(), "pre-tool", event
         )
     return payload or {"decision": "allow"}
 
@@ -472,7 +470,7 @@ def _post_tool(raw: dict[str, Any]) -> dict[str, Any]:
         }
     )
     with click_state.state_lock():
-        click_gate._handle_post_tool(event)
+        HOST_ROUTER.dispatch("post-tool", event)
     return {"decision": "allow"}
 
 
@@ -482,7 +480,7 @@ def _stop(raw: dict[str, Any]) -> dict[str, Any]:
         with click_state.state_lock():
             _capture(
                 AntigravityOutputAdapter(),
-                click_gate._handle_session_end,
+                "session-end",
                 _canonical_event(context),
             )
             if (
@@ -521,7 +519,7 @@ def _control(arguments: list[str]) -> int:
         }
     )
     with click_state.state_lock():
-        payload = _capture(CodexOutputAdapter(), click_gate._handle_pre_tool, event)
+        payload = _capture(CodexOutputAdapter(), "pre-tool", event)
     output = payload.get("hookSpecificOutput") if isinstance(payload, dict) else None
     if not isinstance(output, dict):
         return 0

--- a/hooks/click_gate.py
+++ b/hooks/click_gate.py
@@ -28,6 +28,7 @@ if __package__:
         click_contract,
         click_evidence,
         click_host_coverage,
+        click_host_router,
         click_inspection,
         click_lifecycle,
         click_mutation,
@@ -62,6 +63,7 @@ else:  # Executed directly from the bundled hooks directory.
     import click_contract
     import click_evidence
     import click_host_coverage
+    import click_host_router
     import click_inspection
     import click_lifecycle
     import click_mutation
@@ -334,11 +336,28 @@ SED_READ_SCRIPT = click_inspection.SED_READ_SCRIPT
 _OUTPUT_ADAPTER: HookOutputAdapter = CodexOutputAdapter()
 
 
+def _write_stdout_payload(payload: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(payload, ensure_ascii=False, separators=(",", ":")))
+
+
+_OUTPUT_SINK: click_host_router.OutputSink = _write_stdout_payload
+
+
 def _set_output_adapter(adapter: HookOutputAdapter) -> HookOutputAdapter:
     """Select a host serializer and return the previous serializer."""
     global _OUTPUT_ADAPTER
     previous = _OUTPUT_ADAPTER
     _OUTPUT_ADAPTER = adapter
+    return previous
+
+
+def _set_output_sink(
+    sink: click_host_router.OutputSink,
+) -> click_host_router.OutputSink:
+    """Select a host output sink and return the previous sink."""
+    global _OUTPUT_SINK
+    previous = _OUTPUT_SINK
+    _OUTPUT_SINK = sink
     return previous
 
 RG_OPTIONS_WITH_VALUES = click_inspection.RG_OPTIONS_WITH_VALUES
@@ -349,7 +368,7 @@ GIT_REMOTE_NAME = click_inspection.GIT_REMOTE_NAME
 
 
 def _emit(payload: dict[str, Any]) -> None:
-    sys.stdout.write(json.dumps(payload, ensure_ascii=False, separators=(",", ":")))
+    _OUTPUT_SINK(payload)
 
 
 def _deny(reason: str) -> None:
@@ -1102,6 +1121,23 @@ def _handle_pre_tool(event: dict[str, Any]) -> None:
         )
 
 
+_HOST_ROUTER = click_host_router.HostRouter(
+    click_host_router.HostHandlers(
+        pre_tool=_handle_pre_tool,
+        post_tool=_handle_post_tool,
+        prompt_submit=_handle_prompt_submit,
+        session_end=_handle_session_end,
+    ),
+    set_output_adapter=_set_output_adapter,
+    set_output_sink=_set_output_sink,
+)
+
+
+def host_router() -> click_host_router.HostRouter:
+    """Return the supported routing interface used by bundled host adapters."""
+    return _HOST_ROUTER
+
+
 def _record_verification_result(
     path: Path,
     batch: dict[str, Any],
@@ -1407,18 +1443,8 @@ def main() -> int:
         return 1
     try:
         event = _read_event()
-        if arguments[0] == "prompt-submit":
-            with _state_lock():
-                _handle_prompt_submit(event)
-        elif arguments[0] == "post-tool":
-            with _state_lock():
-                _handle_post_tool(event)
-        elif arguments[0] == "session-end":
-            with _state_lock():
-                _handle_session_end(event)
-        else:
-            with _state_lock():
-                _handle_pre_tool(event)
+        with _state_lock():
+            _HOST_ROUTER.dispatch(arguments[0], event)
     except (OSError, ValueError) as exc:
         sys.stderr.write(f"click hook error: {exc}\n")
         return 1

--- a/hooks/click_host_router.py
+++ b/hooks/click_host_router.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Named host-routing boundary for Click Hook adapters.
+
+The router owns no contract, state, evidence, or capability behavior. It binds
+the four canonical Hook events to their runtime handlers and provides a scoped
+output-capture mechanism for adapters such as Google Antigravity. This keeps
+host adapters from reaching through ``click_gate`` private globals.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+
+Event = dict[str, Any]
+EventHandler = Callable[[Event], None]
+OutputAdapterSetter = Callable[[Any], Any]
+OutputSink = Callable[[dict[str, Any]], None]
+OutputSinkSetter = Callable[[OutputSink], OutputSink]
+
+
+@dataclass(frozen=True)
+class HostHandlers:
+    pre_tool: EventHandler
+    post_tool: EventHandler
+    prompt_submit: EventHandler
+    session_end: EventHandler
+
+
+class HostRouter:
+    """Dispatch canonical host events through one explicit adapter boundary."""
+
+    def __init__(
+        self,
+        handlers: HostHandlers,
+        *,
+        set_output_adapter: OutputAdapterSetter,
+        set_output_sink: OutputSinkSetter,
+    ) -> None:
+        self._handlers = handlers
+        self._set_output_adapter = set_output_adapter
+        self._set_output_sink = set_output_sink
+
+    def dispatch(self, action: str, event: Event) -> None:
+        handlers = {
+            "pre-tool": self._handlers.pre_tool,
+            "post-tool": self._handlers.post_tool,
+            "prompt-submit": self._handlers.prompt_submit,
+            "session-end": self._handlers.session_end,
+        }
+        try:
+            handler = handlers[action]
+        except KeyError as exc:
+            raise ValueError(f"unsupported Click host action: {action}") from exc
+        handler(event)
+
+    def capture(
+        self, action: str, event: Event, *, output_adapter: Any
+    ) -> dict[str, Any]:
+        """Run one event with a temporary serializer and in-memory output sink."""
+
+        outputs: list[dict[str, Any]] = []
+        previous_adapter = self._set_output_adapter(output_adapter)
+        previous_sink = self._set_output_sink(outputs.append)
+        try:
+            self.dispatch(action, event)
+        finally:
+            self._set_output_sink(previous_sink)
+            self._set_output_adapter(previous_adapter)
+        return outputs[-1] if outputs else {}

--- a/scripts/build_antigravity_distribution.py
+++ b/scripts/build_antigravity_distribution.py
@@ -25,6 +25,7 @@ HOOK_FILES = (
     "click_receipt.py",
     "click_receipt_runtime.py",
     "click_host_coverage.py",
+    "click_host_router.py",
     "click_inspection.py",
     "click_lifecycle.py",
     "click_mutation.py",

--- a/tests/click_gate_compatibility_baseline.py
+++ b/tests/click_gate_compatibility_baseline.py
@@ -12,14 +12,7 @@ DOCUMENTED_LEGACY_FORWARDERS: dict[str, str] = {
 HOST_ADAPTER_SURFACE: dict[str, frozenset[str]] = {
     "hooks/antigravity_gate.py": frozenset(
         {
-            "SHELL_CONTROL_PUNCTUATION",
-            "_emit",
-            "_handle_post_tool",
-            "_handle_pre_tool",
-            "_handle_prompt_submit",
-            "_handle_session_end",
-            "_is_read_only_bash",
-            "_set_output_adapter",
+            "host_router",
         }
     ),
     "hooks/click_hook.py": frozenset({"main"}),

--- a/tests/repository_policy_core.py
+++ b/tests/repository_policy_core.py
@@ -531,6 +531,7 @@ class RepositoryPolicyTests(unittest.TestCase):
                 "click_receipt_runtime.py",
                 "click_runner_transport.py",
                 "click_host_coverage.py",
+                "click_host_router.py",
                 "click_inspection.py",
                 "click_lifecycle.py",
                 "click_gate.py",

--- a/tests/test_click_compatibility_surface.py
+++ b/tests/test_click_compatibility_surface.py
@@ -4,12 +4,20 @@ import ast
 from pathlib import Path
 import unittest
 
-from click_gate_compatibility_baseline import (
-    DOCUMENTED_LEGACY_FORWARDERS,
-    HOST_ADAPTER_SURFACE,
-    MAX_PRIVATE_FORWARDERS,
-    PRIVATE_FORWARDERS,
-)
+try:
+    from .click_gate_compatibility_baseline import (
+        DOCUMENTED_LEGACY_FORWARDERS,
+        HOST_ADAPTER_SURFACE,
+        MAX_PRIVATE_FORWARDERS,
+        PRIVATE_FORWARDERS,
+    )
+except ImportError:  # unittest discovery with tests/ as the import root.
+    from click_gate_compatibility_baseline import (
+        DOCUMENTED_LEGACY_FORWARDERS,
+        HOST_ADAPTER_SURFACE,
+        MAX_PRIVATE_FORWARDERS,
+        PRIVATE_FORWARDERS,
+    )
 
 
 ROOT = Path(__file__).resolve().parents[1]

--- a/tests/test_click_host_router.py
+++ b/tests/test_click_host_router.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import unittest
+
+from hooks import click_gate, click_host_router
+
+
+class ClickHostRouterTests(unittest.TestCase):
+    def test_dispatch_uses_the_named_handler_for_each_host_event(self) -> None:
+        calls: list[tuple[str, dict[str, object]]] = []
+
+        def handler(name: str):
+            return lambda event: calls.append((name, event))
+
+        router = click_host_router.HostRouter(
+            click_host_router.HostHandlers(
+                pre_tool=handler("pre-tool"),
+                post_tool=handler("post-tool"),
+                prompt_submit=handler("prompt-submit"),
+                session_end=handler("session-end"),
+            ),
+            set_output_adapter=lambda adapter: adapter,
+            set_output_sink=lambda sink: sink,
+        )
+
+        for action in ("pre-tool", "post-tool", "prompt-submit", "session-end"):
+            router.dispatch(action, {"action": action})
+
+        self.assertEqual(
+            [name for name, _ in calls],
+            ["pre-tool", "post-tool", "prompt-submit", "session-end"],
+        )
+
+    def test_capture_scopes_adapter_and_sink_then_restores_both(self) -> None:
+        active: dict[str, object] = {
+            "adapter": "original-adapter",
+            "sink": lambda _payload: None,
+        }
+
+        def set_adapter(value: object) -> object:
+            previous = active["adapter"]
+            active["adapter"] = value
+            return previous
+
+        def set_sink(value):
+            previous = active["sink"]
+            active["sink"] = value
+            return previous
+
+        def pre_tool(event: dict[str, object]) -> None:
+            active["sink"]({"adapter": active["adapter"], **event})
+
+        router = click_host_router.HostRouter(
+            click_host_router.HostHandlers(
+                pre_tool=pre_tool,
+                post_tool=lambda _event: None,
+                prompt_submit=lambda _event: None,
+                session_end=lambda _event: None,
+            ),
+            set_output_adapter=set_adapter,
+            set_output_sink=set_sink,
+        )
+
+        result = router.capture(
+            "pre-tool", {"event": "captured"}, output_adapter="temporary"
+        )
+
+        self.assertEqual(result, {"adapter": "temporary", "event": "captured"})
+        self.assertEqual(active["adapter"], "original-adapter")
+        self.assertTrue(callable(active["sink"]))
+
+    def test_gate_exposes_one_stable_host_router(self) -> None:
+        self.assertIs(click_gate.host_router(), click_gate.host_router())
+
+    def test_unknown_host_action_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsupported Click host action"):
+            click_gate.host_router().dispatch("unknown", {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import json
 import unittest
 
-import repository_policy_core as core
+try:
+    from . import repository_policy_core as core
+except ImportError:  # unittest discovery with tests/ as the import root.
+    import repository_policy_core as core
 
 
 ROOT = core.ROOT


### PR DESCRIPTION
## Summary

- add a named `click_host_router` boundary for the four canonical Hook events
- replace Antigravity reach-through to eight `click_gate` private symbols with the public `host_router` interface and owning capability/inspection modules
- replace output monkeypatching with scoped adapter and sink capture
- route the Codex gate entrypoint through the same interface and sync the Antigravity distribution

## Scope

- behavior-preserving host-adapter refactor
- no mode, contract, receipt, evidence-cache, CLI, or release behavior changes
- preserves the documented `click_gate._validate_contract` compatibility symbol

## Verification

- architecture/adapter/distribution group: 66 passed, 3 skipped on Linux
- compatibility surface now records only public `host_router` for Antigravity
- `git diff --check`: passed
- GitHub CI is the final Linux, macOS, and Windows verdict