### PR TITLE
Release Click v0.36.2

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/grapefruit0205/click.git",
-        "ref": "v0.36.1"
+        "ref": "v0.36.2"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "click",
-  "version": "0.36.1",
+  "version": "0.36.2",
   "description": "Evidence by default: let the host run normally while Click records revision-aware proof. Opt into Guarded for one human-readable, approval-bound execution contract.",
   "author": {
     "name": "Junseok Pak",

--- a/README.ko.md
+++ b/README.ko.md
@@ -285,16 +285,16 @@ Antigravity IDE에서는 `dist/antigravity`를 워크스페이스의 `.agents/pl
 
 Antigravity의 Hook contract는 Codex와 다릅니다. native file/search와 별도 MCP·Skill 도구는 계속 사용할 수 있지만 cross-tool 중복 제거와 Browser evidence는 아직 지원하지 않습니다. 정확한 제한은 [`platforms/antigravity/README.md`](platforms/antigravity/README.md)를 확인하세요.
 
-## 기존 설치 업데이트 — v0.36.1
+## 기존 설치 업데이트 — v0.36.2
 
-현재 릴리스는 **v0.36.1**입니다.
+현재 릴리스는 **v0.36.2**입니다.
 
 ```bash
 codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-ChatGPT 데스크톱 앱을 다시 시작하고 갱신된 Hook을 검토해 신뢰하세요. v0.36.1은 host가 중첩 실행의 working directory를 receipt export에 전달하지 않아도 모든 current argv evidence가 하나의 정규 Git 루트에 결속된 경우에만 그 루트를 복구합니다. stale·누락·비정규·충돌 binding은 계속 fail-closed로 거부합니다. Codex와 번들 Antigravity 배포본은 같은 runtime module을 사용합니다. 새 Hook 코드를 로드하려면 업그레이드 후 새 작업을 시작하세요.
+ChatGPT 데스크톱 앱을 다시 시작하고 갱신된 Hook을 검토해 신뢰하세요. v0.36.2는 mode, inspection policy, prompt lineage, contract-state persistence를 명시적인 runtime leaf 경계로 분리했습니다. 기존 lifecycle·gate 호환 심볼과 Evidence/Guarded 권한, runner 복구, receipt 의미, Antigravity runtime 동작은 그대로 유지됩니다. 새 Hook 코드를 로드하려면 업그레이드 후 새 작업을 시작하세요.
 
 자세한 릴리스 이력은 [RELEASE_NOTES.md](RELEASE_NOTES.md)에 있습니다.
 

--- a/README.md
+++ b/README.md
@@ -168,9 +168,9 @@ Explicit controls remain available:
 
 Neither silently unlocks an active incomplete Guarded contract.
 
-### Upgrade an existing installation — v0.36.1
+### Upgrade an existing installation — v0.36.2
 
-The current release is **v0.36.1**.
+The current release is **v0.36.2**.
 
 ```bash
 codex plugin marketplace upgrade click
@@ -179,10 +179,10 @@ codex plugin add click@click
 
 Start a fresh task after upgrading so the current Hook code and mode behavior are loaded.
 
-v0.36.1 also handles hosts that omit a nested execution workdir during receipt
-export. Click recovers it only when every current argv evidence source binds the
-same canonical Git root; stale, malformed, missing, or conflicting roots remain
-fail-closed.
+v0.36.2 moves mode, inspection policy, prompt lineage, and contract-state
+persistence behind explicit runtime leaf boundaries. Existing lifecycle and
+gate compatibility symbols remain intact, and Evidence/Guarded authority,
+runner recovery, receipt semantics, and the Antigravity runtime stay unchanged.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -282,16 +282,16 @@ Antigravity IDE 用户也可以把 `dist/antigravity` 复制到工作区的 `.ag
 
 Antigravity 的 Hook contract 与 Codex 不同。native file/search 和其他 MCP、Skill 工具仍可使用，但目前还不支持 cross-tool 去重和 Browser evidence。准确限制请参阅 [`platforms/antigravity/README.md`](platforms/antigravity/README.md)。
 
-## 更新现有安装 — v0.36.1
+## 更新现有安装 — v0.36.2
 
-当前版本是 **v0.36.1**。
+当前版本是 **v0.36.2**。
 
 ```bash
 codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-重启 ChatGPT 桌面应用并检查、信任更新后的 Hook。v0.36.1 在 host 未把嵌套执行的 working directory 传给 receipt export 时，只有所有 current argv evidence 都绑定到同一个规范 Git 根目录，才会恢复该目录。stale、缺失、非规范或冲突的 binding 仍会 fail-closed。Codex 与内置 Antigravity 发行版使用相同 runtime module。升级后请新建任务，以加载新的 Hook 代码。
+重启 ChatGPT 桌面应用并检查、信任更新后的 Hook。v0.36.2 将 mode、inspection policy、prompt lineage 和 contract-state persistence 分离到明确的 runtime leaf 边界中。现有 lifecycle 与 gate 兼容符号、Evidence/Guarded 权限、runner 恢复、receipt 语义以及 Antigravity runtime 行为保持不变。升级后请新建任务，以加载新的 Hook 代码。
 
 详细发布历史见 [RELEASE_NOTES.md](RELEASE_NOTES.md)。
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,21 @@
 # Release notes
 
+## v0.36.2 — 2026-09-02
+
+- Mode and preference persistence plus read-only inspection policy now live in
+  explicit leaf modules, keeping lifecycle orchestration and the gate facade
+  focused on coordination without changing public authority behavior.
+- Prompt lineage, exact bypass/cancel authorization, follow-up digests, and
+  active-turn validation now share one state-only prompt leaf while preserving
+  the existing lifecycle and gate compatibility symbols.
+- Contract JSON read, atomic save, and clear operations now share one
+  `click_contract_state` leaf across lifecycle, Browser, mutation, observation,
+  service, verification, and the gate facade. Clear still revokes the runner
+  recovery mirror, malformed state keeps the exact fallback shape, and all
+  established compatibility identities remain intact.
+- Codex and Antigravity distributions remain byte-synchronized, and the full
+  468-test regression suite passes with three documented skips.
+
 ## v0.36.1 — 2026-09-02
 
 - Receipt export now recovers a nested execution workdir omitted by the host

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -29,7 +29,7 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
             (ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
         )
         self.assertEqual(manifest["name"], "click")
-        self.assertEqual(manifest["version"], "0.36.1")
+        self.assertEqual(manifest["version"], "0.36.2")
         self.assertEqual(manifest["license"], "MIT")
         description = manifest["description"].lower()
         long_description = manifest["interface"]["longDescription"].lower()
@@ -64,7 +64,7 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
         self.assertEqual(marketplace["name"], "click")
         self.assertEqual(marketplace["plugins"][0]["name"], "click")
         self.assertEqual(
-            marketplace["plugins"][0]["source"]["ref"], "v0.36.1"
+            marketplace["plugins"][0]["source"]["ref"], "v0.36.2"
         )
 
     def test_readmes_lead_with_evidence_first_positioning(self) -> None:
@@ -191,11 +191,12 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
 
     def test_release_documents_identify_current_and_preserve_release_history(self) -> None:
         for readme in _readmes().values():
-            self.assertIn("v0.36.1", readme)
+            self.assertIn("v0.36.2", readme)
             self.assertIn("codex plugin marketplace upgrade click", readme)
             self.assertIn("codex plugin add click@click", readme)
         notes = (ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8")
         for marker in (
+            "## v0.36.2",
             "## v0.36.1",
             "## v0.36.0",
             "## v0.35.0",


### PR DESCRIPTION
Release Click v0.36.2 with the mode and inspection-policy leaves from PR #73, prompt-state leaf from PR #74, and shared contract-state persistence leaf from PR #75. Updates immutable marketplace ref, manifest, three localized READMEs, release notes, and release policy tests. Validation: plugin manifest passed, distribution passed, 468 tests passed with 3 skips.