### PR TITLE
Fix receipt export when nested hosts omit workdir

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/grapefruit0205/click.git",
-        "ref": "v0.36.0"
+        "ref": "v0.36.1"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "click",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "Evidence by default: let the host run normally while Click records revision-aware proof. Opt into Guarded for one human-readable, approval-bound execution contract.",
   "author": {
     "name": "Junseok Pak",

--- a/README.ko.md
+++ b/README.ko.md
@@ -285,16 +285,16 @@ Antigravity IDE에서는 `dist/antigravity`를 워크스페이스의 `.agents/pl
 
 Antigravity의 Hook contract는 Codex와 다릅니다. native file/search와 별도 MCP·Skill 도구는 계속 사용할 수 있지만 cross-tool 중복 제거와 Browser evidence는 아직 지원하지 않습니다. 정확한 제한은 [`platforms/antigravity/README.md`](platforms/antigravity/README.md)를 확인하세요.
 
-## 기존 설치 업데이트 — v0.36.0
+## 기존 설치 업데이트 — v0.36.1
 
-현재 릴리스는 **v0.36.0**입니다.
+현재 릴리스는 **v0.36.1**입니다.
 
 ```bash
 codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-ChatGPT 데스크톱 앱을 다시 시작하고 갱신된 Hook을 검토해 신뢰하세요. v0.36.0은 기존 권한 의도를 유지해 저장된 `on`을 Guarded로, `manual`을 Off로 migration하며 새 설치와 미설정 사용자는 계속 Evidence를 기본값으로 사용합니다. Guarded stage는 Hook이 만든 정확한 네 섹션을 제공하고, 범위 안의 follow-up은 새 사용자 승인 없이 같은 contract ID로 resume하여 실제 mutation까지 이어집니다. 완료된 Guarded 작업은 새 Evidence session으로 넘어가지만 미완료 Guarded 작업은 계속 잠깁니다. Receipt export는 host tool이 실제로 선택한 working directory도 반영합니다. Codex와 번들 Antigravity 배포본은 같은 runtime module을 사용합니다. 새 모드와 Hook 코드를 로드하려면 업그레이드 후 새 작업을 시작하세요.
+ChatGPT 데스크톱 앱을 다시 시작하고 갱신된 Hook을 검토해 신뢰하세요. v0.36.1은 host가 중첩 실행의 working directory를 receipt export에 전달하지 않아도 모든 current argv evidence가 하나의 정규 Git 루트에 결속된 경우에만 그 루트를 복구합니다. stale·누락·비정규·충돌 binding은 계속 fail-closed로 거부합니다. Codex와 번들 Antigravity 배포본은 같은 runtime module을 사용합니다. 새 Hook 코드를 로드하려면 업그레이드 후 새 작업을 시작하세요.
 
 자세한 릴리스 이력은 [RELEASE_NOTES.md](RELEASE_NOTES.md)에 있습니다.
 

--- a/README.md
+++ b/README.md
@@ -168,9 +168,9 @@ Explicit controls remain available:
 
 Neither silently unlocks an active incomplete Guarded contract.
 
-### Upgrade an existing installation — v0.36.0
+### Upgrade an existing installation — v0.36.1
 
-The current release is **v0.36.0**.
+The current release is **v0.36.1**.
 
 ```bash
 codex plugin marketplace upgrade click
@@ -178,6 +178,11 @@ codex plugin add click@click
 ```
 
 Start a fresh task after upgrading so the current Hook code and mode behavior are loaded.
+
+v0.36.1 also handles hosts that omit a nested execution workdir during receipt
+export. Click recovers it only when every current argv evidence source binds the
+same canonical Git root; stale, malformed, missing, or conflicting roots remain
+fail-closed.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -282,16 +282,16 @@ Antigravity IDE 用户也可以把 `dist/antigravity` 复制到工作区的 `.ag
 
 Antigravity 的 Hook contract 与 Codex 不同。native file/search 和其他 MCP、Skill 工具仍可使用，但目前还不支持 cross-tool 去重和 Browser evidence。准确限制请参阅 [`platforms/antigravity/README.md`](platforms/antigravity/README.md)。
 
-## 更新现有安装 — v0.36.0
+## 更新现有安装 — v0.36.1
 
-当前版本是 **v0.36.0**。
+当前版本是 **v0.36.1**。
 
 ```bash
 codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-重启 ChatGPT 桌面应用并检查、信任更新后的 Hook。v0.36.0 在迁移存储设置时保留既有权限意图：`on` 迁移为 Guarded，`manual` 迁移为 Off；新安装和未设置用户仍默认使用 Evidence。Guarded stage 现在通过 Hook 提供准确的四部分 human view，范围内 follow-up 无需新的用户批准即可使用同一 contract ID 恢复并完成实际 mutation。已完成的 Guarded 工作会进入新的 Evidence session，未完成的 Guarded 工作仍保持锁定。Receipt export 也会采用 host tool 实际选择的 working directory。Codex 与内置 Antigravity 发行版使用相同 runtime module。升级后请新建任务，以加载新模式和 Hook 代码。
+重启 ChatGPT 桌面应用并检查、信任更新后的 Hook。v0.36.1 在 host 未把嵌套执行的 working directory 传给 receipt export 时，只有所有 current argv evidence 都绑定到同一个规范 Git 根目录，才会恢复该目录。stale、缺失、非规范或冲突的 binding 仍会 fail-closed。Codex 与内置 Antigravity 发行版使用相同 runtime module。升级后请新建任务，以加载新的 Hook 代码。
 
 详细发布历史见 [RELEASE_NOTES.md](RELEASE_NOTES.md)。
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,17 @@
 # Release notes
 
+## v0.36.1 — 2026-09-02
+
+- Receipt export now recovers a nested execution workdir omitted by the host
+  only from the single canonical Git root shared by every current argv evidence
+  source. Stale, missing, non-canonical, or conflicting bindings are never used
+  as an implicit workspace choice, and the final protected tree is still
+  recomputed before export.
+- Regression coverage reproduces the Code Mode shape where the outer Hook cwd
+  is not a Git repository but the verification runner used an explicit nested
+  repository workdir. Unit coverage also keeps stale and invalid root bindings
+  fail-closed.
+
 ## v0.36.0 — 2026-09-01
 
 - Legacy stored authority choices now preserve their meaning during the public

--- a/dist/antigravity/hooks/click_gate.py
+++ b/dist/antigravity/hooks/click_gate.py
@@ -575,6 +575,12 @@ def _tool_working_directory(event: dict[str, Any]) -> Path:
     return workdir.resolve()
 
 
+def _tool_working_directory_is_explicit(event: dict[str, Any]) -> bool:
+    tool_input = event.get("tool_input")
+    requested = tool_input.get("workdir") if isinstance(tool_input, dict) else None
+    return isinstance(requested, str) and bool(requested)
+
+
 def _receipt_export_runner_command(event: dict[str, Any]) -> str:
     host_id = click_host_coverage.host_id_from_event(event)
     return click_runner_transport.render_runner_shell_command(
@@ -583,6 +589,11 @@ def _receipt_export_runner_command(event: dict[str, Any]) -> str:
             str(_contract_path(event).resolve()),
             str(_tool_working_directory(event)),
             host_id,
+            (
+                "explicit"
+                if _tool_working_directory_is_explicit(event)
+                else "ambient"
+            ),
         ]
     )
 
@@ -1274,14 +1285,19 @@ def _run_verification(arguments: list[str]) -> int:
 
 
 def _run_receipt_export(arguments: list[str]) -> int:
-    if len(arguments) != 3:
+    if len(arguments) not in {3, 4}:
         sys.stderr.write(
-            "usage: click_gate.py run-receipt-export <state> <cwd> <host>\n"
+            "usage: click_gate.py run-receipt-export "
+            "<state> <cwd> <host> [explicit|ambient]\n"
         )
         return 2
     state_path = Path(arguments[0])
     workspace = Path(arguments[1])
     host_id = arguments[2]
+    workspace_source = arguments[3] if len(arguments) == 4 else "explicit"
+    if workspace_source not in {"explicit", "ambient"}:
+        sys.stderr.write("Click receipt export received an invalid workspace source.\n")
+        return 2
     if not _managed_contract_path(state_path) or not workspace.is_absolute():
         sys.stderr.write("Click receipt export received an invalid state or workspace.\n")
         return 2
@@ -1299,6 +1315,13 @@ def _run_receipt_export(arguments: list[str]) -> int:
         if not isinstance(state, dict) or not _contract_is_completed(state):
             sys.stderr.write("Click receipt export requires a completed contract.\n")
             return 2
+        if workspace_source == "ambient":
+            verified_workspace = click_receipt_runtime.verified_workspace_root(
+                state,
+                expected_contract_schema_version=CONTRACT_STATE_SCHEMA_VERSION,
+            )
+            if verified_workspace is not None:
+                workspace = verified_workspace
         envelope, error = click_receipt_runtime.build_envelope(
             state,
             workspace_snapshot=_git_workspace_snapshot(workspace),

--- a/dist/antigravity/hooks/click_receipt_runtime.py
+++ b/dist/antigravity/hooks/click_receipt_runtime.py
@@ -77,6 +77,53 @@ def _workspace_receipt(
     }, normalized_root, ""
 
 
+def verified_workspace_root(
+    state: dict[str, Any], *, expected_contract_schema_version: int
+) -> Path | None:
+    """Return the sole canonical Git root bound by all current argv evidence."""
+
+    verification = state.get("verification")
+    if not isinstance(verification, dict):
+        return None
+    revision = verification.get("mutation_revision")
+    if not isinstance(revision, int) or isinstance(revision, bool) or revision < 0:
+        return None
+    sources = click_evidence.sources_from_state(
+        state,
+        expected_contract_schema_version=expected_contract_schema_version,
+    )
+    if sources is None or not sources:
+        return None
+
+    roots: dict[str, Path] = {}
+    for source in sources.values():
+        if not isinstance(source, dict) or not click_evidence.is_current(
+            source, revision
+        ):
+            return None
+        if source.get("kind") != "argv":
+            continue
+        stored_root = source.get("verified_root")
+        if not isinstance(stored_root, str) or not stored_root:
+            return None
+        candidate = Path(stored_root)
+        if not candidate.is_absolute():
+            return None
+        try:
+            resolved = candidate.resolve(strict=True)
+        except (OSError, RuntimeError):
+            return None
+        if not resolved.is_dir():
+            return None
+        normalized = os.path.normcase(str(resolved))
+        if os.path.normcase(stored_root) != normalized:
+            return None
+        roots[normalized] = resolved
+    if len(roots) != 1:
+        return None
+    return next(iter(roots.values()))
+
+
 def _evidence_receipts(
     sources: dict[str, Any],
     *,

--- a/dist/antigravity/skills/click/references/capability-protocol.md
+++ b/dist/antigravity/skills/click/references/capability-protocol.md
@@ -92,6 +92,12 @@ raw argv, runner tokens and token digests, contract prose, and the workspace
 path. Save the stdout JSON separately, then verify it without network access or
 active contract state:
 
+If a host omits the working directory selected by a nested execution tool,
+export may recover it only from the sole canonical Git root shared by every
+current argv evidence source. A stale, missing, non-canonical, or conflicting
+root binding never selects an implicit workspace. Click still recomputes the
+final protected tree and requires it to match current evidence before export.
+
 If a supported host omits a mutation's matching `PostToolUse`, export never
 invents an exit code. It may project that admitted host claim as `observed`
 only after a later passing one-use verification at the same or a newer revision

--- a/hooks/click_gate.py
+++ b/hooks/click_gate.py
@@ -575,6 +575,12 @@ def _tool_working_directory(event: dict[str, Any]) -> Path:
     return workdir.resolve()
 
 
+def _tool_working_directory_is_explicit(event: dict[str, Any]) -> bool:
+    tool_input = event.get("tool_input")
+    requested = tool_input.get("workdir") if isinstance(tool_input, dict) else None
+    return isinstance(requested, str) and bool(requested)
+
+
 def _receipt_export_runner_command(event: dict[str, Any]) -> str:
     host_id = click_host_coverage.host_id_from_event(event)
     return click_runner_transport.render_runner_shell_command(
@@ -583,6 +589,11 @@ def _receipt_export_runner_command(event: dict[str, Any]) -> str:
             str(_contract_path(event).resolve()),
             str(_tool_working_directory(event)),
             host_id,
+            (
+                "explicit"
+                if _tool_working_directory_is_explicit(event)
+                else "ambient"
+            ),
         ]
     )
 
@@ -1274,14 +1285,19 @@ def _run_verification(arguments: list[str]) -> int:
 
 
 def _run_receipt_export(arguments: list[str]) -> int:
-    if len(arguments) != 3:
+    if len(arguments) not in {3, 4}:
         sys.stderr.write(
-            "usage: click_gate.py run-receipt-export <state> <cwd> <host>\n"
+            "usage: click_gate.py run-receipt-export "
+            "<state> <cwd> <host> [explicit|ambient]\n"
         )
         return 2
     state_path = Path(arguments[0])
     workspace = Path(arguments[1])
     host_id = arguments[2]
+    workspace_source = arguments[3] if len(arguments) == 4 else "explicit"
+    if workspace_source not in {"explicit", "ambient"}:
+        sys.stderr.write("Click receipt export received an invalid workspace source.\n")
+        return 2
     if not _managed_contract_path(state_path) or not workspace.is_absolute():
         sys.stderr.write("Click receipt export received an invalid state or workspace.\n")
         return 2
@@ -1299,6 +1315,13 @@ def _run_receipt_export(arguments: list[str]) -> int:
         if not isinstance(state, dict) or not _contract_is_completed(state):
             sys.stderr.write("Click receipt export requires a completed contract.\n")
             return 2
+        if workspace_source == "ambient":
+            verified_workspace = click_receipt_runtime.verified_workspace_root(
+                state,
+                expected_contract_schema_version=CONTRACT_STATE_SCHEMA_VERSION,
+            )
+            if verified_workspace is not None:
+                workspace = verified_workspace
         envelope, error = click_receipt_runtime.build_envelope(
             state,
             workspace_snapshot=_git_workspace_snapshot(workspace),

--- a/hooks/click_receipt_runtime.py
+++ b/hooks/click_receipt_runtime.py
@@ -77,6 +77,53 @@ def _workspace_receipt(
     }, normalized_root, ""
 
 
+def verified_workspace_root(
+    state: dict[str, Any], *, expected_contract_schema_version: int
+) -> Path | None:
+    """Return the sole canonical Git root bound by all current argv evidence."""
+
+    verification = state.get("verification")
+    if not isinstance(verification, dict):
+        return None
+    revision = verification.get("mutation_revision")
+    if not isinstance(revision, int) or isinstance(revision, bool) or revision < 0:
+        return None
+    sources = click_evidence.sources_from_state(
+        state,
+        expected_contract_schema_version=expected_contract_schema_version,
+    )
+    if sources is None or not sources:
+        return None
+
+    roots: dict[str, Path] = {}
+    for source in sources.values():
+        if not isinstance(source, dict) or not click_evidence.is_current(
+            source, revision
+        ):
+            return None
+        if source.get("kind") != "argv":
+            continue
+        stored_root = source.get("verified_root")
+        if not isinstance(stored_root, str) or not stored_root:
+            return None
+        candidate = Path(stored_root)
+        if not candidate.is_absolute():
+            return None
+        try:
+            resolved = candidate.resolve(strict=True)
+        except (OSError, RuntimeError):
+            return None
+        if not resolved.is_dir():
+            return None
+        normalized = os.path.normcase(str(resolved))
+        if os.path.normcase(stored_root) != normalized:
+            return None
+        roots[normalized] = resolved
+    if len(roots) != 1:
+        return None
+    return next(iter(roots.values()))
+
+
 def _evidence_receipts(
     sources: dict[str, Any],
     *,

--- a/skills/click/references/capability-protocol.md
+++ b/skills/click/references/capability-protocol.md
@@ -92,6 +92,12 @@ raw argv, runner tokens and token digests, contract prose, and the workspace
 path. Save the stdout JSON separately, then verify it without network access or
 active contract state:
 
+If a host omits the working directory selected by a nested execution tool,
+export may recover it only from the sole canonical Git root shared by every
+current argv evidence source. A stale, missing, non-canonical, or conflicting
+root binding never selects an implicit workspace. Click still recomputes the
+final protected tree and requires it to match current evidence before export.
+
 If a supported host omits a mutation's matching `PostToolUse`, export never
 invents an exit code. It may project that admitted host claim as `observed`
 only after a later passing one-use verification at the same or a newer revision

--- a/tests/test_click_gate_receipt.py
+++ b/tests/test_click_gate_receipt.py
@@ -10,6 +10,91 @@ from click_gate_test_support import (
 
 
 class ClickGateReceiptTests(ClickGateTestCase):
+    def test_export_recovers_verified_root_when_nested_host_omits_workdir(self) -> None:
+        (self.workspace / ".gitignore").write_text(
+            "__pycache__/\n", encoding="utf-8"
+        )
+        self.initialize_git(".gitignore", "verification_fixture.py")
+        # A code-mode host may expose only its task cwd to the Hook even though
+        # the nested command actually executes in a repository workdir.
+        host_cwd = self.workspace.parent / "code-mode-host-cwd"
+        host_cwd.mkdir()
+        self.base_event["cwd"] = str(host_cwd)
+        self.approve_contract()
+
+        batch = {
+            "version": 2,
+            "checks": [
+                {
+                    "evidence_id": "E1",
+                    "argv": self.verification_argv(),
+                    "class": "targeted",
+                }
+            ],
+        }
+        verification = self.tool_hook(
+            "pre-tool",
+            "Bash",
+            {
+                "command": f"click-gate verify {shlex.quote(json.dumps(batch))}",
+                "workdir": str(self.workspace),
+            },
+            turn_id="turn-2",
+            tool_use_id="verification-tool",
+        )
+        self.assertIsNotNone(verification)
+        assert verification is not None
+        verified = self.run_rewritten(verification)
+        self.assertEqual(verified.returncode, 0, verified.stderr)
+
+        export = self.tool_hook(
+            "pre-tool",
+            "Bash",
+            {"command": "click-gate receipt export"},
+            turn_id="turn-2",
+            tool_use_id="receipt-tool",
+        )
+        self.assertIsNotNone(export)
+        assert export is not None
+        exported = self.run_rewritten(export)
+
+        self.assertEqual(exported.returncode, 0, exported.stderr)
+        envelope = json.loads(exported.stdout)
+        self.assertEqual(
+            envelope["receipt"]["execution"]["workspace"]["assurance"],
+            "git-protected-tree",
+        )
+
+    def test_export_never_replaces_an_explicit_host_workdir(self) -> None:
+        (self.workspace / ".gitignore").write_text(
+            "__pycache__/\n", encoding="utf-8"
+        )
+        self.initialize_git(".gitignore", "verification_fixture.py")
+        self.approve_contract()
+
+        verification = self.verify_gate([self.verification_argv()], "turn-2")
+        verified = self.run_rewritten(verification)
+        self.assertEqual(verified.returncode, 0, verified.stderr)
+
+        explicit_workdir = self.workspace.parent / "explicit-non-git-workdir"
+        explicit_workdir.mkdir()
+        export = self.tool_hook(
+            "pre-tool",
+            "Bash",
+            {
+                "command": "click-gate receipt export",
+                "workdir": str(explicit_workdir),
+            },
+            turn_id="turn-2",
+            tool_use_id="receipt-tool",
+        )
+        self.assertIsNotNone(export)
+        assert export is not None
+        exported = self.run_rewritten(export)
+
+        self.assertEqual(exported.returncode, 2)
+        self.assertIn("final workspace drifted", exported.stderr)
+
     def test_export_uses_bash_workdir_for_final_workspace(self) -> None:
         (self.workspace / ".gitignore").write_text(
             "__pycache__/\n", encoding="utf-8"

--- a/tests/test_click_receipt_runtime.py
+++ b/tests/test_click_receipt_runtime.py
@@ -83,6 +83,64 @@ class ClickReceiptRuntimeTests(unittest.TestCase):
         )
         return state, coverage
 
+    def test_verified_workspace_root_requires_current_canonical_argv_evidence(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            state, _ = self.completed_state(root)
+
+            self.assertEqual(
+                click_receipt_runtime.verified_workspace_root(
+                    state,
+                    expected_contract_schema_version=2,
+                ),
+                root.resolve(),
+            )
+
+            stale = copy.deepcopy(state)
+            stale_source = next(
+                iter(stale["evidence_state"]["sources"].values())
+            )
+            stale_source["verified_revision"] = 1
+            self.assertIsNone(
+                click_receipt_runtime.verified_workspace_root(
+                    stale,
+                    expected_contract_schema_version=2,
+                )
+            )
+
+            missing = copy.deepcopy(state)
+            missing_source = next(
+                iter(missing["evidence_state"]["sources"].values())
+            )
+            missing_source["verified_root"] = str(root / "missing")
+            self.assertIsNone(
+                click_receipt_runtime.verified_workspace_root(
+                    missing,
+                    expected_contract_schema_version=2,
+                )
+            )
+
+            conflicting = copy.deepcopy(state)
+            conflicting_root = root / "other"
+            conflicting_root.mkdir()
+            conflicting_evidence = conflicting["evidence_state"]
+            conflicting_sources = conflicting_evidence["sources"]
+            second_source = copy.deepcopy(next(iter(conflicting_sources.values())))
+            second_source["verified_root"] = str(conflicting_root.resolve())
+            conflicting_sources[click_evidence.evidence_key("E2")] = second_source
+            conflicting_evidence["source_count"] = len(conflicting_sources)
+            conflicting_evidence["registry_digest"] = click_evidence.registry_digest(
+                conflicting_sources
+            )
+            self.assertIsNone(
+                click_receipt_runtime.verified_workspace_root(
+                    conflicting,
+                    expected_contract_schema_version=2,
+                )
+            )
+
     def test_build_binds_final_state_without_exporting_root_or_secrets(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -29,7 +29,7 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
             (ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
         )
         self.assertEqual(manifest["name"], "click")
-        self.assertEqual(manifest["version"], "0.36.0")
+        self.assertEqual(manifest["version"], "0.36.1")
         self.assertEqual(manifest["license"], "MIT")
         description = manifest["description"].lower()
         long_description = manifest["interface"]["longDescription"].lower()
@@ -64,7 +64,7 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
         self.assertEqual(marketplace["name"], "click")
         self.assertEqual(marketplace["plugins"][0]["name"], "click")
         self.assertEqual(
-            marketplace["plugins"][0]["source"]["ref"], "v0.36.0"
+            marketplace["plugins"][0]["source"]["ref"], "v0.36.1"
         )
 
     def test_readmes_lead_with_evidence_first_positioning(self) -> None:
@@ -191,11 +191,12 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
 
     def test_release_documents_identify_current_and_preserve_release_history(self) -> None:
         for readme in _readmes().values():
-            self.assertIn("v0.36.0", readme)
+            self.assertIn("v0.36.1", readme)
             self.assertIn("codex plugin marketplace upgrade click", readme)
             self.assertIn("codex plugin add click@click", readme)
         notes = (ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8")
         for marker in (
+            "## v0.36.1",
             "## v0.36.0",
             "## v0.35.0",
             "## v0.33.0",


### PR DESCRIPTION
## Summary

- recover an omitted nested execution workdir from the sole canonical Git root shared by all current argv evidence
- preserve explicit host-selected workdirs and keep stale, missing, non-canonical, or conflicting bindings fail-closed
- add Code Mode-shaped integration coverage and runtime guard tests
- release as v0.36.1 and rebuild the Antigravity distribution

## Verification

- `python3 -m unittest -v tests.test_click_gate_receipt tests.test_click_receipt_runtime`
- `python3 -m unittest -v tests.test_repository_policy`
- `python3 -m unittest -v tests.test_distribution_validation`
- `python3 -m unittest discover -v` — 446 passed, 3 skipped