### PR TITLE
refactor: centralize hook import bootstrap

### DIFF
--- a/dist/antigravity/hooks/antigravity_gate.py
+++ b/dist/antigravity/hooks/antigravity_gate.py
@@ -19,23 +19,32 @@ import time
 from typing import Any
 
 if __package__:
-    from . import (
-        click_capability,
-        click_gate,
-        click_host_coverage,
-        click_inspection,
-        click_runner_transport,
-        click_state,
-    )
-    from .platform_protocol import AntigravityOutputAdapter, CodexOutputAdapter
+    from . import click_import_bootstrap
 else:  # Executed directly from the bundled hooks directory.
-    import click_capability
-    import click_gate
-    import click_host_coverage
-    import click_inspection
-    import click_runner_transport
-    import click_state
-    from platform_protocol import AntigravityOutputAdapter, CodexOutputAdapter
+    import click_import_bootstrap
+
+
+(
+    click_capability,
+    click_gate,
+    click_host_coverage,
+    click_inspection,
+    click_runner_transport,
+    click_state,
+    platform_protocol,
+) = click_import_bootstrap.load_siblings(
+    __package__,
+    "click_capability",
+    "click_gate",
+    "click_host_coverage",
+    "click_inspection",
+    "click_runner_transport",
+    "click_state",
+    "platform_protocol",
+)
+
+AntigravityOutputAdapter = platform_protocol.AntigravityOutputAdapter
+CodexOutputAdapter = platform_protocol.CodexOutputAdapter
 
 
 ANTIGRAVITY_TOOL_MAP = click_host_coverage.ANTIGRAVITY_TOOL_MAP

--- a/dist/antigravity/hooks/click_gate.py
+++ b/dist/antigravity/hooks/click_gate.py
@@ -21,75 +21,87 @@ import time
 from typing import Any
 
 if __package__:
-    from . import (
-        click_browser,
-        click_browser_advisory,
-        click_capability,
-        click_contract,
-        click_evidence,
-        click_host_coverage,
-        click_host_router,
-        click_inspection,
-        click_lifecycle,
-        click_mutation,
-        click_observation,
-        click_process,
-        click_receipt_runtime,
-        click_runner_transport,
-        click_service,
-        click_verification,
-        click_verification_policy,
-    )
-    from .click_state import (
-        STATE_LOCK_STALE_SECONDS,
-        STATE_LOCK_TIMEOUT_SECONDS,
-        contract_path as _contract_path,
-        identity_path as _identity_path,
-        managed_state_path as _managed_state_path,
-        mode_path as _mode_path,
-        preference_path as _preference_path,
-        prompt_path as _prompt_path,
-        review_path as _review_path,
-        state_lock as _state_lock,
-        state_path as _state_path,
-        state_root as _state_root,
-        write_json as _write_json,
-    )
-    from .platform_protocol import CodexOutputAdapter, HookOutputAdapter
+    from . import click_import_bootstrap
 else:  # Executed directly from the bundled hooks directory.
-    import click_browser
-    import click_browser_advisory
-    import click_capability
-    import click_contract
-    import click_evidence
-    import click_host_coverage
-    import click_host_router
-    import click_inspection
-    import click_lifecycle
-    import click_mutation
-    import click_observation
-    import click_process
-    import click_receipt_runtime
-    import click_runner_transport
-    import click_service
-    import click_verification
-    import click_verification_policy
-    from click_state import (
-        STATE_LOCK_STALE_SECONDS,
-        STATE_LOCK_TIMEOUT_SECONDS,
-        contract_path as _contract_path,
-        identity_path as _identity_path,
-        managed_state_path as _managed_state_path,
-        mode_path as _mode_path,
-        preference_path as _preference_path,
-        prompt_path as _prompt_path,
-        review_path as _review_path,
-        state_lock as _state_lock,
-        state_path as _state_path,
-        state_root as _state_root,
-        write_json as _write_json,
-    )
-    from platform_protocol import CodexOutputAdapter, HookOutputAdapter
+    import click_import_bootstrap
+
+
+(
+    click_browser,
+    click_browser_advisory,
+    click_capability,
+    click_contract,
+    click_evidence,
+    click_host_coverage,
+    click_host_router,
+    click_inspection,
+    click_lifecycle,
+    click_mutation,
+    click_observation,
+    click_process,
+    click_receipt_runtime,
+    click_runner_transport,
+    click_service,
+    click_state,
+    click_verification,
+    click_verification_policy,
+    platform_protocol,
+) = click_import_bootstrap.load_siblings(
+    __package__,
+    "click_browser",
+    "click_browser_advisory",
+    "click_capability",
+    "click_contract",
+    "click_evidence",
+    "click_host_coverage",
+    "click_host_router",
+    "click_inspection",
+    "click_lifecycle",
+    "click_mutation",
+    "click_observation",
+    "click_process",
+    "click_receipt_runtime",
+    "click_runner_transport",
+    "click_service",
+    "click_state",
+    "click_verification",
+    "click_verification_policy",
+    "platform_protocol",
+)
+
+(
+    STATE_LOCK_STALE_SECONDS,
+    STATE_LOCK_TIMEOUT_SECONDS,
+    _contract_path,
+    _identity_path,
+    _managed_state_path,
+    _mode_path,
+    _preference_path,
+    _prompt_path,
+    _review_path,
+    _state_lock,
+    _state_path,
+    _state_root,
+    _write_json,
+    CodexOutputAdapter,
+    HookOutputAdapter,
+) = (
+    click_state.STATE_LOCK_STALE_SECONDS,
+    click_state.STATE_LOCK_TIMEOUT_SECONDS,
+    click_state.contract_path,
+    click_state.identity_path,
+    click_state.managed_state_path,
+    click_state.mode_path,
+    click_state.preference_path,
+    click_state.prompt_path,
+    click_state.review_path,
+    click_state.state_lock,
+    click_state.state_path,
+    click_state.state_root,
+    click_state.write_json,
+    platform_protocol.CodexOutputAdapter,
+    platform_protocol.HookOutputAdapter,
+)
 
 
 # Compatibility alias for direct callers and the deterministic suite. Contract

--- a/dist/antigravity/hooks/click_import_bootstrap.py
+++ b/dist/antigravity/hooks/click_import_bootstrap.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Load Click runtime siblings in package and direct-script contexts.
+
+Hook entrypoints are imported as ``hooks.<module>`` by tests and integrations,
+but installed launchers also execute their files directly.  Keep that import
+choice in one stdlib-only leaf so entrypoints do not duplicate every sibling
+import in two branches.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+
+
+def load_siblings(package: str | None, *names: str) -> tuple[ModuleType, ...]:
+    """Return named sibling modules for a package import or direct execution."""
+
+    package_name = package if isinstance(package, str) and package else ""
+    modules: list[ModuleType] = []
+    for name in names:
+        if not isinstance(name, str) or not name.isidentifier():
+            raise ValueError("Click sibling module names must be identifiers.")
+        module = (
+            import_module(f".{name}", package_name)
+            if package_name
+            else import_module(name)
+        )
+        modules.append(module)
+    return tuple(modules)

--- a/hooks/antigravity_gate.py
+++ b/hooks/antigravity_gate.py
@@ -19,23 +19,32 @@ import time
 from typing import Any
 
 if __package__:
-    from . import (
-        click_capability,
-        click_gate,
-        click_host_coverage,
-        click_inspection,
-        click_runner_transport,
-        click_state,
-    )
-    from .platform_protocol import AntigravityOutputAdapter, CodexOutputAdapter
+    from . import click_import_bootstrap
 else:  # Executed directly from the bundled hooks directory.
-    import click_capability
-    import click_gate
-    import click_host_coverage
-    import click_inspection
-    import click_runner_transport
-    import click_state
-    from platform_protocol import AntigravityOutputAdapter, CodexOutputAdapter
+    import click_import_bootstrap
+
+
+(
+    click_capability,
+    click_gate,
+    click_host_coverage,
+    click_inspection,
+    click_runner_transport,
+    click_state,
+    platform_protocol,
+) = click_import_bootstrap.load_siblings(
+    __package__,
+    "click_capability",
+    "click_gate",
+    "click_host_coverage",
+    "click_inspection",
+    "click_runner_transport",
+    "click_state",
+    "platform_protocol",
+)
+
+AntigravityOutputAdapter = platform_protocol.AntigravityOutputAdapter
+CodexOutputAdapter = platform_protocol.CodexOutputAdapter
 
 
 ANTIGRAVITY_TOOL_MAP = click_host_coverage.ANTIGRAVITY_TOOL_MAP

--- a/hooks/click_gate.py
+++ b/hooks/click_gate.py
@@ -21,75 +21,87 @@ import time
 from typing import Any
 
 if __package__:
-    from . import (
-        click_browser,
-        click_browser_advisory,
-        click_capability,
-        click_contract,
-        click_evidence,
-        click_host_coverage,
-        click_host_router,
-        click_inspection,
-        click_lifecycle,
-        click_mutation,
-        click_observation,
-        click_process,
-        click_receipt_runtime,
-        click_runner_transport,
-        click_service,
-        click_verification,
-        click_verification_policy,
-    )
-    from .click_state import (
-        STATE_LOCK_STALE_SECONDS,
-        STATE_LOCK_TIMEOUT_SECONDS,
-        contract_path as _contract_path,
-        identity_path as _identity_path,
-        managed_state_path as _managed_state_path,
-        mode_path as _mode_path,
-        preference_path as _preference_path,
-        prompt_path as _prompt_path,
-        review_path as _review_path,
-        state_lock as _state_lock,
-        state_path as _state_path,
-        state_root as _state_root,
-        write_json as _write_json,
-    )
-    from .platform_protocol import CodexOutputAdapter, HookOutputAdapter
+    from . import click_import_bootstrap
 else:  # Executed directly from the bundled hooks directory.
-    import click_browser
-    import click_browser_advisory
-    import click_capability
-    import click_contract
-    import click_evidence
-    import click_host_coverage
-    import click_host_router
-    import click_inspection
-    import click_lifecycle
-    import click_mutation
-    import click_observation
-    import click_process
-    import click_receipt_runtime
-    import click_runner_transport
-    import click_service
-    import click_verification
-    import click_verification_policy
-    from click_state import (
-        STATE_LOCK_STALE_SECONDS,
-        STATE_LOCK_TIMEOUT_SECONDS,
-        contract_path as _contract_path,
-        identity_path as _identity_path,
-        managed_state_path as _managed_state_path,
-        mode_path as _mode_path,
-        preference_path as _preference_path,
-        prompt_path as _prompt_path,
-        review_path as _review_path,
-        state_lock as _state_lock,
-        state_path as _state_path,
-        state_root as _state_root,
-        write_json as _write_json,
-    )
-    from platform_protocol import CodexOutputAdapter, HookOutputAdapter
+    import click_import_bootstrap
+
+
+(
+    click_browser,
+    click_browser_advisory,
+    click_capability,
+    click_contract,
+    click_evidence,
+    click_host_coverage,
+    click_host_router,
+    click_inspection,
+    click_lifecycle,
+    click_mutation,
+    click_observation,
+    click_process,
+    click_receipt_runtime,
+    click_runner_transport,
+    click_service,
+    click_state,
+    click_verification,
+    click_verification_policy,
+    platform_protocol,
+) = click_import_bootstrap.load_siblings(
+    __package__,
+    "click_browser",
+    "click_browser_advisory",
+    "click_capability",
+    "click_contract",
+    "click_evidence",
+    "click_host_coverage",
+    "click_host_router",
+    "click_inspection",
+    "click_lifecycle",
+    "click_mutation",
+    "click_observation",
+    "click_process",
+    "click_receipt_runtime",
+    "click_runner_transport",
+    "click_service",
+    "click_state",
+    "click_verification",
+    "click_verification_policy",
+    "platform_protocol",
+)
+
+(
+    STATE_LOCK_STALE_SECONDS,
+    STATE_LOCK_TIMEOUT_SECONDS,
+    _contract_path,
+    _identity_path,
+    _managed_state_path,
+    _mode_path,
+    _preference_path,
+    _prompt_path,
+    _review_path,
+    _state_lock,
+    _state_path,
+    _state_root,
+    _write_json,
+    CodexOutputAdapter,
+    HookOutputAdapter,
+) = (
+    click_state.STATE_LOCK_STALE_SECONDS,
+    click_state.STATE_LOCK_TIMEOUT_SECONDS,
+    click_state.contract_path,
+    click_state.identity_path,
+    click_state.managed_state_path,
+    click_state.mode_path,
+    click_state.preference_path,
+    click_state.prompt_path,
+    click_state.review_path,
+    click_state.state_lock,
+    click_state.state_path,
+    click_state.state_root,
+    click_state.write_json,
+    platform_protocol.CodexOutputAdapter,
+    platform_protocol.HookOutputAdapter,
+)
 
 
 # Compatibility alias for direct callers and the deterministic suite. Contract

--- a/hooks/click_hook.py
+++ b/hooks/click_hook.py
@@ -14,10 +14,14 @@ import sys
 from typing import Any
 
 if __package__:
-    from . import click_gate, click_host_coverage
-else:
-    import click_gate
-    import click_host_coverage
+    from . import click_import_bootstrap
+else:  # Executed directly from the bundled hooks directory.
+    import click_import_bootstrap
+
+
+(click_gate, click_host_coverage) = click_import_bootstrap.load_siblings(
+    __package__, "click_gate", "click_host_coverage"
+)
 
 
 DIRECT_EXEC_TOOL_NAMES = click_host_coverage.CODEX_DIRECT_EXEC_TOOL_NAMES

--- a/hooks/click_import_bootstrap.py
+++ b/hooks/click_import_bootstrap.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Load Click runtime siblings in package and direct-script contexts.
+
+Hook entrypoints are imported as ``hooks.<module>`` by tests and integrations,
+but installed launchers also execute their files directly.  Keep that import
+choice in one stdlib-only leaf so entrypoints do not duplicate every sibling
+import in two branches.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+
+
+def load_siblings(package: str | None, *names: str) -> tuple[ModuleType, ...]:
+    """Return named sibling modules for a package import or direct execution."""
+
+    package_name = package if isinstance(package, str) and package else ""
+    modules: list[ModuleType] = []
+    for name in names:
+        if not isinstance(name, str) or not name.isidentifier():
+            raise ValueError("Click sibling module names must be identifiers.")
+        module = (
+            import_module(f".{name}", package_name)
+            if package_name
+            else import_module(name)
+        )
+        modules.append(module)
+    return tuple(modules)

--- a/hooks/click_windows.py
+++ b/hooks/click_windows.py
@@ -12,10 +12,14 @@ import os
 from pathlib import Path
 
 if __package__:
-    from . import click_hook, click_runner_transport
+    from . import click_import_bootstrap
 else:  # Executed directly from the bundled hooks directory.
-    import click_hook
-    import click_runner_transport
+    import click_import_bootstrap
+
+
+(click_hook, click_runner_transport) = click_import_bootstrap.load_siblings(
+    __package__, "click_hook", "click_runner_transport"
+)
 
 
 def _powershell_single_quote(value: str) -> str:

--- a/scripts/build_antigravity_distribution.py
+++ b/scripts/build_antigravity_distribution.py
@@ -26,6 +26,7 @@ HOOK_FILES = (
     "click_receipt_runtime.py",
     "click_host_coverage.py",
     "click_host_router.py",
+    "click_import_bootstrap.py",
     "click_inspection.py",
     "click_lifecycle.py",
     "click_mutation.py",

--- a/tests/repository_policy_core.py
+++ b/tests/repository_policy_core.py
@@ -533,6 +533,7 @@ class RepositoryPolicyTests(unittest.TestCase):
                 "click_runtime_state.py",
                 "click_host_coverage.py",
                 "click_host_router.py",
+                "click_import_bootstrap.py",
                 "click_inspection.py",
                 "click_lifecycle.py",
                 "click_gate.py",

--- a/tests/test_click_import_bootstrap.py
+++ b/tests/test_click_import_bootstrap.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import ast
+import importlib
+import os
+from pathlib import Path
+import subprocess
+import sys
+import unittest
+
+from hooks import click_import_bootstrap
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOKS = ROOT / "hooks"
+ENTRYPOINTS = (
+    "click_gate.py",
+    "antigravity_gate.py",
+    "click_hook.py",
+    "click_windows.py",
+)
+
+
+class ClickImportBootstrapTests(unittest.TestCase):
+    def test_load_siblings_uses_the_active_package_context(self) -> None:
+        (state_module,) = click_import_bootstrap.load_siblings(
+            "hooks", "click_state"
+        )
+
+        self.assertIs(state_module, importlib.import_module("hooks.click_state"))
+
+    def test_load_siblings_rejects_non_sibling_module_paths(self) -> None:
+        for name in ("", ".click_state", "hooks.click_state", "../click_state"):
+            with self.subTest(name=name):
+                with self.assertRaises(ValueError):
+                    click_import_bootstrap.load_siblings("hooks", name)
+
+    def test_entrypoints_only_branch_to_import_the_shared_bootstrap(self) -> None:
+        for name in ENTRYPOINTS:
+            with self.subTest(entrypoint=name):
+                tree = ast.parse((HOOKS / name).read_text(encoding="utf-8"))
+                branches = [
+                    node
+                    for node in tree.body
+                    if isinstance(node, ast.If)
+                    and isinstance(node.test, ast.Name)
+                    and node.test.id == "__package__"
+                ]
+                self.assertEqual(len(branches), 1)
+                branch = branches[0]
+                self.assertEqual(len(branch.body), 1)
+                self.assertEqual(len(branch.orelse), 1)
+                package_import = branch.body[0]
+                direct_import = branch.orelse[0]
+                self.assertIsInstance(package_import, ast.ImportFrom)
+                self.assertEqual(
+                    [alias.name for alias in package_import.names],
+                    ["click_import_bootstrap"],
+                )
+                self.assertIsInstance(direct_import, ast.Import)
+                self.assertEqual(
+                    [alias.name for alias in direct_import.names],
+                    ["click_import_bootstrap"],
+                )
+
+    def test_entrypoints_import_in_package_and_direct_script_contexts(self) -> None:
+        for name in ENTRYPOINTS:
+            module_name = Path(name).stem
+            with self.subTest(context="package", entrypoint=name):
+                module = importlib.import_module(f"hooks.{module_name}")
+                self.assertEqual(module.__package__, "hooks")
+
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "PYTHONNOUSERSITE": "1",
+                "PYTHONPATH": str(HOOKS),
+            }
+        )
+        module_names = ", ".join(Path(name).stem for name in ENTRYPOINTS)
+        result = subprocess.run(
+            [sys.executable, "-c", f"import {module_names}; print('ok')"],
+            cwd=ROOT,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a stdlib-only sibling import bootstrap for package and direct-script contexts
- migrate `click_gate`, `antigravity_gate`, `click_hook`, and `click_windows` entrypoints
- preserve the existing facade symbols and direct launcher behavior
- add package/direct import regression coverage and sync the Antigravity distribution

## Verification

- import/bootstrap + distribution group: 7 tests passed
- architecture/adapter group: 66 tests passed, 3 Linux-only skips
- full regression suite: 443 tests passed, 3 skips
- `git diff --check` passed