### PR TITLE
Refactor service and mutation gate facade

### DIFF
--- a/COMPATIBILITY_SURFACE.md
+++ b/COMPATIBILITY_SURFACE.md
@@ -40,7 +40,7 @@ decision and release note.
 ## Private module forwarders
 
 The v0.36.0 facade baseline started with 144 private module-forwarding bindings.
-The current facade contains **123 private module-forwarding bindings** such as
+The current facade contains **118 private module-forwarding bindings** such as
 `_evidence_key = click_evidence.evidence_key`. Their exact names and owners are
 recorded in `tests/click_gate_compatibility_baseline.py`.
 
@@ -55,5 +55,5 @@ These bindings follow four rules:
    migrated to the owning module or a formal host API.
 
 The architecture test intentionally records the current debt without claiming
-that the remaining 123 names are supported forever. Its purpose is to make the surface
+that the remaining 118 names are supported forever. Its purpose is to make the surface
 shrink deliberately and prevent accidental expansion.

--- a/dist/antigravity/hooks/click_gate.py
+++ b/dist/antigravity/hooks/click_gate.py
@@ -112,19 +112,6 @@ else:  # Executed directly from the bundled hooks directory.
 # schema validation now lives in the one-way click_contract boundary.
 _validate_contract = click_contract.validate_contract
 
-# Compatibility aliases for direct callers and the deterministic suite. The
-# managed local-service state machine and runner lifecycle live in the one-way
-# click_service boundary; gate wrappers below provide only cross-domain routing.
-_looks_like_managed_service = click_service.looks_like_managed_service
-_request_service_stop = click_service.request_stop
-_service_snapshot = click_service.service_snapshot
-
-# Compatibility aliases for mutation state and direct result recording. The
-# gate wrappers below inject host routing and shared execution mechanics into
-# the one-way click_mutation boundary.
-_fresh_mutation_state = click_mutation.fresh_state
-_mutation_is_running = click_mutation.is_running
-
 # Compatibility aliases for shared shell-free capability validation. These
 # leaves are used by inspection, mutation, service, and verification without
 # importing the gate or one another.
@@ -424,23 +411,6 @@ def _mark_contract_mutated(
 _prune_state = click_lifecycle.prune_state
 
 
-def _validate_mutation_request(raw: str) -> tuple[dict[str, Any] | None, str]:
-    return click_mutation.validate_request(
-        raw,
-        validate_argv=_validate_argv,
-        looks_like_managed_service=_looks_like_managed_service,
-        protocol_version=CAPABILITY_PROTOCOL_VERSION,
-    )
-
-
-def _validate_service_request(raw: str) -> tuple[dict[str, Any] | None, str]:
-    return click_service.validate_request(
-        raw,
-        validate_argv=_validate_argv,
-        protocol_version=CAPABILITY_PROTOCOL_VERSION,
-    )
-
-
 _validate_evidence_result = click_lifecycle.validate_evidence_result
 _control_request = click_lifecycle.control_request
 
@@ -481,8 +451,8 @@ def _prepare_observation(
         request,
         broad_inventory,
         review=review,
-        mutation_is_running=_mutation_is_running,
-        fresh_mutation_state=_fresh_mutation_state,
+        mutation_is_running=click_mutation.is_running,
+        fresh_mutation_state=click_mutation.fresh_state,
         runner_script=Path(__file__).resolve(),
         render_command=click_runner_transport.render_runner_shell_command,
     )
@@ -514,7 +484,7 @@ def _prepare_mutation(event: dict[str, Any], raw: str) -> tuple[str, str]:
         event,
         raw,
         validate_argv=_validate_argv,
-        looks_like_managed_service=_looks_like_managed_service,
+        looks_like_managed_service=click_service.looks_like_managed_service,
         protocol_version=CAPABILITY_PROTOCOL_VERSION,
         expected_contract_schema_version=CONTRACT_STATE_SCHEMA_VERSION,
         observation_is_running=_observation_is_running,
@@ -641,7 +611,7 @@ def _prepare_browser_evidence(event: dict[str, Any]) -> tuple[bool, str, str]:
         event,
         expected_contract_schema_version=CONTRACT_STATE_SCHEMA_VERSION,
         contract_is_completed=_contract_is_completed,
-        mutation_is_running=_mutation_is_running,
+        mutation_is_running=click_mutation.is_running,
     )
 
 
@@ -667,7 +637,7 @@ def _handle_prompt_submit(event: dict[str, Any]) -> None:
 
 
 def _handle_session_end(event: dict[str, Any]) -> None:
-    _request_service_stop(event)
+    click_service.request_stop(event)
 
 
 def _handle_pre_tool(event: dict[str, Any]) -> None:
@@ -711,7 +681,7 @@ def _handle_pre_tool(event: dict[str, Any]) -> None:
                 if authorization_error:
                     _deny(authorization_error)
                     return
-                _request_service_stop(event)
+                click_service.request_stop(event)
                 _clear_contract_state(event)
                 _clear_review_state(event)
                 _write_state(event, "idle")
@@ -1208,7 +1178,7 @@ def _claim_mutation_run(
         request_digest,
         runner_token,
         validate_argv=_validate_argv,
-        looks_like_managed_service=_looks_like_managed_service,
+        looks_like_managed_service=click_service.looks_like_managed_service,
         protocol_version=CAPABILITY_PROTOCOL_VERSION,
     )
 
@@ -1217,7 +1187,7 @@ def _run_mutation(arguments: list[str]) -> int:
     return click_mutation.run(
         arguments,
         validate_argv=_validate_argv,
-        looks_like_managed_service=_looks_like_managed_service,
+        looks_like_managed_service=click_service.looks_like_managed_service,
         protocol_version=CAPABILITY_PROTOCOL_VERSION,
         execute_commands=_execute_argv_commands,
     )
@@ -1248,7 +1218,7 @@ def _run_service_start(arguments: list[str]) -> int:
 def _run_service_stop(arguments: list[str]) -> int:
     return click_service.run_service_stop(
         arguments,
-        snapshot_reader=_service_snapshot,
+        snapshot_reader=click_service.service_snapshot,
     )
 
 

--- a/hooks/click_gate.py
+++ b/hooks/click_gate.py
@@ -112,19 +112,6 @@ else:  # Executed directly from the bundled hooks directory.
 # schema validation now lives in the one-way click_contract boundary.
 _validate_contract = click_contract.validate_contract
 
-# Compatibility aliases for direct callers and the deterministic suite. The
-# managed local-service state machine and runner lifecycle live in the one-way
-# click_service boundary; gate wrappers below provide only cross-domain routing.
-_looks_like_managed_service = click_service.looks_like_managed_service
-_request_service_stop = click_service.request_stop
-_service_snapshot = click_service.service_snapshot
-
-# Compatibility aliases for mutation state and direct result recording. The
-# gate wrappers below inject host routing and shared execution mechanics into
-# the one-way click_mutation boundary.
-_fresh_mutation_state = click_mutation.fresh_state
-_mutation_is_running = click_mutation.is_running
-
 # Compatibility aliases for shared shell-free capability validation. These
 # leaves are used by inspection, mutation, service, and verification without
 # importing the gate or one another.
@@ -424,23 +411,6 @@ def _mark_contract_mutated(
 _prune_state = click_lifecycle.prune_state
 
 
-def _validate_mutation_request(raw: str) -> tuple[dict[str, Any] | None, str]:
-    return click_mutation.validate_request(
-        raw,
-        validate_argv=_validate_argv,
-        looks_like_managed_service=_looks_like_managed_service,
-        protocol_version=CAPABILITY_PROTOCOL_VERSION,
-    )
-
-
-def _validate_service_request(raw: str) -> tuple[dict[str, Any] | None, str]:
-    return click_service.validate_request(
-        raw,
-        validate_argv=_validate_argv,
-        protocol_version=CAPABILITY_PROTOCOL_VERSION,
-    )
-
-
 _validate_evidence_result = click_lifecycle.validate_evidence_result
 _control_request = click_lifecycle.control_request
 
@@ -481,8 +451,8 @@ def _prepare_observation(
         request,
         broad_inventory,
         review=review,
-        mutation_is_running=_mutation_is_running,
-        fresh_mutation_state=_fresh_mutation_state,
+        mutation_is_running=click_mutation.is_running,
+        fresh_mutation_state=click_mutation.fresh_state,
         runner_script=Path(__file__).resolve(),
         render_command=click_runner_transport.render_runner_shell_command,
     )
@@ -514,7 +484,7 @@ def _prepare_mutation(event: dict[str, Any], raw: str) -> tuple[str, str]:
         event,
         raw,
         validate_argv=_validate_argv,
-        looks_like_managed_service=_looks_like_managed_service,
+        looks_like_managed_service=click_service.looks_like_managed_service,
         protocol_version=CAPABILITY_PROTOCOL_VERSION,
         expected_contract_schema_version=CONTRACT_STATE_SCHEMA_VERSION,
         observation_is_running=_observation_is_running,
@@ -641,7 +611,7 @@ def _prepare_browser_evidence(event: dict[str, Any]) -> tuple[bool, str, str]:
         event,
         expected_contract_schema_version=CONTRACT_STATE_SCHEMA_VERSION,
         contract_is_completed=_contract_is_completed,
-        mutation_is_running=_mutation_is_running,
+        mutation_is_running=click_mutation.is_running,
     )
 
 
@@ -667,7 +637,7 @@ def _handle_prompt_submit(event: dict[str, Any]) -> None:
 
 
 def _handle_session_end(event: dict[str, Any]) -> None:
-    _request_service_stop(event)
+    click_service.request_stop(event)
 
 
 def _handle_pre_tool(event: dict[str, Any]) -> None:
@@ -711,7 +681,7 @@ def _handle_pre_tool(event: dict[str, Any]) -> None:
                 if authorization_error:
                     _deny(authorization_error)
                     return
-                _request_service_stop(event)
+                click_service.request_stop(event)
                 _clear_contract_state(event)
                 _clear_review_state(event)
                 _write_state(event, "idle")
@@ -1208,7 +1178,7 @@ def _claim_mutation_run(
         request_digest,
         runner_token,
         validate_argv=_validate_argv,
-        looks_like_managed_service=_looks_like_managed_service,
+        looks_like_managed_service=click_service.looks_like_managed_service,
         protocol_version=CAPABILITY_PROTOCOL_VERSION,
     )
 
@@ -1217,7 +1187,7 @@ def _run_mutation(arguments: list[str]) -> int:
     return click_mutation.run(
         arguments,
         validate_argv=_validate_argv,
-        looks_like_managed_service=_looks_like_managed_service,
+        looks_like_managed_service=click_service.looks_like_managed_service,
         protocol_version=CAPABILITY_PROTOCOL_VERSION,
         execute_commands=_execute_argv_commands,
     )
@@ -1248,7 +1218,7 @@ def _run_service_start(arguments: list[str]) -> int:
 def _run_service_stop(arguments: list[str]) -> int:
     return click_service.run_service_stop(
         arguments,
-        snapshot_reader=_service_snapshot,
+        snapshot_reader=click_service.service_snapshot,
     )
 
 

--- a/tests/click_gate_compatibility_baseline.py
+++ b/tests/click_gate_compatibility_baseline.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 
-MAX_PRIVATE_FORWARDERS = 123
+MAX_PRIVATE_FORWARDERS = 118
 
 DOCUMENTED_LEGACY_FORWARDERS: dict[str, str] = {
     "_validate_contract": "click_contract.validate_contract",
@@ -49,7 +49,6 @@ PRIVATE_FORWARDERS: dict[str, str] = {
     "_execute_read_only_git": "click_inspection.execute_read_only_git",
     "_execution_argv": "click_inspection.execution_argv",
     "_file_content_digest": "click_verification.file_content_digest",
-    "_fresh_mutation_state": "click_mutation.fresh_state",
     "_fresh_observation_state": "click_observation.fresh_state",
     "_fresh_verification_state": "click_verification.fresh_state",
     "_get_content_paths": "click_inspection.get_content_paths",
@@ -70,11 +69,9 @@ PRIVATE_FORWARDERS: dict[str, str] = {
     "_is_read_only_tokens": "click_inspection.is_read_only_tokens",
     "_is_recognized_verification_command": "click_verification.is_recognized_command",
     "_is_recognized_verification_tokens": "click_verification.is_recognized_tokens",
-    "_looks_like_managed_service": "click_service.looks_like_managed_service",
     "_managed_observation_path": "click_observation.managed_path",
     "_minimum_test_runner_class": "click_verification._minimum_test_runner_class",
     "_minimum_verification_class": "click_verification.minimum_class",
-    "_mutation_is_running": "click_mutation.is_running",
     "_new_untracked_is_suspicious": "click_verification.new_untracked_is_suspicious",
     "_observation_is_running": "click_observation.is_running",
     "_parse_read_only_git_tokens": "click_inspection.parse_read_only_git_tokens",
@@ -95,7 +92,6 @@ PRIVATE_FORWARDERS: dict[str, str] = {
     "_record_user_prompt": "click_prompt.record_user_prompt",
     "_redact_git_remote_output": "click_inspection.redact_git_remote_output",
     "_redact_git_remote_url": "click_inspection.redact_git_remote_url",
-    "_request_service_stop": "click_service.request_stop",
     "_resolve_read_only_executable": "click_inspection.resolve_read_only_executable",
     "_sanitized_executable_path": "click_inspection.sanitized_executable_path",
     "_sanitized_git_environment": "click_inspection.sanitized_git_environment",
@@ -103,7 +99,6 @@ PRIVATE_FORWARDERS: dict[str, str] = {
     "_save_contract_state": "click_contract_state.save_contract_state",
     "_save_review_state": "click_observation.save_review_state",
     "_scope_with_kind_floor": "click_verification._scope_with_kind_floor",
-    "_service_snapshot": "click_service.service_snapshot",
     "_session_contract_is_active": "click_lifecycle.session_contract_is_active",
     "_shell_segments": "click_capability.shell_segments",
     "_store_dependency_receipt": "click_verification.store_dependency_receipt",

--- a/tests/test_click_compatibility_surface.py
+++ b/tests/test_click_compatibility_surface.py
@@ -47,6 +47,21 @@ def _private_forwarders() -> dict[str, str]:
     return bindings
 
 
+def _top_level_names() -> frozenset[str]:
+    tree = ast.parse((HOOKS / "click_gate.py").read_text(encoding="utf-8"))
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+        elif isinstance(node, ast.Assign):
+            names.update(
+                target.id for target in node.targets if isinstance(target, ast.Name)
+            )
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            names.add(node.target.id)
+    return frozenset(names)
+
+
 def _click_gate_surface(path: Path) -> frozenset[str]:
     tree = ast.parse(path.read_text(encoding="utf-8"))
     names = {
@@ -89,6 +104,19 @@ class ClickCompatibilitySurfaceTests(unittest.TestCase):
             with self.subTest(name=name):
                 self.assertEqual(actual.get(name), target)
 
+    def test_removed_domain_helpers_stay_out_of_the_gate_facade(self) -> None:
+        self.assertTrue(
+            {
+                "_fresh_mutation_state",
+                "_looks_like_managed_service",
+                "_mutation_is_running",
+                "_request_service_stop",
+                "_service_snapshot",
+                "_validate_mutation_request",
+                "_validate_service_request",
+            }.isdisjoint(_top_level_names())
+        )
+
     def test_only_declared_host_adapters_depend_on_the_gate_facade(self) -> None:
         actual: dict[str, frozenset[str]] = {}
         for path in HOOKS.glob("*.py"):
@@ -104,7 +132,7 @@ class ClickCompatibilitySurfaceTests(unittest.TestCase):
         policy = (ROOT / "COMPATIBILITY_SURFACE.md").read_text(encoding="utf-8")
 
         self.assertIn("started with 144 private module-forwarding bindings", policy)
-        self.assertIn("123 private module-forwarding bindings", policy)
+        self.assertIn("118 private module-forwarding bindings", policy)
         self.assertIn("baseline must not grow", policy)
         self.assertIn("not a general public extension API", policy)
         self.assertIn("formal host API", policy)

--- a/tests/test_click_gate_execution.py
+++ b/tests/test_click_gate_execution.py
@@ -106,7 +106,7 @@ class ClickGateExecutionTests(ClickGateTestCase):
             "started_at": int(time.time()) - 10_000,
         }
         with mock.patch.object(CLICK_GATE.time, "time", return_value=20_000):
-            self.assertTrue(CLICK_GATE._mutation_is_running(mutation))
+            self.assertTrue(CLICK_MUTATION.is_running(mutation))
 
     def test_mutation_runner_claims_authorization_before_execution(self) -> None:
         self.approve_contract()

--- a/tests/test_click_gate_service.py
+++ b/tests/test_click_gate_service.py
@@ -21,6 +21,14 @@ from click_gate_test_support import (
 )
 
 
+def validate_service_request(raw: str):
+    return CLICK_SERVICE.validate_request(
+        raw,
+        validate_argv=CLICK_GATE.click_capability.validate_argv,
+        protocol_version=CLICK_GATE.CAPABILITY_PROTOCOL_VERSION,
+    )
+
+
 class ClickGateServiceTests(ClickGateTestCase):
     def test_managed_service_start_runner_is_one_use_and_preclaimed(self) -> None:
         self.approve_contract()
@@ -48,7 +56,7 @@ class ClickGateServiceTests(ClickGateTestCase):
         state_path = next(
             (self.plugin_data / "gate-state").glob("session-contract-*.json")
         ).resolve()
-        normalized, error = CLICK_GATE._validate_service_request(json.dumps(request))
+        normalized, error = validate_service_request(json.dumps(request))
         self.assertEqual(error, "")
         self.assertIsNotNone(normalized)
         assert normalized is not None
@@ -126,9 +134,7 @@ class ClickGateServiceTests(ClickGateTestCase):
                 state = json.loads(state_path.read_text(encoding="utf-8"))
                 state["service"]["started_at"] = started_at
                 state_path.write_text(json.dumps(state), encoding="utf-8")
-                normalized, error = CLICK_GATE._validate_service_request(
-                    json.dumps(request)
-                )
+                normalized, error = validate_service_request(json.dumps(request))
                 self.assertEqual(error, "")
                 assert normalized is not None
                 arguments = [
@@ -171,7 +177,7 @@ class ClickGateServiceTests(ClickGateTestCase):
         state_path = next(
             (self.plugin_data / "gate-state").glob("session-contract-*.json")
         ).resolve()
-        normalized, error = CLICK_GATE._validate_service_request(json.dumps(request))
+        normalized, error = validate_service_request(json.dumps(request))
         self.assertEqual(error, "")
         assert normalized is not None
         cwd_raw = str(self.workspace.resolve())
@@ -240,7 +246,7 @@ class ClickGateServiceTests(ClickGateTestCase):
         state_path = next(
             (self.plugin_data / "gate-state").glob("session-contract-*.json")
         ).resolve()
-        normalized, error = CLICK_GATE._validate_service_request(json.dumps(request))
+        normalized, error = validate_service_request(json.dumps(request))
         self.assertEqual(error, "")
         assert normalized is not None
         cwd_raw = str(self.workspace.resolve())
@@ -307,7 +313,7 @@ class ClickGateServiceTests(ClickGateTestCase):
         state_path = next(
             (self.plugin_data / "gate-state").glob("session-contract-*.json")
         ).resolve()
-        normalized, error = CLICK_GATE._validate_service_request(json.dumps(request))
+        normalized, error = validate_service_request(json.dumps(request))
         self.assertEqual(error, "")
         assert normalized is not None
         arguments = [
@@ -415,7 +421,7 @@ class ClickGateServiceTests(ClickGateTestCase):
             ),
             mock.patch.object(Path, "read_text", transient_read),
         ):
-            snapshot = CLICK_GATE._service_snapshot(state_path, "service-1")
+            snapshot = CLICK_SERVICE.service_snapshot(state_path, "service-1")
         self.assertIsNotNone(snapshot)
         assert snapshot is not None
         self.assertEqual(snapshot["status"], "stopped")
@@ -423,8 +429,8 @@ class ClickGateServiceTests(ClickGateTestCase):
     def test_service_stop_does_not_treat_unreadable_state_as_stopped(self) -> None:
         with (
             mock.patch.object(
-                CLICK_GATE,
-                "_service_snapshot",
+                CLICK_SERVICE,
+                "service_snapshot",
                 side_effect=[None, {"status": "stopped"}],
             ) as snapshot,
             mock.patch.object(

--- a/tests/test_click_mutation.py
+++ b/tests/test_click_mutation.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 import unittest
 
-from hooks import click_gate, click_mutation
+from hooks import click_capability, click_mutation, click_service
 
 
 class ClickMutationTests(unittest.TestCase):
@@ -49,29 +49,15 @@ class ClickMutationTests(unittest.TestCase):
             with self.subTest(required=required):
                 self.assertIn(required, imported)
 
-    def test_gate_keeps_mutation_compatibility_aliases(self) -> None:
-        aliases = {
-            "_fresh_mutation_state": click_mutation.fresh_state,
-            "_mutation_is_running": click_mutation.is_running,
-        }
-        for name, expected in aliases.items():
-            with self.subTest(name=name):
-                self.assertIs(getattr(click_gate, name), expected)
-
-        for name in ("_fresh_mutation_boundary", "_record_mutation_result"):
-            with self.subTest(name=name):
-                self.assertFalse(hasattr(click_gate, name))
-
-        self.assertIs(
-            click_gate.MUTATION_REQUEST_FIELDS,
-            click_mutation.REQUEST_FIELDS,
-        )
-        self.assertEqual(
-            click_gate.MUTATION_RUNNING_TTL_SECONDS,
-            click_mutation.RUNNING_TTL_SECONDS,
-        )
-
     def test_mutation_validation_preserves_exact_errors_and_normalization(self) -> None:
+        def validate(raw: str):
+            return click_mutation.validate_request(
+                raw,
+                validate_argv=click_capability.validate_argv,
+                looks_like_managed_service=click_service.looks_like_managed_service,
+                protocol_version=click_capability.PROTOCOL_VERSION,
+            )
+
         cases = (
             ("{", "Mutation request must be valid JSON."),
             ("[]", "Mutation request must be a JSON object."),
@@ -91,11 +77,11 @@ class ClickMutationTests(unittest.TestCase):
         )
         for raw, expected in cases:
             with self.subTest(expected=expected):
-                value, error = click_gate._validate_mutation_request(raw)
+                value, error = validate(raw)
                 self.assertIsNone(value)
                 self.assertEqual(error, expected)
 
-        request, error = click_gate._validate_mutation_request(
+        request, error = validate(
             json.dumps({"version": 1, "argv": ["python", "build.py"]})
         )
         self.assertEqual(error, "")

--- a/tests/test_click_service.py
+++ b/tests/test_click_service.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 import unittest
 
-from hooks import click_gate, click_service
+from hooks import click_capability, click_service
 
 
 class ClickServiceTests(unittest.TestCase):
@@ -42,42 +42,14 @@ class ClickServiceTests(unittest.TestCase):
         self.assertIn("click_process", imported)
         self.assertIn("click_state", imported)
 
-    def test_gate_keeps_service_compatibility_aliases(self) -> None:
-        aliases = {
-            "_looks_like_managed_service": click_service.looks_like_managed_service,
-            "_request_service_stop": click_service.request_stop,
-            "_service_snapshot": click_service.service_snapshot,
-        }
-        for name, expected in aliases.items():
-            with self.subTest(name=name):
-                self.assertIs(getattr(click_gate, name), expected)
-
-        for name in (
-            "_fresh_service_state",
-            "_record_service_fields",
-            "_claim_service_runner",
-        ):
-            with self.subTest(name=name):
-                self.assertFalse(hasattr(click_gate, name))
-
-        self.assertIs(
-            click_gate.SERVICE_REQUEST_FIELDS,
-            click_service.SERVICE_REQUEST_FIELDS,
-        )
-        self.assertEqual(
-            click_gate.SERVICE_START_TIMEOUT_SECONDS,
-            click_service.SERVICE_START_TIMEOUT_SECONDS,
-        )
-        self.assertEqual(
-            click_gate.SERVICE_STOP_TIMEOUT_SECONDS,
-            click_service.SERVICE_STOP_TIMEOUT_SECONDS,
-        )
-        self.assertEqual(
-            click_gate.MANAGED_SERVICE_MAX_SECONDS,
-            click_service.MANAGED_SERVICE_MAX_SECONDS,
-        )
-
     def test_service_validation_preserves_exact_errors_and_normalization(self) -> None:
+        def validate(raw: str):
+            return click_service.validate_request(
+                raw,
+                validate_argv=click_capability.validate_argv,
+                protocol_version=click_capability.PROTOCOL_VERSION,
+            )
+
         cases = (
             ("{", "Managed service request must be valid JSON."),
             ("[]", "Managed service request must be a JSON object."),
@@ -107,17 +79,15 @@ class ClickServiceTests(unittest.TestCase):
         )
         for raw, expected in cases:
             with self.subTest(expected=expected):
-                value, error = click_gate._validate_service_request(raw)
+                value, error = validate(raw)
                 self.assertIsNone(value)
                 self.assertEqual(error, expected)
 
-        stop, error = click_gate._validate_service_request(
-            json.dumps({"version": 1, "action": "stop"})
-        )
+        stop, error = validate(json.dumps({"version": 1, "action": "stop"}))
         self.assertEqual(error, "")
         self.assertEqual(stop, {"version": 1, "action": "stop"})
 
-        start, error = click_gate._validate_service_request(
+        start, error = validate(
             json.dumps({"version": 1, "action": "start", "argv": ["vite"]})
         )
         self.assertEqual(error, "")


### PR DESCRIPTION
## Summary\n\n- remove obsolete service and mutation compatibility forwarders from `click_gate.py`\n- route gate and owner tests directly through `click_service` and `click_mutation`\n- reduce the private forwarder compatibility baseline from 123 to 118\n- keep the Antigravity distribution synchronized\n\n## Verification\n\n- `python3 -m unittest tests.test_click_mutation tests.test_click_gate_execution tests.test_click_compatibility_surface -q` (28 passed)\n- `python3 -m unittest tests.test_distribution_validation -q` (3 passed)