### PR TITLE
release: Click v0.51.1 fixes duplicate Antigravity contracts

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/grapefruit0205/click.git",
-        "ref": "v0.51.0"
+        "ref": "v0.51.1"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "click",
-  "version": "0.51.0",
+  "version": "0.51.1",
   "description": "Evidence by default: let the host run normally while Click records revision-aware proof. Opt into Guarded for one human-readable, approval-bound execution contract.",
   "author": {
     "name": "Junseok Pak",

--- a/README.ko.md
+++ b/README.ko.md
@@ -106,7 +106,7 @@ Guarded를 직접 선택할 수도 있습니다.
 
 ## 업데이트
 
-현재 릴리스: **v0.51.0**
+현재 릴리스: **v0.51.1**
 
 ~~~bash
 codex plugin marketplace upgrade click

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Or explicitly choose Guarded:
 
 ## Update
 
-Current release: **v0.51.0**
+Current release: **v0.51.1**
 
 ~~~bash
 codex plugin marketplace upgrade click

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -104,7 +104,7 @@ Evidence 模式下直接提出普通请求即可：
 
 ## 更新
 
-当前版本：**v0.51.0**
+当前版本：**v0.51.1**
 
 ~~~bash
 codex plugin marketplace upgrade click

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Release notes
 
+## v0.51.1 — 2026-09-03
+
+- Antigravity now remembers when the staged Guarded projection has already
+  been delivered within one execution epoch. Repeated `PreInvocation` events
+  no longer ask the model to compile, present, or request approval for the same
+  contract again.
+- A later explicit approval is routed to the existing `contract_id`, and an
+  already approved execution continues without another pass, stage, or approval
+  request. The one-user-response approval boundary and fail-closed behavior are
+  unchanged.
+
 ## v0.51.0 — 2026-09-03
 
 - A committed `.click/evidence-reuse.json` can bind an exact check group to

--- a/dist/antigravity/hooks/antigravity_gate.py
+++ b/dist/antigravity/hooks/antigravity_gate.py
@@ -26,19 +26,25 @@ else:  # Executed directly from the bundled hooks directory.
 
 (
     click_capability,
+    click_contract_state,
     click_gate,
     click_host_coverage,
     click_inspection,
+    click_lifecycle,
     click_runner_transport,
+    click_runtime_state,
     click_state,
     platform_protocol,
 ) = click_import_bootstrap.load_siblings(
     __package__,
     "click_capability",
+    "click_contract_state",
     "click_gate",
     "click_host_coverage",
     "click_inspection",
+    "click_lifecycle",
     "click_runner_transport",
+    "click_runtime_state",
     "click_state",
     "platform_protocol",
 )
@@ -209,6 +215,59 @@ def _capture(
     return HOST_ROUTER.capture(action, event, output_adapter=adapter)
 
 
+def _guarded_continuation_context(
+    event: dict[str, Any], lifecycle: dict[str, Any]
+) -> str:
+    state = click_contract_state.read_contract_state(event)
+    runtime = click_runtime_state.view(state)
+    contract_id = click_lifecycle.contract_id_from_state(state)
+    if not contract_id or not click_lifecycle.session_contract_is_active(state):
+        return ""
+
+    current_turn_id = str(event.get("turn_id", ""))
+    if runtime.staged:
+        if str(state.get("staged_turn_id", "")) == current_turn_id:
+            if lifecycle.get("staged_projection_context_id") == contract_id:
+                return (
+                    "Click Guarded mode already staged contract_id "
+                    f"`{contract_id}` in this user execution. The existing "
+                    "Hook-generated projection was already returned for presentation. "
+                    "Do not compile, stage, present, or request approval for another "
+                    "contract; finish this execution and wait for the user's next response."
+                )
+            lifecycle["staged_projection_context_id"] = contract_id
+            return (
+                "Click Guarded mode already staged contract_id "
+                f"`{contract_id}` in this user execution. Do not compile or stage "
+                "another contract and do not pass this one yet. Present the existing "
+                "Hook-generated projection exactly once, ask for approval once, then "
+                "finish this execution and wait for a later user response."
+            )
+        return (
+            "Click Guarded mode has active staged contract_id "
+            f"`{contract_id}`. Do not compile, stage, restate, or request approval "
+            "for another contract. If and only if the current user response explicitly "
+            "approves the existing proposal, pass this exact id once; otherwise leave "
+            "the staged contract unchanged."
+        )
+
+    if runtime.guarded_approved:
+        if str(state.get("approved_turn_id", "")) == current_turn_id:
+            return (
+                "Click Guarded contract_id "
+                f"`{contract_id}` is already approved for this user execution. "
+                "Continue the approved implementation without passing, staging, "
+                "presenting, or requesting approval again."
+            )
+        return (
+            "Click Guarded contract_id "
+            f"`{contract_id}` is already approved and incomplete. Resume it by "
+            "passing this exact id once for the current user execution. Do not compile, "
+            "stage, present, or request approval for another contract."
+        )
+    return ""
+
+
 def _record_pre_invocation(raw: dict[str, Any]) -> dict[str, Any]:
     conversation_id = _conversation_id(raw)
     workspace = _workspace(raw)
@@ -238,6 +297,9 @@ def _record_pre_invocation(raw: dict[str, Any]) -> dict[str, Any]:
             "invocation_num": raw.get("invocationNum"),
             "prompt_fingerprint": prompt_fingerprint,
             "awaiting_next_execution": awaiting_next,
+            "staged_projection_context_id": str(
+                lifecycle.get("staged_projection_context_id", "")
+            ),
             "updated_at": int(time.time()),
         }
         click_state.write_json(lifecycle_path, context)
@@ -246,9 +308,15 @@ def _record_pre_invocation(raw: dict[str, Any]) -> dict[str, Any]:
         payload = _capture(
             AntigravityOutputAdapter(), "prompt-submit", event
         )
+        continuation_context = _guarded_continuation_context(event, context)
+        if continuation_context:
+            click_state.write_json(lifecycle_path, context)
+            click_state.write_json(_workspace_context_path(workspace), context)
         steps = payload.get("injectSteps") if isinstance(payload, dict) else None
         if isinstance(steps, list) and steps and isinstance(steps[0], dict):
-            message = str(steps[0].get("ephemeralMessage", ""))
+            message = continuation_context or str(
+                steps[0].get("ephemeralMessage", "")
+            )
             steps[0]["ephemeralMessage"] = (
                 "Use this exact absolute Click control launcher for this installation: `"
                 f"{_control_launcher_command()}`. "

--- a/hooks/antigravity_gate.py
+++ b/hooks/antigravity_gate.py
@@ -26,19 +26,25 @@ else:  # Executed directly from the bundled hooks directory.
 
 (
     click_capability,
+    click_contract_state,
     click_gate,
     click_host_coverage,
     click_inspection,
+    click_lifecycle,
     click_runner_transport,
+    click_runtime_state,
     click_state,
     platform_protocol,
 ) = click_import_bootstrap.load_siblings(
     __package__,
     "click_capability",
+    "click_contract_state",
     "click_gate",
     "click_host_coverage",
     "click_inspection",
+    "click_lifecycle",
     "click_runner_transport",
+    "click_runtime_state",
     "click_state",
     "platform_protocol",
 )
@@ -209,6 +215,59 @@ def _capture(
     return HOST_ROUTER.capture(action, event, output_adapter=adapter)
 
 
+def _guarded_continuation_context(
+    event: dict[str, Any], lifecycle: dict[str, Any]
+) -> str:
+    state = click_contract_state.read_contract_state(event)
+    runtime = click_runtime_state.view(state)
+    contract_id = click_lifecycle.contract_id_from_state(state)
+    if not contract_id or not click_lifecycle.session_contract_is_active(state):
+        return ""
+
+    current_turn_id = str(event.get("turn_id", ""))
+    if runtime.staged:
+        if str(state.get("staged_turn_id", "")) == current_turn_id:
+            if lifecycle.get("staged_projection_context_id") == contract_id:
+                return (
+                    "Click Guarded mode already staged contract_id "
+                    f"`{contract_id}` in this user execution. The existing "
+                    "Hook-generated projection was already returned for presentation. "
+                    "Do not compile, stage, present, or request approval for another "
+                    "contract; finish this execution and wait for the user's next response."
+                )
+            lifecycle["staged_projection_context_id"] = contract_id
+            return (
+                "Click Guarded mode already staged contract_id "
+                f"`{contract_id}` in this user execution. Do not compile or stage "
+                "another contract and do not pass this one yet. Present the existing "
+                "Hook-generated projection exactly once, ask for approval once, then "
+                "finish this execution and wait for a later user response."
+            )
+        return (
+            "Click Guarded mode has active staged contract_id "
+            f"`{contract_id}`. Do not compile, stage, restate, or request approval "
+            "for another contract. If and only if the current user response explicitly "
+            "approves the existing proposal, pass this exact id once; otherwise leave "
+            "the staged contract unchanged."
+        )
+
+    if runtime.guarded_approved:
+        if str(state.get("approved_turn_id", "")) == current_turn_id:
+            return (
+                "Click Guarded contract_id "
+                f"`{contract_id}` is already approved for this user execution. "
+                "Continue the approved implementation without passing, staging, "
+                "presenting, or requesting approval again."
+            )
+        return (
+            "Click Guarded contract_id "
+            f"`{contract_id}` is already approved and incomplete. Resume it by "
+            "passing this exact id once for the current user execution. Do not compile, "
+            "stage, present, or request approval for another contract."
+        )
+    return ""
+
+
 def _record_pre_invocation(raw: dict[str, Any]) -> dict[str, Any]:
     conversation_id = _conversation_id(raw)
     workspace = _workspace(raw)
@@ -238,6 +297,9 @@ def _record_pre_invocation(raw: dict[str, Any]) -> dict[str, Any]:
             "invocation_num": raw.get("invocationNum"),
             "prompt_fingerprint": prompt_fingerprint,
             "awaiting_next_execution": awaiting_next,
+            "staged_projection_context_id": str(
+                lifecycle.get("staged_projection_context_id", "")
+            ),
             "updated_at": int(time.time()),
         }
         click_state.write_json(lifecycle_path, context)
@@ -246,9 +308,15 @@ def _record_pre_invocation(raw: dict[str, Any]) -> dict[str, Any]:
         payload = _capture(
             AntigravityOutputAdapter(), "prompt-submit", event
         )
+        continuation_context = _guarded_continuation_context(event, context)
+        if continuation_context:
+            click_state.write_json(lifecycle_path, context)
+            click_state.write_json(_workspace_context_path(workspace), context)
         steps = payload.get("injectSteps") if isinstance(payload, dict) else None
         if isinstance(steps, list) and steps and isinstance(steps[0], dict):
-            message = str(steps[0].get("ephemeralMessage", ""))
+            message = continuation_context or str(
+                steps[0].get("ephemeralMessage", "")
+            )
             steps[0]["ephemeralMessage"] = (
                 "Use this exact absolute Click control launcher for this installation: `"
                 f"{_control_launcher_command()}`. "

--- a/tests/test_antigravity_adapter.py
+++ b/tests/test_antigravity_adapter.py
@@ -292,6 +292,52 @@ class AntigravityAdapterTests(unittest.TestCase):
         self.assertEqual(state["status"], "evidence")
         self.assertEqual(state["verification"]["mutation_revision"], 1)
 
+    def test_repeated_pre_invocation_requests_staged_approval_only_once(self) -> None:
+        self.pre_invocation("build the requested feature", invocation_num=1)
+        self.assertEqual(self.control("default", "on").returncode, 0)
+        contract_id = self.stage()
+
+        first = self.pre_invocation(
+            "build the requested feature", invocation_num=2
+        )
+        first_message = first["injectSteps"][0]["ephemeralMessage"]
+        self.assertIn(contract_id, first_message)
+        self.assertIn("projection exactly once", first_message)
+        self.assertIn("ask for approval once", first_message)
+        self.assertNotIn("compile the compact Click contract", first_message)
+
+        repeated = self.pre_invocation(
+            "build the requested feature", invocation_num=3
+        )
+        repeated_message = repeated["injectSteps"][0]["ephemeralMessage"]
+        self.assertIn(contract_id, repeated_message)
+        self.assertIn("was already returned for presentation", repeated_message)
+        self.assertIn("Do not compile, stage, present, or request", repeated_message)
+        self.assertNotIn("projection exactly once", repeated_message)
+        self.assertNotIn("compile the compact Click contract", repeated_message)
+
+    def test_approval_execution_does_not_request_another_contract(self) -> None:
+        self.pre_invocation("build the requested feature")
+        self.assertEqual(self.control("default", "on").returncode, 0)
+        contract_id = self.stage()
+        self.pre_invocation("build the requested feature", invocation_num=1)
+        self.stop()
+
+        approval = self.pre_invocation("I approve")
+        approval_message = approval["injectSteps"][0]["ephemeralMessage"]
+        self.assertIn(contract_id, approval_message)
+        self.assertIn("explicitly approves the existing proposal", approval_message)
+        self.assertIn("Do not compile, stage, restate, or request", approval_message)
+        self.assertNotIn("compile the compact Click contract", approval_message)
+
+        passed = self.control("pass", contract_id)
+        self.assertEqual(passed.returncode, 0, passed.stderr)
+        continued = self.pre_invocation("I approve", invocation_num=1)
+        continued_message = continued["injectSteps"][0]["ephemeralMessage"]
+        self.assertIn("already approved for this user execution", continued_message)
+        self.assertIn("without passing, staging, presenting, or requesting", continued_message)
+        self.assertNotIn("compile the compact Click contract", continued_message)
+
     def test_post_tool_closes_the_approved_mutation_snapshot(self) -> None:
         self.initialize_git("tests/test_sample.py")
         self.approve()

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -43,7 +43,7 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
             (ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
         )
         self.assertEqual(manifest["name"], "click")
-        self.assertEqual(manifest["version"], "0.51.0")
+        self.assertEqual(manifest["version"], "0.51.1")
         self.assertEqual(manifest["license"], "MIT")
         combined_copy = " ".join(
             (
@@ -69,7 +69,7 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
         self.assertEqual(marketplace["name"], "click")
         self.assertEqual(marketplace["plugins"][0]["name"], "click")
         self.assertEqual(
-            marketplace["plugins"][0]["source"]["ref"], "v0.51.0"
+            marketplace["plugins"][0]["source"]["ref"], "v0.51.1"
         )
 
     def test_readmes_lead_with_evidence_first_positioning(self) -> None:
@@ -214,13 +214,14 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
 
     def test_release_documents_identify_current_and_preserve_release_history(self) -> None:
         for readme in _readmes().values():
-            self.assertIn("v0.51.0", readme)
+            self.assertIn("v0.51.1", readme)
             self.assertIn("codex plugin marketplace upgrade click", readme)
             self.assertIn("codex plugin add click@click", readme)
             self.assertIn("RELEASE_NOTES.md", readme)
 
         notes = (ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8")
         for marker in (
+            "## v0.51.1",
             "## v0.51.0",
             "## v0.50.0",
             "## v0.36.2",


### PR DESCRIPTION
## Problem

Antigravity emits PreInvocation more than once within one user execution. After Click staged a Guarded contract, each repeated invocation received the generic instruction to compile and request a contract again. That could make the model repeat the same approval request.

## Fix

- detect active staged and approved contracts in the Antigravity adapter
- deliver the staged projection instruction only once per contract
- tell later invocations in the same execution not to compile, stage, present, or request another contract
- route the later approval execution directly to the existing contract id
- keep incomplete approved work on the same contract without another approval
- rebuild the self-contained Antigravity distribution

## Release

- publish as v0.51.1
- align plugin metadata, marketplace immutable ref, all README release labels, tests, and release notes

## Verification

- 500 repository tests passed, 3 skipped
- 75 Antigravity and Guarded lifecycle tests passed, 1 skipped
- release metadata tests passed
- distribution and agy plugin validation passed
- git diff --check passed