### PR TITLE
Click v0.81.0: preserve Evidence continuity and live verification results

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/grapefruit0205/click.git",
-        "ref": "v0.80.0"
+        "ref": "v0.81.0"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "click",
-  "version": "0.80.0",
+  "version": "0.81.0",
   "description": "Incremental verification for coding agents: rerun affected checks and keep authoritative passing evidence reusable, with optional Guarded approval boundaries.",
   "author": {
     "name": "Junseok Pak",

--- a/README.ko.md
+++ b/README.ko.md
@@ -106,7 +106,7 @@ Guarded를 직접 선택할 수도 있습니다.
 
 ## 업데이트
 
-현재 릴리스: **v0.80.0**
+현재 릴리스: **v0.81.0**
 
 ~~~bash
 codex plugin marketplace upgrade click
@@ -169,16 +169,11 @@ Git과 플러그인의 Python만 사용하므로 Linux, macOS, Windows에서 별
 모든 의존성을 자동 발견했다는 뜻은 아닙니다.
 커밋된 [Evidence Shards 맵](skills/click/references/evidence-shards-v1.md)은 정확한 broad suite 하나를 독립 자식으로 나눠, 뒤의 shard가 실패해도 앞의 통과 결과를 보존합니다. 이 맵만으로 mutation 뒤 재사용할 수는 없으며 위 규칙이 자식별로 다시 적용되고, 맵이 잘못되면 원래 suite를 실행합니다.
 
-Observer는 기본적으로 꺼져 있고 Dashboard와 별개입니다. `click-gate observer off`,
-`shadow`, `status`로 제어하며, 명시적으로 `shadow`를 켠 때만 호환되는 실제 검사에
-네이티브 수집기를 붙입니다. Linux는 `strace`, 권한이 이미 있는 macOS는 `fs_usage`,
-Windows는 기본 ETW 도구인 `logman.exe`와 `tracerpt.exe`를 사용합니다. Click은 어떤
-도구도 설치하거나 권한을 올리지 않습니다. Shadow 예측만으로 검사를 생략하지
-않습니다. Dashboard는 실제 실행, 권한 있는 exact/dependency/policy 재사용, 최근
-실행 기준 추정 회피 시간, Shadow 잠재값을 분리합니다. `click-gate dashboard start`,
-`status`, `stop`으로 열고 확인하고 닫습니다.
+Observer는 기본적으로 꺼져 있고 Dashboard와 별개입니다. `click-gate observer off`, `shadow`, `status`로 제어하며, 명시적으로 `shadow`를 켠 때만 호환되는 실제 검사에 네이티브 수집기를 붙입니다. Linux는 `strace`, 권한이 이미 있는 macOS는 `fs_usage`, Windows는 기본 ETW 도구인 `logman.exe`와 `tracerpt.exe`를 사용합니다. Click은 도구를 설치하거나 권한을 올리지 않으며 Shadow 예측만으로 검사를 생략하지 않습니다. Dashboard는 실제 실행, 권한 있는 exact/dependency/policy 재사용, 최근 실행 기준 추정 회피 시간, Shadow 잠재값을 분리하며 `click-gate dashboard start`, `status`, `stop`으로 제어합니다.
 
 검증 효율 화면은 **검증 묶음**별 계획과 실제 실행·재사용·미실행을 구분합니다. 부분 계측과 전체 대기시간, 과거 실행 기반 추정을 섞지 않으며 배치 타임라인과 JSON·독립형 HTML 공유본을 제공합니다. `python3 benchmarks/incremental_verification.py --iterations 3 --warmups 1 --output /tmp/click-comparison.json`으로 실제 Hook·runner 비교를 실행한 뒤 화면에서 JSON을 선택하세요. 짧은 검사는 관리 비용 때문에 느려질 수도 있습니다. [계측 범위·모드별 차이·내보내기](VERIFICATION_EFFICIENCY.md)를 확인하세요.
+
+대시보드를 한 번 열면 같은 host 세션과 작업 공간의 다음 Evidence 작업에서도 연결이 유지됩니다. 각 검증 묶음이 끝날 때 결과를 즉시 저장하므로 다음 묶음 실행 중에도 앞 묶음의 통과를 볼 수 있고, 취소 뒤에도 이미 발생한 실행 사실은 최근 결과에 남습니다. viewer 연결과 검증 권한은 분리되므로 이전 Guarded 승인이나 runner token은 이어지지 않습니다. 완료된 Evidence 작업의 실제 성공 결과는 다음 Evidence 작업에 **후보**로만 전달되며, Click은 새 요청의 정확한 검사, 작업트리, 환경, 실행 파일, host coverage와 현재 커밋된 정책을 기존 authoritative 규칙으로 다시 확인합니다. revision 숫자만 같거나 history·공유본·Shadow 예측만 있는 경우에는 다시 실행합니다.
 
 ## 완료 영수증
 
@@ -189,7 +184,7 @@ click-gate receipt export
 click-gate receipt verify ./completion-receipt.json
 ~~~
 
-영수증에는 요청 흐름, mutation revision, 최종 workspace, 검사 결과, 환경, 실행 파일, host coverage, 재사용 이력이 묶입니다.
+영수증에는 요청 흐름, mutation revision, 최종 workspace, 검사 결과, 환경, 실행 파일, host coverage, 재사용 이력이 묶입니다. 후속 Evidence 작업에서 재판정해 재사용한 경우 v4 lineage가 원래 Evidence session과 batch, 재판정 방식 및 후보 digest를 기록합니다.
 
 현재 검증 결과는 **unsigned-integrity-only**입니다. 영수증이 바뀌었는지는 확인하지만 발행자 신원까지 증명하지는 않습니다.
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Or explicitly choose Guarded:
 
 ## Update
 
-Current release: **v0.80.0**
+Current release: **v0.81.0**
 
 ~~~bash
 codex plugin marketplace upgrade click
@@ -135,8 +135,7 @@ Cross-revision reuse is intentionally conservative. Evidence mode uses a committ
 .click/evidence-dependencies.json
 ~~~
 
-The committed map authorizes reuse for a specific check. Concrete paths remain
-hard dependencies. When the baseline observation is complete, expanding map
+The committed map authorizes reuse for a specific check, and concrete paths remain hard dependencies. When the baseline observation is complete, expanding map
 patterns such as `*`, `**`, and directory prefixes are refined to the inputs
 the check actually consumed; observed inputs are then hashed into the receipt.
 Working-tree edits cannot narrow the committed policy. If observation is
@@ -175,6 +174,8 @@ Observer collection is off by default and independent from the dashboard. Use `c
 
 Use `click-gate dashboard start`, `status`, or `stop` for actual **verification-group** outcomes, batch history and JSON/standalone HTML exports. Planned, started, reused and unstarted groups are distinct; partial processing measurements, full request wait (unknown when unmeasured), baseline-cost estimates and Shadow remain separate. Run `python3 benchmarks/incremental_verification.py --iterations 3 --warmups 1 --output /tmp/click-comparison.json`, then select that JSON in the viewer for a real hook/runner comparison. Short checks can be slower with runtime overhead. See [measurement scope, mode boundaries and exports](VERIFICATION_EFFICIENCY.md).
 
+An opened dashboard remains attached to the same host session and workspace across successive Evidence tasks. Each verification group is persisted as soon as it finishes, so an already-passed group remains visible while the next group runs and after cancellation. Viewer connectivity does not carry Guarded approval, runner tokens, unfinished commands, or completion authority into the next task. A completed Evidence task may pass real successful results forward as **candidates only**; Click rechecks the exact source and check, workspace and mutation boundary, environment, executable, host coverage, and existing dependency or committed safe-change rules. Equal revision numbers, dashboard history, exports, timing, and Shadow predictions never authorize reuse.
+
 ## Completion receipt
 
 Click can export a receipt after current evidence is complete:
@@ -184,7 +185,7 @@ click-gate receipt export
 click-gate receipt verify ./completion-receipt.json
 ~~~
 
-The receipt binds the request lineage, mutation revision, final workspace, checks, environment, executable identity, host coverage, and reuse lineage.
+The receipt binds request lineage, mutation revision, final workspace, checks, environment, executable identity, host coverage, and reuse lineage. When a later Evidence task requalifies and applies an earlier success, receipt v4 records `successor-reused` lineage with the origin Evidence session and batch, origin revision, requalification mode, and candidate digest.
 
 Receipt verification currently reports **unsigned-integrity-only**. It detects accidental or uncoordinated changes to the receipt, but it does not yet prove the publisher's identity.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -108,7 +108,7 @@ Evidence 模式下直接提出普通请求即可：
 
 ## 更新
 
-当前版本：**v0.80.0**
+当前版本：**v0.81.0**
 
 ~~~bash
 codex plugin marketplace upgrade click

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,28 @@
 # Release notes
 
+## v0.81.0 — 2026-09-05
+
+- Verification runners now persist each verification-group completion and duration
+  before starting the next group. Cancellation preserves already-witnessed passes,
+  distinguishes an active unconfirmed interruption from later not-run groups, and
+  cannot let a late runner restore revoked authority or overwrite another batch.
+- Dashboard viewer state is now bound to the host session and workspace in a
+  separate sidecar rather than an individual Evidence lifecycle. One explicitly
+  opened viewer survives successive Evidence tasks and cancellation as a read-only
+  recent-results view; explicit stop, SessionEnd, access-token/origin checks, and
+  bounded lifetime remain in force.
+- A completed Evidence task can retain real successful source facts as candidates
+  for the next Evidence task in the same scope. The new task requalifies check,
+  tree, mutation, environment, executable, host coverage, dependency, and committed
+  safe-change bindings. History, timing, Shadow data, equal revision numbers, and
+  prior approval never grant reuse.
+- Successor reuse records its origin batch and Evidence session in dashboard and
+  sanitized exports. Completion receipt v4 adds strict `successor-reused` lineage.
+- The real benchmark adds a `partial-reuse` Evidence lifecycle scenario in which
+  one shard is policy-reused and one shard actually runs; no receipt or decision is
+  injected. Lifecycle state-machine tests use an in-process hook harness while
+  dedicated transport suites retain executable-boundary coverage.
+
 ## v0.80.0 — 2026-09-05
 
 - The verification-efficiency dashboard now projects actual batch results,

--- a/VERIFICATION_EFFICIENCY.md
+++ b/VERIFICATION_EFFICIENCY.md
@@ -10,9 +10,20 @@ Click을 사용하는 현재 작업에서 `click-gate dashboard start`로 열고
 Observer는 별개이며 `click-gate observer off` 상태에서도 계측·receipt·기존 재사용이 동작합니다.
 새 코드가 설치되지 않은 환경의 기존 viewer에는 새 화면이 나타나지 않습니다.
 
+대시보드는 개별 계약이나 Evidence 배치가 아니라 **검증 가능한 host 세션 + 작업 공간**에
+속합니다. 한 번 열면 같은 범위에서 `수정 → 검증 → 다음 Evidence 작업 → 수정 → 검증`을
+반복해도 같은 URL과 접근 토큰으로 현재 배치와 이전 배치를 계속 읽습니다. 새 Evidence
+작업이 이전 Guarded 승인, runner token, 미완료 명령, 완료 상태를 상속한다는 뜻은 아닙니다.
+`click-gate cancel`은 실행 권한을 폐기하지만 이미 열린 읽기 전용 화면은 최근 결과를
+history-only 상태로 보여줍니다. `dashboard stop`, SessionEnd, 기존 최대 수명 정리는 계속
+viewer를 종료합니다. 다른 host 세션이나 작업 공간은 별도 바인딩이므로 연결되지 않습니다.
+
 상단은 선택한 배치의 **검증 묶음** 수입니다. 개별 테스트 케이스 수나 시간 절감률이 아닙니다.
 최근 배치를 선택하면 계획, 실제 시작·완료·통과·실패·중단·미실행, 재사용 적용,
 영어 reason code와 한국어 설명, 이전 성공 실행 표본을 확인할 수 있습니다.
+각 묶음이 끝나는 즉시 다음 묶음이 시작되기 전에 완료 상태와 실행 구간을 저장하므로,
+`A 통과 → B 실행 중`인 순간에도 A는 통과로 보입니다. 이후 취소하더라도 A의 실행 사실은
+유지되고, B는 확인한 범위에 따라 중단/결과 미확정, 뒤 묶음은 미실행으로 남습니다.
 첫 묶음 실패로 다음 묶음이 시작되지 않았다면 실제 실행 1개 / 미실행 1개입니다.
 종료를 확인하지 못한 실행은 미확정으로 남습니다. 재사용 예정은 적용 실적이 아닙니다.
 Evidence Map은 최신 배치의 상세 분석이며 과거 배치의 입력 그래프를 추측해 복원하지 않습니다.
@@ -59,7 +70,8 @@ python3 benchmarks/incremental_verification.py --mode guarded --iterations 3 --w
 Windows에서는 쓰기 가능한 출력 경로와 현재 Python 명령을 사용하세요. 기존 출력 파일을 덮어쓰지 않습니다.
 비교 driver, Hook 준비, 실제 runner는 같은 Python으로 고정합니다. Windows의 `py -3`가 다른 버전을
 선택해 비교 환경이 달라지는 것을 막되, 발급된 capability와 실제 재사용 권한 검사는 그대로 유지합니다.
-`--scenario`는 first-run, unchanged, docs, code, environment, first-failure 중 여러 번 지정할 수 있습니다.
+`--scenario`는 first-run, unchanged, docs, partial-reuse, code, environment,
+first-failure 중 여러 번 지정할 수 있습니다.
 `--workload-rounds`는 PBKDF2 계산량이며 sleep은 사용하지 않습니다.
 
 각 비교 쌍은 별도 임시 Git 저장소에 같은 코드·두 test 파일·정확한 shard inventory·안전 변경 정책을
@@ -69,9 +81,11 @@ ledger·passing receipt·dependency observation·skip 결정은 주입하지 않
 Guarded fixture는 **임시 테스트 사용자**가 실제 stage와 다음 turn의 pass를 통과하고,
 비교 종료 조건을 가진 계약을 유지합니다. 사용자 저장소의 실제 승인으로 간주하지 않습니다.
 
-기본 Evidence는 완료 후 mutation에서 새 세션을 시작할 수 있어 문서 변경도 재실행될 수 있습니다.
-Guarded fixture의 계속 열린 계약에서는 커밋된 문서 변경 정책 재사용 경로를 측정합니다.
-이 lifecycle 차이를 벤치마크 결과를 좋게 만들려고 바꾸지 않았습니다.
+`partial-reuse`는 기본 Evidence에서 baseline 완료 후 실제 다음 Evidence lifecycle로 넘어간
+다음 README를 변경합니다. 커밋된 서로 다른 정책 때문에 alpha는 이전 실제 성공을 후보로
+가져와 현재 상태에서 safe-change 규칙을 다시 통과해 재사용하고, beta는 정책 범위 밖이라
+실제로 실행합니다. 정책 기반 결과이며 자동 의존성 발견이라고 표현하지 않습니다.
+Guarded fixture는 기존 계약 안에서 같은 권한 규칙을 사용하며 계약 간 승인을 상속하지 않습니다.
 현재 native Shadow는 authoritative dependency observation이 아니므로 코드 변경의 부분 재사용을
 미리 지정하지 않습니다. 실행 권한이 없으면 보수적 재실행 결과를 그대로 보고합니다.
 
@@ -104,3 +118,16 @@ canonical plan v2는 계획만 저장하고, 실제 결과는 `verification-batc
 취소된 실행의 실제 자식 종료가 확인되지 않으면 미확정 중단으로 표시하며 재사용 후보는 적용하지 않습니다.
 파일 시스템 오류가 나면 기록이 없을 수 있지만 계측 실패가 승인 경계·검사 결과·취소를 변경하지 않습니다.
 정상 저장은 기존 atomic replace 방식을 사용하므로 저장 도중 종료에도 반쪽 JSON을 노출하지 않습니다.
+
+완료된 Evidence lifecycle은 같은 host 세션·작업 공간의 다음 Evidence 작업에 이전 성공을
+**재판정 후보**로만 전달할 수 있습니다. 후보는 원래 evidence session, batch, source 사실과
+무결성 digest를 보존합니다. 새 요청의 source/check 범위, 현재 Git tree, mutation boundary,
+환경, 실행 파일, host coverage를 다시 비교하고, 변경된 tree에서는 기존 complete dependency
+observation 또는 현재 커밋된 safe-change policy까지 다시 통과해야 실제 재사용됩니다. revision
+숫자가 우연히 같거나 과거 실행시간이 있다는 이유만으로는 재사용하지 않습니다. Dashboard
+history, 공유 리포트와 Shadow record를 authoritative evidence로 역변환하지 않습니다.
+현재 조합을 안전하게 입증할 수 없으면 reason code를 남기고 실제 검사를 실행합니다.
+
+후속 Evidence 재사용이 있는 completion receipt는 v4 `successor-reused` lineage로 원래 batch와
+Evidence session, 원래 revision, 재판정 방식(exact/dependency/safe-change), 후보 digest를
+기록합니다. 이것은 여전히 `unsigned-integrity-only`이며 발행자 신원 인증은 아닙니다.

--- a/benchmarks/incremental_verification.py
+++ b/benchmarks/incremental_verification.py
@@ -27,7 +27,15 @@ if str(ROOT) not in sys.path:
 from hooks import click_dashboard_projection, click_incremental  # noqa: E402
 
 GATE = ROOT / "hooks" / "click_gate.py"
-SCENARIOS = ("first-run", "unchanged", "docs", "code", "environment", "first-failure")
+SCENARIOS = (
+    "first-run",
+    "unchanged",
+    "docs",
+    "partial-reuse",
+    "code",
+    "environment",
+    "first-failure",
+)
 COMPARISONS = ("same-shards", "parent-suite")
 DEFAULT_ITERATIONS = 3
 DEFAULT_WORKLOAD_ROUNDS = 40_000
@@ -77,7 +85,14 @@ def _fixture_runner_argv(command: str) -> list[str]:
 class Fixture:
     """One independent checkout and lifecycle; no shared receipt across roots."""
 
-    def __init__(self, directory: Path, rounds: int, mode: str = "evidence"):
+    def __init__(
+        self,
+        directory: Path,
+        rounds: int,
+        mode: str = "evidence",
+        *,
+        partial_policy: bool = False,
+    ):
         self.root = directory / "repository"
         self.data = directory / "runtime"
         self.root.mkdir(parents=True)
@@ -97,6 +112,7 @@ class Fixture:
                          for name in ("alpha", "beta")]
         self._write(".gitignore", "__pycache__/\n*.pyc\n")
         self._write("README.md", "Benchmark fixture\n")
+        self._write("docs-beta.md", "Beta-owned documentation\n")
         self._write("implementation.py", f"ROUNDS = {rounds}\nVALUE = 1\n")
         self._write("tests/__init__.py", "")
         for name in ("alpha", "beta"):
@@ -110,8 +126,20 @@ class Fixture:
             "checks": [self.parent], "inventory": ["tests/test*.py"],
             "shards": [{"id": name, "checks": [argv], "covers": [f"tests/test_{name}.py"]}
                        for name, argv in zip(("alpha", "beta"), self.children)]}]}
-        policy = {"version": 1, "entries": [
-            {"checks": [argv], "reuse_if_only_changed": ["README.md"]} for argv in self.children]}
+        policy = {
+            "version": 1,
+            "entries": [
+                {
+                    "checks": [argv],
+                    "reuse_if_only_changed": [
+                        "README.md"
+                        if not partial_policy or name == "alpha"
+                        else "docs-beta.md"
+                    ],
+                }
+                for name, argv in zip(("alpha", "beta"), self.children)
+            ],
+        }
         self._write(".click/evidence-shards.json", json.dumps(shards))
         self._write(".click/evidence-reuse.json", json.dumps(policy))
         for args in (["git", "init", "-q"], ["git", "add", "."],
@@ -182,13 +210,24 @@ class Fixture:
         if scenario == "environment":
             self.environment["CLICK_BENCHMARK_VARIANT"] = "changed"
             return
+        if scenario == "partial-reuse" and self.state().get("runtime_mode") == "evidence":
+            # Exercise the real completed-Evidence -> next-Evidence lifecycle.
+            # No receipt, source status, or plan decision is manufactured here.
+            self.event["turn_id"] = f"measurement-successor-{self.sequence + 1}"
+            self._hook(
+                "prompt-submit",
+                {
+                    "hook_event_name": "UserPromptSubmit",
+                    "prompt": "Measure a follow-up Evidence task after the baseline.",
+                },
+            )
         self.sequence += 1
         event = {"tool_name": "apply_patch", "tool_use_id": f"change-{self.sequence}",
                  "tool_input": {"patch": "*** benchmark fixture mutation ***"}}
         admission = self._hook("pre-tool", {**event, "hook_event_name": "PreToolUse"})
         if admission.get("hookSpecificOutput", {}).get("permissionDecision") == "deny":
             raise RuntimeError("fixture-mutation-rejected")
-        if scenario == "docs":
+        if scenario in {"docs", "partial-reuse"}:
             self._write("README.md", "Documentation changed by the fixture.\n")
         elif scenario == "code":
             with (self.root / "implementation.py").open("a", encoding="utf-8") as handle:
@@ -267,7 +306,12 @@ def run_benchmark(*, iterations: int = DEFAULT_ITERATIONS, warmups: int = 1,
         for comparison in COMPARISONS:
             for index in range(warmups + iterations):
                 with tempfile.TemporaryDirectory(prefix="click-efficiency-") as directory:
-                    arms = {name: Fixture(Path(directory) / name, workload_rounds, mode)
+                    arms = {name: Fixture(
+                                Path(directory) / name,
+                                workload_rounds,
+                                mode,
+                                partial_policy=scenario == "partial-reuse",
+                            )
                             for name in ("baseline", "incremental")}
                     for arm in arms.values():
                         if scenario != "first-run":

--- a/dist/antigravity/hooks/click_contract_state.py
+++ b/dist/antigravity/hooks/click_contract_state.py
@@ -26,9 +26,33 @@ else:  # Imported from a directly executed bundled hook.
 EMPTY_CONTRACT_STATE = {"status": "none", "contract_digest": ""}
 
 
-def _history_path(event: dict[str, Any]):
-    path = click_state.contract_path(event)
+def history_path_for_contract(path):
     return path.with_name("efficiency-history-" + path.name.removeprefix("session-contract-"))
+
+
+def _history_path(event: dict[str, Any]):
+    return history_path_for_contract(click_state.contract_path(event))
+
+
+def read_projection_state_path(path) -> dict[str, Any]:
+    """Read current state or an authority-free history-only dashboard state."""
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError, TypeError):
+        value = None
+    if isinstance(value, dict):
+        return value
+    empty = dict(EMPTY_CONTRACT_STATE)
+    try:
+        archived = json.loads(
+            history_path_for_contract(path).read_text(encoding="utf-8")
+        )
+        verification: dict[str, Any] = {}
+        click_incremental.merge_history(archived, verification)
+        empty["verification"] = verification
+    except (OSError, ValueError, TypeError, json.JSONDecodeError):
+        pass
+    return empty
 
 
 def read_contract_state(event: dict[str, Any]) -> dict[str, Any]:
@@ -59,7 +83,7 @@ def save_contract_state(event: dict[str, Any], state: dict[str, Any]) -> None:
     click_state.write_json(click_state.contract_path(event), state)
 
 
-def clear_contract_state(event: dict[str, Any]) -> None:
+def _clear_contract_state_locked(event: dict[str, Any]) -> None:
     try:
         previous = read_contract_state(event).get("verification")
         if isinstance(previous, dict):
@@ -74,3 +98,19 @@ def clear_contract_state(event: dict[str, Any]) -> None:
         click_state.contract_path(event).unlink()
     except OSError:
         pass
+
+
+def clear_contract_state(
+    event: dict[str, Any], *, lock_already_held: bool = False
+) -> None:
+    """Archive measurements and revoke authority without a lost-update window.
+
+    Hook dispatch already owns the global state lock.  Direct callers, including
+    tests and future maintenance commands, acquire it here instead.  Keeping the
+    two cases explicit avoids attempting to recursively acquire the file lock.
+    """
+    if lock_already_held:
+        _clear_contract_state_locked(event)
+        return
+    with click_state.state_lock():
+        _clear_contract_state_locked(event)

--- a/dist/antigravity/hooks/click_dashboard_projection.py
+++ b/dist/antigravity/hooks/click_dashboard_projection.py
@@ -99,6 +99,7 @@ _SOURCE_FIELDS = frozenset(
         "shadow_limitations",
         "shadow_outcome",
         "execution_status", "execution_reason_code", "duration_ms", "duration_baseline",
+        "reuse_origin",
     }
 )
 _MAP_FIELDS = frozenset(
@@ -359,6 +360,7 @@ def dashboard_projection(
                 "execution_reason_code": result.get("execution_reason_code", "outcome-unconfirmed"),
                 "duration_ms": result.get("duration_ms"),
                 "duration_baseline": duration_baseline,
+                "reuse_origin": result.get("reuse_origin"),
                 "observer_status": observer_status,
                 "input_count": len(input_keys),
                 "visible_input_count": source_visible,
@@ -561,6 +563,12 @@ def projection_is_valid(value: Any) -> bool:
             or source.get("execution_reason_code") not in click_incremental.EXECUTION_REASONS
             or (source.get("duration_ms") is not None and not click_incremental.is_duration(source["duration_ms"]))
             or (source.get("duration_baseline") is not None and not click_incremental.baseline_is_valid(source["duration_baseline"]))
+            or (
+                source.get("reuse_origin") is not None
+                and not click_incremental.reuse_origin_is_valid(
+                    source["reuse_origin"]
+                )
+            )
             or source.get("observer_status")
             not in click_dependency_cache.SHADOW_OBSERVER_STATUSES
             or any(

--- a/dist/antigravity/hooks/click_evidence.py
+++ b/dist/antigravity/hooks/click_evidence.py
@@ -13,6 +13,7 @@ import hashlib
 import json
 import re
 import secrets
+import time
 from typing import Any
 
 if __package__:
@@ -32,6 +33,16 @@ else:  # Executed directly from the bundled hooks directory.
 EVIDENCE_KINDS = ("argv", "browser", "hosted", "manual", "existing")
 EVIDENCE_STATUSES = {"ready", "running", "observed", "passed", "failed", "stale"}
 EVIDENCE_STATE_VERSION = 1
+SUCCESSOR_EVIDENCE_FIELD = "successor_evidence"
+SUCCESSOR_EVIDENCE_VERSION = 1
+MAX_SUCCESSOR_EVIDENCE_BYTES = 2 * 1024 * 1024
+MAX_SUCCESSOR_SOURCES = 256
+_SUCCESSOR_FIELDS = frozenset({
+    "version", "scope_digest", "origin_evidence_session_id",
+    "origin_intent_digest", "origin_revision", "origin_registry_digest",
+    "captured_at", "evidence_state", "origins", "digest",
+})
+_SUCCESSOR_ORIGIN_FIELDS = frozenset({"batch_id", "execution_status"})
 
 
 def evidence_key(evidence_id: str) -> str:
@@ -95,6 +106,13 @@ def _fresh_source(kind: str, dependency_patterns: tuple[str, ...] = ()) -> dict[
         "last_safe_change_paths": [],
         "last_safe_change_path_count": 0,
         "last_safe_change_decision_digest": "",
+        "successor_reuse_count": 0,
+        "last_successor_reused_at": 0,
+        "last_successor_origin_batch_id": "",
+        "last_successor_origin_evidence_session_id": "",
+        "last_successor_candidate_digest": "",
+        "last_successor_origin_revision": -1,
+        "last_successor_mode": "",
     }
 
 
@@ -129,6 +147,188 @@ def fresh_state(contract: dict[str, Any]) -> dict[str, Any]:
         "sources": sources,
         "shard_sets": {},
     }
+
+
+def fresh_successor_evidence() -> dict[str, Any]:
+    return {}
+
+
+def successor_scope_digest(identity: str) -> str:
+    return hashlib.sha256(identity.encode()).hexdigest()
+
+
+def _successor_digest(value: dict[str, Any]) -> str:
+    payload = {key: item for key, item in value.items() if key != "digest"}
+    encoded = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def successor_evidence_is_valid(
+    value: Any,
+    *,
+    expected_contract_schema_version: int,
+    scope_digest: str,
+) -> bool:
+    if (
+        not isinstance(value, dict)
+        or set(value) != _SUCCESSOR_FIELDS
+        or value.get("version") != SUCCESSOR_EVIDENCE_VERSION
+        or value.get("scope_digest") != scope_digest
+        or not isinstance(scope_digest, str)
+        or re.fullmatch(r"[0-9a-f]{64}", scope_digest) is None
+        or not isinstance(value.get("origin_evidence_session_id"), str)
+        or re.fullmatch(r"evs_[0-9a-f]{32}", value["origin_evidence_session_id"])
+        is None
+        or not isinstance(value.get("origin_intent_digest"), str)
+        or re.fullmatch(r"[0-9a-f]{64}", value["origin_intent_digest"]) is None
+        or not isinstance(value.get("origin_revision"), int)
+        or isinstance(value.get("origin_revision"), bool)
+        or value["origin_revision"] < 0
+        or not isinstance(value.get("origin_registry_digest"), str)
+        or re.fullmatch(r"[0-9a-f]{64}", value["origin_registry_digest"]) is None
+        or not isinstance(value.get("captured_at"), int)
+        or isinstance(value.get("captured_at"), bool)
+        or value["captured_at"] <= 0
+        or not isinstance(value.get("origins"), dict)
+        or not isinstance(value.get("evidence_state"), dict)
+        or not isinstance(value.get("digest"), str)
+        or re.fullmatch(r"[0-9a-f]{64}", value["digest"]) is None
+        or not secrets.compare_digest(value["digest"], _successor_digest(value))
+        or len(json.dumps(value, sort_keys=True, separators=(",", ":")).encode())
+        > MAX_SUCCESSOR_EVIDENCE_BYTES
+    ):
+        return False
+    synthetic = {
+        "state_schema_version": expected_contract_schema_version,
+        "evidence_state": value["evidence_state"],
+    }
+    sources = sources_from_state(
+        synthetic,
+        expected_contract_schema_version=expected_contract_schema_version,
+    )
+    if (
+        sources is None
+        or not sources
+        or len(sources) > MAX_SUCCESSOR_SOURCES
+        or registry_digest(sources) != value["origin_registry_digest"]
+        or len(value["origins"]) > len(sources)
+    ):
+        return False
+    for key, origin in value["origins"].items():
+        source = sources.get(key) if isinstance(key, str) else None
+        if (
+            not isinstance(origin, dict)
+            or set(origin) != _SUCCESSOR_ORIGIN_FIELDS
+            or not isinstance(origin.get("batch_id"), str)
+            or re.fullmatch(r"[0-9a-f]{32}", origin["batch_id"]) is None
+            or origin.get("execution_status") not in {"passed", "reused"}
+            or not is_current(source, value["origin_revision"])
+            or source.get("kind") != "argv"
+            or source.get("verified_contract_digest")
+            != value["origin_intent_digest"]
+        ):
+            return False
+    return bool(value["origins"])
+
+
+def carry_successor_evidence(
+    previous: dict[str, Any],
+    current: dict[str, Any],
+    *,
+    origins: dict[str, dict[str, str]],
+    scope_digest: str,
+    expected_contract_schema_version: int,
+    now: int | None = None,
+) -> bool:
+    """Carry one completed Evidence ledger as re-evaluation candidates only."""
+    sources = sources_from_state(
+        previous,
+        expected_contract_schema_version=expected_contract_schema_version,
+    )
+    evidence_state = previous.get("evidence_state")
+    verification = previous.get("verification")
+    revision = (
+        verification.get("mutation_revision")
+        if isinstance(verification, dict)
+        else None
+    )
+    session_id = previous.get("evidence_session_id")
+    intent_digest = previous.get("intent_digest")
+    if (
+        not sources
+        or len(sources) > MAX_SUCCESSOR_SOURCES
+        or not isinstance(evidence_state, dict)
+        or not isinstance(revision, int)
+        or isinstance(revision, bool)
+        or revision < 0
+        or not isinstance(session_id, str)
+        or re.fullmatch(r"evs_[0-9a-f]{32}", session_id) is None
+        or not isinstance(intent_digest, str)
+        or re.fullmatch(r"[0-9a-f]{64}", intent_digest) is None
+    ):
+        return False
+    eligible = {
+        key: dict(origin)
+        for key, origin in origins.items()
+        if key in sources
+        and isinstance(origin, dict)
+        and set(origin) == _SUCCESSOR_ORIGIN_FIELDS
+        and is_current(sources[key], revision)
+    }
+    if not eligible:
+        return False
+    value = {
+        "version": SUCCESSOR_EVIDENCE_VERSION,
+        "scope_digest": scope_digest,
+        "origin_evidence_session_id": session_id,
+        "origin_intent_digest": intent_digest,
+        "origin_revision": revision,
+        "origin_registry_digest": registry_digest(sources),
+        "captured_at": int(time.time()) if now is None else now,
+        "evidence_state": json.loads(json.dumps(evidence_state)),
+        "origins": eligible,
+        "digest": "",
+    }
+    value["digest"] = _successor_digest(value)
+    if not successor_evidence_is_valid(
+        value,
+        expected_contract_schema_version=expected_contract_schema_version,
+        scope_digest=scope_digest,
+    ):
+        return False
+    current[SUCCESSOR_EVIDENCE_FIELD] = value
+    return True
+
+
+def successor_candidate(
+    state: dict[str, Any],
+    source_key: str,
+    *,
+    expected_contract_schema_version: int,
+    scope_digest: str,
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    value = state.get(SUCCESSOR_EVIDENCE_FIELD)
+    if not successor_evidence_is_valid(
+        value,
+        expected_contract_schema_version=expected_contract_schema_version,
+        scope_digest=scope_digest,
+    ):
+        return None
+    assert isinstance(value, dict)
+    origin = value["origins"].get(source_key)
+    source = value["evidence_state"]["sources"].get(source_key)
+    if not isinstance(origin, dict) or not isinstance(source, dict):
+        return None
+    metadata = {
+        "kind": "successor-evidence",
+        "batch_id": origin["batch_id"],
+        "evidence_session_id": value["origin_evidence_session_id"],
+        "candidate_digest": value["digest"],
+        "origin_revision": value["origin_revision"],
+    }
+    return json.loads(json.dumps(source)), metadata
 
 
 def _refresh_registry(evidence_state: dict[str, Any], sources: dict[str, Any]) -> None:
@@ -410,6 +610,40 @@ def _safe_change_fields_are_valid(source: dict[str, Any]) -> bool:
     )
 
 
+def _successor_fields_are_valid(source: dict[str, Any]) -> bool:
+    count = source.get("successor_reuse_count", 0)
+    reused_at = source.get("last_successor_reused_at", 0)
+    origin_revision = source.get("last_successor_origin_revision", -1)
+    batch_id = source.get("last_successor_origin_batch_id", "")
+    session_id = source.get("last_successor_origin_evidence_session_id", "")
+    candidate_digest = source.get("last_successor_candidate_digest", "")
+    mode = source.get("last_successor_mode", "")
+    if any(
+        not isinstance(value, int) or isinstance(value, bool)
+        for value in (count, reused_at, origin_revision)
+    ):
+        return False
+    if count < 0 or reused_at < 0 or origin_revision < -1:
+        return False
+    if not all(isinstance(value, str) for value in (
+        batch_id, session_id, candidate_digest, mode
+    )):
+        return False
+    if count == 0:
+        return bool(
+            reused_at == 0 and origin_revision == -1 and not batch_id
+            and not session_id and not candidate_digest and not mode
+        )
+    return bool(
+        reused_at > 0
+        and origin_revision >= 0
+        and re.fullmatch(r"[0-9a-f]{32}", batch_id)
+        and re.fullmatch(r"evs_[0-9a-f]{32}", session_id)
+        and re.fullmatch(r"[0-9a-f]{64}", candidate_digest)
+        and mode in {"exact", "dependency", "safe-change"}
+    )
+
+
 def sources_from_state(
     state: dict[str, Any],
     *,
@@ -474,6 +708,7 @@ def sources_from_state(
             is None
             or not _dependency_fields_are_valid(source)
             or not _safe_change_fields_are_valid(source)
+            or not _successor_fields_are_valid(source)
             or not _host_coverage_field_is_valid(source)
             or (
                 "reserved_units" in source

--- a/dist/antigravity/hooks/click_gate.py
+++ b/dist/antigravity/hooks/click_gate.py
@@ -512,8 +512,7 @@ def _handle_pre_tool(event: dict[str, Any]) -> None:
                     _deny(authorization_error)
                     return
                 click_service.request_stop(event)
-                click_shadow_dashboard.request_stop(event)
-                click_contract_state.clear_contract_state(event)
+                click_contract_state.clear_contract_state(event, lock_already_held=True)
                 click_observation.clear_review_state(event)
                 click_lifecycle.write_state(event, "idle")
                 _allow_rewritten("echo Click active contract cancelled")
@@ -546,7 +545,9 @@ def _handle_pre_tool(event: dict[str, Any]) -> None:
                     normalized != "evidence"
                     and runtime_state.get("status") == "evidence"
                 ):
-                    click_contract_state.clear_contract_state(event)
+                    click_contract_state.clear_contract_state(
+                        event, lock_already_held=True
+                    )
                     click_lifecycle.write_state(event, "idle")
                 label = {
                     "evidence": "Evidence",

--- a/dist/antigravity/hooks/click_incremental.py
+++ b/dist/antigravity/hooks/click_incremental.py
@@ -45,6 +45,11 @@ AUTHORITY_SOURCES = frozenset(
 REASON_CODES = frozenset(
     {
         "same-revision-receipt-current",
+        "successor-evidence-current",
+        "successor-evidence-dependencies-unchanged",
+        "successor-evidence-safe-change-covered",
+        "successor-evidence-scope-mismatch",
+        "successor-evidence-integrity-invalid",
         "observed-dependencies-unchanged",
         "safe-change-policy-covered",
         "no-passing-evidence",
@@ -176,6 +181,7 @@ def decision(
 # share the existing age/count/byte budget with legacy planning events.
 BATCH_STATUSES = frozenset({"planned", "running", "passed", "failed", "interrupted", "rejected", "incomplete"})
 SOURCE_STATUSES = frozenset({"planned", "reuse-pending", "running", "passed", "failed", "interrupted", "not-run", "reused", "unknown"})
+REUSE_ORIGIN_KINDS = frozenset({"successor-evidence"})
 EXECUTION_REASONS = frozenset({
     "", "batch-finished", "request-rejected", "runner-admission-rejected",
     "plan-not-created", "reuse-applied", "command-started", "command-passed",
@@ -189,10 +195,15 @@ _BATCH_FIELDS = frozenset({
     "status", "reason_code", "requested_source_count", "sources",
     "prepare_duration_ms", "runner_duration_ms", "request_wall_ms", "measurement_scope",
 })
-_SOURCE_FIELDS = _DECISION_FIELDS | {
+_SOURCE_FIELDS_V1 = _DECISION_FIELDS | {
     "duration_baseline", "label", "status", "started", "completed",
     "duration_ms", "execution_reason_code",
 }
+_SOURCE_FIELDS = _SOURCE_FIELDS_V1 | {"reuse_origin"}
+_REUSE_ORIGIN_FIELDS = frozenset({
+    "kind", "batch_id", "evidence_session_id", "candidate_digest",
+    "origin_revision",
+})
 SUMMARY_FIELDS = (
     "total_source_count", "planned_execution_source_count", "planned_reuse_source_count",
     "executed_source_count", "completed_source_count", "passed_source_count",
@@ -214,14 +225,32 @@ def safe_label(value: Any, fallback: str) -> str:
     ) else fallback
 
 
+def reuse_origin_is_valid(value: Any) -> bool:
+    return bool(
+        isinstance(value, dict)
+        and set(value) == _REUSE_ORIGIN_FIELDS
+        and value.get("kind") in REUSE_ORIGIN_KINDS
+        and isinstance(value.get("batch_id"), str)
+        and re.fullmatch(r"[0-9a-f]{32}", value["batch_id"])
+        and isinstance(value.get("evidence_session_id"), str)
+        and re.fullmatch(r"evs_[0-9a-f]{32}", value["evidence_session_id"])
+        and isinstance(value.get("candidate_digest"), str)
+        and _DIGEST.fullmatch(value["candidate_digest"])
+        and _is_integer(value.get("origin_revision"))
+    )
+
+
 def source_result_is_valid(value: Any) -> bool:
-    if not isinstance(value, dict) or set(value) != _SOURCE_FIELDS:
+    if not isinstance(value, dict) or set(value) not in {
+        _SOURCE_FIELDS_V1, _SOURCE_FIELDS
+    }:
         return False
     planned = {key: value[key] for key in _DECISION_FIELDS | {"duration_baseline"}}
     if planned["decision"] is None:
         planned.update(decision="not-evaluable", reason_code="receipt-invalid")
     if not decision_is_valid(planned):
         return False
+    reuse_origin = value.get("reuse_origin")
     return bool(
         value["label"] == safe_label(value["label"], "")
         and value["label"]
@@ -235,6 +264,8 @@ def source_result_is_valid(value: Any) -> bool:
         and (value["status"] not in {"passed", "failed"} or (value["started"] and value["completed"]))
         and (value["status"] != "running" or (value["started"] and not value["completed"]))
         and (value["started"] or value["duration_ms"] is None)
+        and (reuse_origin is None or reuse_origin_is_valid(reuse_origin))
+        and (reuse_origin is None or value["decision"] in REUSE_DECISIONS)
     )
 
 
@@ -243,7 +274,7 @@ def batch_is_valid(value: Any) -> bool:
         return False
     items = value.get("sources")
     return bool(
-        value.get("event") == BATCH_EVENT and value.get("version") == 1
+        value.get("event") == BATCH_EVENT and value.get("version") in {1, 2}
         and isinstance(value.get("batch_id"), str)
         and re.fullmatch(r"[0-9a-f]{32}", value["batch_id"])
         and _is_integer(value.get("timestamp"), minimum=1)
@@ -254,6 +285,11 @@ def batch_is_valid(value: Any) -> bool:
         and (value.get("requested_source_count") is None or _is_integer(value["requested_source_count"]))
         and isinstance(items, list)
         and all(source_result_is_valid(item) for item in items)
+        and all(
+            (value["version"] == 1 and "reuse_origin" not in item)
+            or (value["version"] == 2 and "reuse_origin" in item)
+            for item in items
+        )
         and len({item["source_key"] for item in items}) == len(items)
         and (value["requested_source_count"] is None or len(items) <= value["requested_source_count"])
         and all(value.get(key) is None or is_duration(value[key]) for key in (
@@ -269,7 +305,9 @@ def batch_is_valid(value: Any) -> bool:
 def new_batch(
     plan: dict[str, Any] | None, *, batch_id: str, revision: int,
     prepared_ms: float | None, requested: list[dict[str, str]] | None = None,
-    labels: dict[str, str] | None = None, now: int | None = None,
+    labels: dict[str, str] | None = None,
+    reuse_origins: dict[str, dict[str, Any]] | None = None,
+    now: int | None = None,
 ) -> dict[str, Any]:
     timestamp = int(time.time()) if now is None else now
     items = plan["decisions"] if plan_is_valid(plan) else [
@@ -282,7 +320,7 @@ def new_batch(
         for item in requested or []
     ]
     batch = {
-        "event": BATCH_EVENT, "version": 1, "batch_id": batch_id,
+        "event": BATCH_EVENT, "version": 2, "batch_id": batch_id,
         "timestamp": timestamp, "finished_at": None, "current_revision": revision,
         "status": "planned", "reason_code": "", "requested_source_count": len(items) if plan or requested is not None else None,
         "sources": [],
@@ -297,6 +335,9 @@ def new_batch(
             label=safe_label((labels or {}).get(item["source_key"]), f"검증 묶음 {index}"),
             status="reuse-pending" if item["decision"] in REUSE_DECISIONS else "planned",
             started=False, completed=False, duration_ms=None, execution_reason_code="",
+            reuse_origin=json.loads(json.dumps((reuse_origins or {}).get(item["source_key"])))
+            if reuse_origin_is_valid((reuse_origins or {}).get(item["source_key"]))
+            else None,
         )
         batch["sources"].append(source)
     if not batch_is_valid(batch):
@@ -392,6 +433,41 @@ def mark_started(verification: dict[str, Any], source_key: str) -> bool:
     return False
 
 
+def mark_completed(
+    verification: dict[str, Any], source_key: str, *, status: str,
+    reason: str, duration_ms: int | float | None, completed: bool = True,
+) -> bool:
+    """Persist one witnessed source outcome before the next source starts."""
+    if status not in {"passed", "failed", "interrupted", "unknown"}:
+        return False
+    if reason not in EXECUTION_REASONS or reason == "":
+        return False
+    if duration_ms is not None and not is_duration(duration_ms):
+        return False
+    batch = current_batch(verification)
+    if batch is None or batch["status"] not in {"planned", "running"}:
+        return False
+    for item in batch["sources"]:
+        if item["source_key"] != source_key or not item["started"]:
+            continue
+        if item["completed"]:
+            return bool(
+                item["status"] == status
+                and item["execution_reason_code"] == reason
+                and item["duration_ms"] == duration_ms
+                and completed
+            )
+        item.update(
+            status=status,
+            completed=completed,
+            duration_ms=duration_ms,
+            execution_reason_code=reason,
+        )
+        batch["status"] = "running"
+        return store_batch(verification, batch)
+    return False
+
+
 def interrupt_batch(verification: dict[str, Any]) -> bool:
     """Cancellation is witnessed; an active child's termination is not assumed."""
     batch = current_batch(verification)
@@ -399,6 +475,10 @@ def interrupt_batch(verification: dict[str, Any]) -> bool:
         return False
     batch.update(status="interrupted", reason_code="user-cancelled", finished_at=int(time.time()))
     for item in batch["sources"]:
+        if item["completed"]:
+            # Cancellation revokes current authority, not the already witnessed
+            # fact that this source finished before the cancellation boundary.
+            continue
         item.update(
             status="interrupted" if item["started"] else "not-run",
             execution_reason_code="user-cancelled", completed=False,
@@ -660,6 +740,10 @@ def record_execution(
     for source in batch["sources"]:
         key = source["source_key"]
         result = source_results.get(key)
+        if source["completed"]:
+            # A source-level completion was already persisted under the claimed
+            # runner. The final batch fold must not roll that fact backward.
+            continue
         if result is not None:
             source.update({
                 "status": result["status"], "started": result["started"],

--- a/dist/antigravity/hooks/click_lifecycle.py
+++ b/dist/antigravity/hooks/click_lifecycle.py
@@ -24,6 +24,7 @@ if __package__:
         click_contract,
         click_contract_state,
         click_evidence,
+        click_incremental,
         click_mode,
         click_mutation,
         click_observation,
@@ -41,6 +42,7 @@ else:  # Executed directly from the bundled hooks directory.
     import click_contract
     import click_contract_state
     import click_evidence
+    import click_incremental
     import click_mode
     import click_mutation
     import click_observation
@@ -168,6 +170,9 @@ def _fresh_evidence_state(
         "capability_ledger": click_claims.fresh_state(),
         "verification": click_verification.fresh_state(virtual_contract),
         "evidence_state": click_evidence.fresh_state(virtual_contract),
+        click_evidence.SUCCESSOR_EVIDENCE_FIELD: (
+            click_evidence.fresh_successor_evidence()
+        ),
         "external_evidence": click_evidence.fresh_external_state(),
         "observations": click_observation.fresh_state(),
         "mutation": click_mutation.fresh_state(),
@@ -199,8 +204,34 @@ def _ensure_evidence_state(event: dict[str, Any]) -> tuple[dict[str, Any], bool]
     ):
         return state, False
     recovered = runtime.evidence and not _evidence_state_is_usable(state)
-    if not _evidence_state_is_usable(state) or _contract_is_completed(state):
+    completed_evidence = bool(
+        runtime.evidence
+        and _evidence_state_is_usable(state)
+        and _contract_is_completed(state)
+    )
+    if not _evidence_state_is_usable(state) or completed_evidence:
+        previous = state
         state = _fresh_evidence_state(event, history_complete=not recovered)
+        if completed_evidence:
+            origins: dict[str, dict[str, str]] = {}
+            for batch in click_incremental.batch_history(
+                previous.get("verification")
+            ):
+                for source in batch["sources"]:
+                    if source["status"] in {"passed", "reused"}:
+                        origins[source["source_key"]] = {
+                            "batch_id": batch["batch_id"],
+                            "execution_status": source["status"],
+                        }
+            click_evidence.carry_successor_evidence(
+                previous,
+                state,
+                origins=origins,
+                scope_digest=click_evidence.successor_scope_digest(
+                    str(click_state.contract_path(event).resolve())
+                ),
+                expected_contract_schema_version=CONTRACT_STATE_SCHEMA_VERSION,
+            )
         _save_contract_state(event, state)
         return state, recovered
     if _append_follow_up(event, state):

--- a/dist/antigravity/hooks/click_receipt.py
+++ b/dist/antigravity/hooks/click_receipt.py
@@ -18,10 +18,12 @@ from typing import Any
 LEGACY_RECEIPT_VERSION = 1
 RECEIPT_VERSION = 2
 SHARD_RECEIPT_VERSION = 3
+SUCCESSOR_RECEIPT_VERSION = 4
 SUPPORTED_RECEIPT_VERSIONS = {
     LEGACY_RECEIPT_VERSION,
     RECEIPT_VERSION,
     SHARD_RECEIPT_VERSION,
+    SUCCESSOR_RECEIPT_VERSION,
 }
 ENVELOPE_VERSION = 1
 UNSIGNED_ASSURANCE = "unsigned-integrity-only"
@@ -110,6 +112,11 @@ SHARD_PROVIDER = "repository-evidence-shards-v1"
 SHARD_ID_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
 EVIDENCE_RESULT_FIELDS = {"status", "exit_code", "completed_at"}
 LINEAGE_FIELDS = {"mode", "from_revision", "dependency_digest"}
+SUCCESSOR_LINEAGE_FIELDS = LINEAGE_FIELDS | {
+    "origin_batch_id",
+    "origin_evidence_session_id",
+    "requalification_mode",
+}
 COVERAGE_FIELDS = {
     "host_assurance",
     "host_coverage_digest",
@@ -338,9 +345,11 @@ def _normalize_capability(
 
 
 def _normalize_lineage(
-    value: Any, *, kind: str, revision: int
+    value: Any, *, kind: str, revision: int, receipt_version: int
 ) -> tuple[dict[str, Any] | None, str]:
-    error = _exact_fields(value, LINEAGE_FIELDS, "evidence.lineage")
+    successor = isinstance(value, dict) and value.get("mode") == "successor-reused"
+    fields = SUCCESSOR_LINEAGE_FIELDS if successor else LINEAGE_FIELDS
+    error = _exact_fields(value, fields, "evidence.lineage")
     if error:
         return None, error
     assert isinstance(value, dict)
@@ -351,7 +360,7 @@ def _normalize_lineage(
         return None, "Completion receipt evidence lineage revision is invalid."
 
     expected_modes = {
-        "argv": {"executed", "dependency-reused"},
+        "argv": {"executed", "dependency-reused", "successor-reused"},
         "browser": {"browser-observed"},
         "hosted": {"attested"},
         "manual": {"attested"},
@@ -359,6 +368,29 @@ def _normalize_lineage(
     }
     if mode not in expected_modes[kind]:
         return None, f"Completion receipt lineage mode is invalid for `{kind}` evidence."
+    if mode == "successor-reused":
+        origin_batch_id = value.get("origin_batch_id")
+        origin_session_id = value.get("origin_evidence_session_id")
+        requalification_mode = value.get("requalification_mode")
+        if (
+            receipt_version != SUCCESSOR_RECEIPT_VERSION
+            or kind != "argv"
+            or not _is_digest(dependency_digest)
+            or not isinstance(origin_batch_id, str)
+            or re.fullmatch(r"[0-9a-f]{32}", origin_batch_id) is None
+            or not isinstance(origin_session_id, str)
+            or re.fullmatch(r"evs_[0-9a-f]{32}", origin_session_id) is None
+            or requalification_mode not in {"exact", "dependency", "safe-change"}
+        ):
+            return None, "Successor-reused evidence lineage is invalid."
+        return {
+            "mode": mode,
+            "from_revision": from_revision,
+            "dependency_digest": dependency_digest,
+            "origin_batch_id": origin_batch_id,
+            "origin_evidence_session_id": origin_session_id,
+            "requalification_mode": requalification_mode,
+        }, ""
     if mode == "dependency-reused":
         if from_revision >= revision or not _is_digest(dependency_digest):
             return (
@@ -425,7 +457,7 @@ def _normalize_evidence(
 ) -> tuple[dict[str, Any] | None, str]:
     fields = (
         SHARDED_EVIDENCE_FIELDS
-        if receipt_version == SHARD_RECEIPT_VERSION
+        if receipt_version in {SHARD_RECEIPT_VERSION, SUCCESSOR_RECEIPT_VERSION}
         else EVIDENCE_FIELDS
     )
     error = _exact_fields(value, fields, "evidence source")
@@ -473,7 +505,8 @@ def _normalize_evidence(
         return None, "Completion receipt evidence result must be a timestamped pass."
 
     lineage, error = _normalize_lineage(
-        value.get("lineage"), kind=str(kind), revision=revision
+        value.get("lineage"), kind=str(kind), revision=revision,
+        receipt_version=receipt_version,
     )
     if error:
         return None, error
@@ -492,7 +525,7 @@ def _normalize_evidence(
         },
         "lineage": lineage,
     }
-    if receipt_version == SHARD_RECEIPT_VERSION:
+    if receipt_version in {SHARD_RECEIPT_VERSION, SUCCESSOR_RECEIPT_VERSION}:
         if kind != "argv" and value.get("shard") is not None:
             return None, "Only argv evidence may carry shard provenance."
         shard, error = _normalize_shard(value.get("shard"), source_key=source_key)
@@ -547,7 +580,11 @@ def validate_receipt(value: Any) -> tuple[dict[str, Any] | None, str]:
     if version not in SUPPORTED_RECEIPT_VERSIONS or isinstance(version, bool):
         return None, "Completion receipt `version` is unsupported."
     authority: dict[str, Any] | None = None
-    if version in {RECEIPT_VERSION, SHARD_RECEIPT_VERSION}:
+    if version in {
+        RECEIPT_VERSION,
+        SHARD_RECEIPT_VERSION,
+        SUCCESSOR_RECEIPT_VERSION,
+    }:
         authority, error = _normalize_authority(value.get("authority"))
         if error:
             return None, error
@@ -614,11 +651,11 @@ def validate_receipt(value: Any) -> tuple[dict[str, Any] | None, str]:
         seen.add(source_key)
         normalized_evidence.append(normalized)
     normalized_evidence.sort(key=lambda source: str(source["source_key"]))
-    if version == SHARD_RECEIPT_VERSION:
+    if version in {SHARD_RECEIPT_VERSION, SUCCESSOR_RECEIPT_VERSION}:
         sharded = [
             source for source in normalized_evidence if source.get("shard") is not None
         ]
-        if not sharded:
+        if version == SHARD_RECEIPT_VERSION and not sharded:
             return None, "Receipt v3 requires at least one sharded evidence source."
         groups: dict[str, list[dict[str, Any]]] = {}
         for source in sharded:
@@ -644,6 +681,11 @@ def validate_receipt(value: Any) -> tuple[dict[str, Any] | None, str]:
                 )
             ):
                 return None, "Completion receipt evidence shard set is incomplete."
+    if version == SUCCESSOR_RECEIPT_VERSION and not any(
+        source["lineage"]["mode"] == "successor-reused"
+        for source in normalized_evidence
+    ):
+        return None, "Receipt v4 requires successor-reused evidence lineage."
 
     workspace = execution["workspace"]
     assert isinstance(workspace, dict)

--- a/dist/antigravity/hooks/click_receipt_runtime.py
+++ b/dist/antigravity/hooks/click_receipt_runtime.py
@@ -171,7 +171,28 @@ def _evidence_receipts(
             if source.get("verified_host_coverage") != host_coverage:
                 return None, "The host coverage identity changed after argv evidence completed."
 
-        if kind == "argv" and int(source.get("safe_change_reuse_count", 0)) > 0:
+        if kind == "argv" and int(source.get("successor_reuse_count", 0)) > 0:
+            lineage = {
+                "mode": "successor-reused",
+                "from_revision": int(
+                    source.get("last_successor_origin_revision", -1)
+                ),
+                # This digest binds the carried candidate, including its
+                # authoritative source facts and origin mapping.
+                "dependency_digest": str(
+                    source.get("last_successor_candidate_digest", "")
+                ),
+                "origin_batch_id": str(
+                    source.get("last_successor_origin_batch_id", "")
+                ),
+                "origin_evidence_session_id": str(
+                    source.get("last_successor_origin_evidence_session_id", "")
+                ),
+                "requalification_mode": str(
+                    source.get("last_successor_mode", "")
+                ),
+            }
+        elif kind == "argv" and int(source.get("safe_change_reuse_count", 0)) > 0:
             lineage = {
                 "mode": "dependency-reused",
                 "from_revision": int(
@@ -220,7 +241,10 @@ def _evidence_receipts(
                 },
                 "lineage": lineage,
             }
-        if receipt_version == click_receipt.SHARD_RECEIPT_VERSION:
+        if receipt_version in {
+            click_receipt.SHARD_RECEIPT_VERSION,
+            click_receipt.SUCCESSOR_RECEIPT_VERSION,
+        }:
             metadata = source.get("shard")
             receipt_source["shard"] = (
                 {
@@ -271,8 +295,15 @@ def build_envelope(
     workspace, normalized_root, error = _workspace_receipt(workspace_snapshot)
     if error:
         return None, error
+    has_successor = any(
+        isinstance(source, dict)
+        and int(source.get("successor_reuse_count", 0)) > 0
+        for source in sources.values()
+    )
     receipt_version = (
-        click_receipt.SHARD_RECEIPT_VERSION
+        click_receipt.SUCCESSOR_RECEIPT_VERSION
+        if has_successor
+        else click_receipt.SHARD_RECEIPT_VERSION
         if any(
             click_evidence_shards.source_metadata_is_valid(source.get("shard"))
             for source in sources.values()

--- a/dist/antigravity/hooks/click_shadow_dashboard.py
+++ b/dist/antigravity/hooks/click_shadow_dashboard.py
@@ -134,7 +134,7 @@ JS = r"""(() => {
     planned: '실행 예정', 'reuse-pending': '재사용 예정 · 미적용', running: '실행 중',
     passed: '통과', failed: '실패', interrupted: '중단 · 일부 결과 미확정',
     'not-run': '미실행', reused: '재사용 적용', unknown: '측정 정보 없음',
-    rejected: '실행 전 거부', incomplete: '미확정', evidence: 'Evidence', approved: 'Guarded'
+    rejected: '실행 전 거부', incomplete: '미확정', evidence: 'Evidence', approved: 'Guarded', none: '활성 작업 없음'
   };
   const outcomeText = {
     'request-rejected': '요청이 거부되어 시작하지 않았습니다.',
@@ -158,6 +158,11 @@ JS = r"""(() => {
   };
   const reasonText = {
     'same-revision-receipt-current': '같은 revision의 검사 결과가 현재 작업트리와 정확히 일치해 재사용했습니다.',
+    'successor-evidence-current': '이전 Evidence 작업의 실제 통과 결과를 현재 명령·작업트리·환경·실행 파일·호스트 범위에 다시 결합해 재사용했습니다.',
+    'successor-evidence-dependencies-unchanged': '이전 Evidence 작업의 실제 통과 결과를 가져와, 현재 변경 뒤에도 관찰된 입력이 바뀌지 않았음을 다시 확인해 재사용했습니다.',
+    'successor-evidence-safe-change-covered': '이전 Evidence 작업의 실제 통과 결과를 가져와, 현재 커밋된 안전 변경 정책이 이번 변경을 허용하는지 다시 확인해 재사용했습니다.',
+    'successor-evidence-scope-mismatch': '이전 결과가 현재 호스트 세션과 작업 공간의 후속 작업 범위에 속하지 않아 실제 검사를 실행했습니다.',
+    'successor-evidence-integrity-invalid': '이전 실행 사실의 무결성이나 출처를 확인할 수 없어 실제 검사를 실행했습니다.',
     'observed-dependencies-unchanged': '이 검사가 실제로 읽었던 입력이 바뀌지 않아 이전 통과 결과를 재사용했습니다.',
     'safe-change-policy-covered': '저장소 소유자가 미리 허용한 안전 변경 범위 안이라 이전 결과를 재사용했습니다.',
     'no-passing-evidence': '재사용할 수 있는 이전 통과 결과가 없어 실제 검사를 실행했습니다.',
@@ -204,6 +209,7 @@ JS = r"""(() => {
       `계획 ${executionLabels[source.execution_decision]?.[0] || '없음'} · 실제 ${label}`,
       `실행 구간 ${fmt(source.duration_ms)}`,
       source.duration_baseline ? `과거 표본 ${source.duration_baseline.sample_count}개 · revision ${source.duration_baseline.revision} · ${fmt(source.duration_baseline.duration_ms)}` : '과거 시간 표본 없음',
+      source.reuse_origin ? `이전 Evidence 배치 ${source.reuse_origin.batch_id.slice(0,12)} · 출처 revision ${source.reuse_origin.origin_revision}` : '현재 작업 안의 근거',
       `판정 식별자 ${source.reason_code || '없음'}`,
       ...source.shadow_limitations.map(item => `Shadow: ${item}`)
     ];
@@ -362,7 +368,7 @@ JS = r"""(() => {
         execution_decision:item.decision || 'not-planned', reason_code:item.reason_code,
         execution_reason_code:item.execution_reason_code, current_revision:item.current_revision,
         previous_revision:item.previous_revision, duration_ms:item.duration_ms, duration_baseline:item.duration_baseline,
-        authority_source:item.authority_source};
+        authority_source:item.authority_source, reuse_origin:item.reuse_origin};
     }), map: current ? data.map : {nodes:[],edges:[]}};
   }
 
@@ -387,7 +393,7 @@ JS = r"""(() => {
     return batchView(data, activeBatch);
   }
 
-  const scenarios = {'first-run':'첫 실행','unchanged':'변경 없음','docs':'문서 변경','code':'코드 변경','environment':'환경 변경','first-failure':'첫 검사 실패'};
+  const scenarios = {'first-run':'첫 실행','unchanged':'변경 없음','docs':'문서 변경','partial-reuse':'일부 실행 + 일부 재사용','code':'코드 변경','environment':'환경 변경','first-failure':'첫 검사 실패'};
   const criteria = {'same-shards':'같은 샤드 전체 실행','parent-suite':'기존 전체 검증 명령'};
   function readComparison(value) {
     if (value?.version !== 2 || value.kind !== 'click-paired-verification-benchmark' || !Array.isArray(value.samples) || value.samples.length > 240) throw Error('지원하지 않는 비교 형식');
@@ -472,7 +478,8 @@ JS = r"""(() => {
           decision:item.decision,status:item.status,started:item.started,completed:item.completed,reason_code:item.reason_code,
           execution_reason_code:item.execution_reason_code,authority_source:item.authority_source,
           current_revision:item.current_revision,previous_revision:item.previous_revision,duration_ms:item.duration_ms,
-          duration_baseline:item.duration_baseline,estimated_avoided_ms:item.status === 'reused' ? item.duration_baseline?.duration_ms ?? null : 0}))} : null,
+          duration_baseline:item.duration_baseline,reuse_origin:item.reuse_origin,
+          estimated_avoided_ms:item.status === 'reused' ? item.duration_baseline?.duration_ms ?? null : 0}))} : null,
       comparison,shadow:snapshot.summary.shadow,
       notes:['전체 대기시간은 별도 측정값이 없으면 알 수 없음','준비와 runner 구간만 부분 계측 · 호스트 전달·대기·최종 저장·반환 제외',
         '생략 비용은 실제 적용된 재사용의 이전 성공 실행 표본에 기반한 추정','Shadow는 실제 재사용·실측 절약 아님',
@@ -494,7 +501,7 @@ JS = r"""(() => {
     add('p',`생략한 실행 비용 추정: ${fmt(s.estimated_avoided_ms)} · 표본이 있는 ${count(s.estimated_source_count)} / 재사용 ${count(s.authoritative_reuse_count)}개 묶음`);
     add('h2','검증 묶음별 실제 결과');const table=add('table','');
     const heading=add('tr','',table);['이름','계획','실제 결과','시간 / 과거 표본','이유'].forEach(text=>add('th',text,heading));
-    report.batch?.sources.forEach(item=>{const tr=add('tr','',table);[item.label,executionLabels[item.decision]?.[0]||'없음',statusText[item.status],item.status==='reused'?fmt(item.duration_baseline?.duration_ms)+' (과거 표본)':fmt(item.duration_ms),outcomeText[item.execution_reason_code]||reasonText[item.reason_code]||'정보 없음'].forEach(text=>add('td',text,tr));});
+    report.batch?.sources.forEach(item=>{const tr=add('tr','',table);const origin=item.reuse_origin?` · 이전 배치 ${item.reuse_origin.batch_id.slice(0,12)}에서 재판정`:'';[item.label,executionLabels[item.decision]?.[0]||'없음',statusText[item.status],item.status==='reused'?fmt(item.duration_baseline?.duration_ms)+' (과거 표본)':fmt(item.duration_ms),(outcomeText[item.execution_reason_code]||reasonText[item.reason_code]||'정보 없음')+origin].forEach(text=>add('td',text,tr));});
     add('h2','별도 실측 비교');
     if (!report.comparison) add('p','비교 측정 없음. 일상 추정 비용을 실측한 전체 재실행 시간으로 환산하지 않습니다.');
     else {
@@ -522,7 +529,9 @@ JS = r"""(() => {
     snapshot = data;
     $('connection').textContent = '연결됨';
     document.querySelector('.live').classList.add('ok');
-    $('taskline').textContent = `${data.task.runtime_mode === 'guarded' ? 'Guarded' : 'Evidence'} 모드 · 변경 ${data.task.mutation_revision} · ${statusText[data.task.status] || '상태 확인 중'}`;
+    $('taskline').textContent = data.task.runtime_mode === 'unknown'
+      ? '현재 실행 중인 검증이 없습니다. 아래에서 최근 검증 결과를 볼 수 있습니다.'
+      : `${data.task.runtime_mode === 'guarded' ? 'Guarded' : 'Evidence'} 모드 · 변경 ${data.task.mutation_revision} · ${statusText[data.task.status] || '상태 확인 중'}`;
     const view = renderBatch(data);
     const incremental = activeBatch ? summarize(activeBatch) : data.summary.incremental;
     activeSummary = incremental;
@@ -630,6 +639,27 @@ def _dashboard_state(state: Any) -> dict[str, Any]:
     return dict(value) if state_is_valid(value) else fresh_state()
 
 
+def _dashboard_path(state_path: Path) -> Path:
+    return state_path.with_name(
+        "dashboard-" + state_path.name.removeprefix("session-contract-")
+    )
+
+
+def _dashboard_state_for_path(state_path: Path) -> dict[str, Any]:
+    sidecar = _read_state(_dashboard_path(state_path))
+    if state_is_valid(sidecar):
+        return dict(sidecar)
+    # Compatibility for a viewer prepared by v0.80 before the sidecar split.
+    return _dashboard_state(_read_state(state_path))
+
+
+def _write_dashboard_state(state_path: Path, dashboard: dict[str, Any]) -> bool:
+    if not state_is_valid(dashboard):
+        return False
+    click_state.write_json(_dashboard_path(state_path), dashboard)
+    return True
+
+
 def _managed_state_path(path: Path) -> bool:
     return click_state.managed_state_path(path, ("session-contract-",))
 
@@ -674,8 +704,9 @@ def prepare(
     runtime = click_runtime_state.view(state)
     if not runtime.execution_authorized:
         return "", "Start Guarded or Evidence runtime state before opening its dashboard."
-    dashboard = _dashboard_state(state)
-    state_path = str(click_state.contract_path(event).resolve())
+    contract_path = click_state.contract_path(event).resolve()
+    dashboard = _dashboard_state_for_path(contract_path)
+    state_path = str(contract_path)
     if action == "status":
         return runner_command(
             event,
@@ -695,8 +726,7 @@ def prepare(
             ), ""
         dashboard["status"] = "stopping"
         dashboard["stop_requested"] = True
-        state[DASHBOARD_FIELD] = dashboard
-        click_contract_state.save_contract_state(event, state)
+        _write_dashboard_state(contract_path, dashboard)
         return runner_command(
             event,
             "run-dashboard-stop",
@@ -723,8 +753,7 @@ def prepare(
         "stop_requested": False,
         "last_error": "",
     }
-    state[DASHBOARD_FIELD] = dashboard
-    click_contract_state.save_contract_state(event, state)
+    _write_dashboard_state(contract_path, dashboard)
     return runner_command(
         event,
         "run-dashboard-start",
@@ -735,15 +764,13 @@ def prepare(
 
 
 def request_stop(event: dict[str, Any]) -> bool:
-    state = click_contract_state.read_contract_state(event)
-    dashboard = _dashboard_state(state)
+    state_path = click_state.contract_path(event).resolve()
+    dashboard = _dashboard_state_for_path(state_path)
     if dashboard["status"] not in {"starting", "running", "stopping"}:
         return False
     dashboard["status"] = "stopping"
     dashboard["stop_requested"] = True
-    state[DASHBOARD_FIELD] = dashboard
-    click_contract_state.save_contract_state(event, state)
-    return True
+    return _write_dashboard_state(state_path, dashboard)
 
 
 def _read_state(path: Path) -> dict[str, Any] | None:
@@ -757,28 +784,20 @@ def _read_state(path: Path) -> dict[str, Any] | None:
 def _write_dashboard_fields(
     path: Path, instance_id: str, **fields: Any
 ) -> bool:
-    state = _read_state(path)
-    if state is None:
-        return False
-    dashboard = _dashboard_state(state)
+    dashboard = _dashboard_state_for_path(path)
     if dashboard.get("instance_id") != instance_id:
         return False
     dashboard.update(fields)
     if not state_is_valid(dashboard):
         return False
-    state[DASHBOARD_FIELD] = dashboard
-    click_state.write_json(path, state)
-    return True
+    return _write_dashboard_state(path, dashboard)
 
 
 def _snapshot(path: Path, instance_id: str) -> tuple[dict[str, Any] | None, dict[str, Any]]:
-    state = _read_state(path)
-    if state is None:
-        return None, fresh_state()
-    dashboard = _dashboard_state(state)
+    dashboard = _dashboard_state_for_path(path)
     if dashboard.get("instance_id") != instance_id:
         return None, dashboard
-    return state, dashboard
+    return click_contract_state.read_projection_state_path(path), dashboard
 
 
 def run_start(
@@ -893,8 +912,7 @@ def run_status(arguments: list[str]) -> int:
     if not _managed_state_path(state_path):
         return 2
     with click_state.state_lock():
-        state = _read_state(state_path)
-        dashboard = _dashboard_state(state)
+        dashboard = _dashboard_state_for_path(state_path)
     sys.stdout.write(
         json.dumps(
             {
@@ -1061,8 +1079,7 @@ def run_server(arguments: list[str]) -> int:
             with click_state.state_lock():
                 state, dashboard = _snapshot(state_path, instance_id)
             if (
-                state is None
-                or dashboard.get("stop_requested") is True
+                dashboard.get("stop_requested") is True
                 or dashboard.get("status") != "running"
                 or not hmac.compare_digest(
                     str(dashboard.get("access_token_digest", "")), access_digest

--- a/dist/antigravity/hooks/click_verification.py
+++ b/dist/antigravity/hooks/click_verification.py
@@ -1001,6 +1001,123 @@ def _reuse_binding_reason(
     return "receipt-invalid"
 
 
+def _successor_binding_reason(
+    previous: dict[str, Any],
+    current: dict[str, Any],
+    *,
+    group_digest: str,
+    git_root: str,
+    environment_digest: str,
+    executable_digest: str,
+    host_coverage: dict[str, Any],
+) -> str:
+    """Validate a prior Evidence fact without pretending it is this lifecycle."""
+    if previous.get("verified_check_digest") != group_digest:
+        return "check-binding-changed"
+    if previous.get("verified_root") != git_root:
+        return "workspace-ambiguous"
+    if previous.get("verified_executable_digest") != executable_digest:
+        return "executable-binding-changed"
+    if previous.get("verified_environment_digest") != environment_digest:
+        return "environment-binding-changed"
+    if (
+        not click_host_coverage.receipt_is_current(host_coverage)
+        or previous.get("verified_host_coverage") != host_coverage
+    ):
+        return "host-coverage-binding-changed"
+    if previous.get("shard") != current.get("shard"):
+        return "check-binding-changed"
+    verified_at = previous.get("verified_at")
+    if (
+        previous.get("status") != "passed"
+        or previous.get("last_exit_code") != 0
+        or not isinstance(verified_at, int)
+        or isinstance(verified_at, bool)
+        or verified_at <= 0
+        or not isinstance(previous.get("verified_tree_digest"), str)
+        or re.fullmatch(r"[0-9a-f]{64}", previous["verified_tree_digest"])
+        is None
+    ):
+        return "successor-evidence-integrity-invalid"
+    return ""
+
+
+def _requalify_successor_baseline(
+    current: dict[str, Any],
+    previous: dict[str, Any],
+    *,
+    contract_digest: str,
+    revision: int,
+    group_digest: str,
+    units: int,
+    tree_digest: str,
+    environment_digest: str,
+    executable_digest: str,
+    host_coverage: dict[str, Any],
+    exact_tree: bool,
+) -> None:
+    """Create a new-lifecycle baseline only after explicit binding checks."""
+    current_shard = current.get("shard")
+    preserved = json.loads(json.dumps(previous))
+    current.clear()
+    current.update(preserved)
+    if current_shard is None:
+        current.pop("shard", None)
+    else:
+        current["shard"] = current_shard
+    current.update(
+        status="passed" if exact_tree else "stale",
+        verified_revision=revision if exact_tree else max(0, revision - 1),
+        attempts=0,
+        unchanged_failure_retries=0,
+        last_exit_code=0,
+        last_check_digest=group_digest,
+        locked_check_digest=group_digest,
+        reserved_units=units,
+        reserved_check_digest=group_digest,
+        verified_contract_digest=contract_digest,
+        verified_check_digest=group_digest,
+        verified_units=units,
+        verified_tree_digest=tree_digest if exact_tree else previous["verified_tree_digest"],
+        verified_environment_digest=environment_digest,
+        verified_executable_digest=executable_digest,
+        verified_host_coverage=dict(host_coverage),
+        dependency_reuse_count=0,
+        last_dependency_reused_at=0,
+        last_dependency_reused_from_revision=-1,
+        safe_change_reuse_count=0,
+        last_safe_change_reused_at=0,
+        last_safe_change_reused_from_revision=-1,
+        last_safe_change_paths=[],
+        last_safe_change_path_count=0,
+        last_safe_change_decision_digest="",
+        successor_reuse_count=0,
+        last_successor_reused_at=0,
+        last_successor_origin_batch_id="",
+        last_successor_origin_evidence_session_id="",
+        last_successor_candidate_digest="",
+        last_successor_origin_revision=-1,
+        last_successor_mode="",
+    )
+
+
+def _mark_successor_reuse(
+    source: dict[str, Any], metadata: dict[str, Any], *, mode: str
+) -> None:
+    source["successor_reuse_count"] = int(
+        source.get("successor_reuse_count", 0)
+    ) + 1
+    source["last_successor_reused_at"] = int(time.time()) or 1
+    source["last_successor_origin_batch_id"] = metadata["batch_id"]
+    source["last_successor_origin_evidence_session_id"] = metadata[
+        "evidence_session_id"
+    ]
+    source["last_successor_candidate_digest"] = metadata["candidate_digest"]
+    source["last_successor_origin_revision"] = metadata["origin_revision"]
+    source["last_successor_mode"] = mode
+    source["verified_at"] = int(time.time()) or 1
+
+
 def _observation_nonreuse_reason(observation: Any) -> str:
     if not click_dependency_cache.dependency_observation_is_valid(observation):
         return "observer-incomplete"
@@ -1798,6 +1915,7 @@ def _prepare_verification(
             trace.get("plan"), batch_id=request_id,
             revision=int(verification.get("mutation_revision", 0)), prepared_ms=elapsed,
             requested=trace.get("requested"), labels=trace.get("labels"),
+            reuse_origins=trace.get("reuse_origins"),
         )
         if click_incremental.store_batch(verification, batch):
             if result[1]:
@@ -2021,6 +2139,21 @@ def _prepare_verification_impl(
         if not str(source.get("reserved_check_digest", "")):
             source["reserved_check_digest"] = group_digests[source_key]
 
+    successor_candidates: dict[str, tuple[dict[str, Any], dict[str, Any]]] = {}
+    if runtime.evidence:
+        scope_digest = click_evidence.successor_scope_digest(
+            str(click_state.contract_path(event).resolve())
+        )
+        for source_key in requested_keys:
+            candidate = click_evidence.successor_candidate(
+                state,
+                source_key,
+                expected_contract_schema_version=CONTRACT_STATE_SCHEMA_VERSION,
+                scope_digest=scope_digest,
+            )
+            if candidate is not None:
+                successor_candidates[source_key] = candidate
+
     previous_revisions: dict[str, int] = {}
     reason_codes: dict[str, str] = {}
     not_evaluable_keys: set[str] = set()
@@ -2100,11 +2233,21 @@ def _prepare_verification_impl(
     reused_keys: set[str] = set()
     dependency_reused_keys: set[str] = set()
     safe_change_reused_keys: set[str] = set()
-    if current_requested or dependency_candidates or safe_change_candidates:
+    successor_origins: dict[str, dict[str, Any]] = {}
+    successor_imported: dict[str, dict[str, Any]] = {}
+    if (
+        current_requested
+        or dependency_candidates
+        or safe_change_candidates
+        or successor_candidates
+    ):
         snapshot = git_workspace_snapshot(workspace)
         if snapshot is None:
             for source_key in (
-                current_requested | dependency_candidates | safe_change_candidates
+                current_requested
+                | dependency_candidates
+                | safe_change_candidates
+                | set(successor_candidates)
             ):
                 reason_codes[source_key] = "workspace-ambiguous"
                 not_evaluable_keys.add(source_key)
@@ -2116,6 +2259,60 @@ def _prepare_verification_impl(
             contract_digest = str(state.get("contract_digest", ""))
             git_root = os.path.normcase(str(snapshot.get("root", "")))
             tree_digest = str(snapshot.get("digest", ""))
+            for source_key, (previous, metadata) in successor_candidates.items():
+                source = sources[source_key]
+                binding_reason = _successor_binding_reason(
+                    previous,
+                    source,
+                    group_digest=group_digests[source_key],
+                    git_root=git_root,
+                    environment_digest=current_environment_digests[source_key],
+                    executable_digest=current_executable_digests[source_key],
+                    host_coverage=host_coverage,
+                )
+                if binding_reason:
+                    reason_codes[source_key] = binding_reason
+                    if binding_reason in {
+                        "workspace-ambiguous",
+                        "successor-evidence-integrity-invalid",
+                    }:
+                        not_evaluable_keys.add(source_key)
+                    continue
+                exact_tree = previous.get("verified_tree_digest") == tree_digest
+                successor_imported[source_key] = json.loads(json.dumps(source))
+                _requalify_successor_baseline(
+                    source,
+                    previous,
+                    contract_digest=contract_digest,
+                    revision=revision,
+                    group_digest=group_digests[source_key],
+                    units=group_units[source_key],
+                    tree_digest=tree_digest,
+                    environment_digest=current_environment_digests[source_key],
+                    executable_digest=current_executable_digests[source_key],
+                    host_coverage=host_coverage,
+                    exact_tree=exact_tree,
+                )
+                previous_revisions[source_key] = metadata["origin_revision"]
+                successor_origins[source_key] = metadata
+                if exact_tree:
+                    current_requested.add(source_key)
+                elif source.get("verified_dependency_provider") in (
+                    click_dependency_cache.PROVIDER_NAMES
+                ):
+                    dependency_candidates.add(source_key)
+                elif (
+                    click_change_policy.receipt_is_valid(
+                        source.get("verified_safe_change_receipt")
+                    )
+                    and not source.get("verified_dependency_observation")
+                ):
+                    safe_change_candidates.add(source_key)
+                else:
+                    reason, not_evaluable = _default_incremental_reason(source)
+                    reason_codes[source_key] = reason
+                    if not_evaluable:
+                        not_evaluable_keys.add(source_key)
             mutation_boundary = verification.get("mutation_boundary")
             if (dependency_candidates or safe_change_candidates) and not (
                 isinstance(mutation_boundary, dict)
@@ -2195,9 +2392,15 @@ def _prepare_verification_impl(
                         host_coverage=host_coverage,
                     ):
                         reused_keys.add(source_key)
-                        reason_codes[source_key] = (
-                            "same-revision-receipt-current"
-                        )
+                        if source_key in successor_origins:
+                            _mark_successor_reuse(
+                                source, successor_origins[source_key], mode="exact"
+                            )
+                            reason_codes[source_key] = "successor-evidence-current"
+                        else:
+                            reason_codes[source_key] = (
+                                "same-revision-receipt-current"
+                            )
                     else:
                         reason_codes[source_key] = _reuse_binding_reason(
                             source,
@@ -2256,9 +2459,17 @@ def _prepare_verification_impl(
                         )
                         reused_keys.add(source_key)
                         dependency_reused_keys.add(source_key)
+                        if source_key in successor_origins:
+                            _mark_successor_reuse(
+                                source,
+                                successor_origins[source_key],
+                                mode="dependency",
+                            )
                         not_evaluable_keys.discard(source_key)
                         reason_codes[source_key] = (
-                            "observed-dependencies-unchanged"
+                            "successor-evidence-dependencies-unchanged"
+                            if source_key in successor_origins
+                            else "observed-dependencies-unchanged"
                         )
                     else:
                         binding_reason = _reuse_binding_reason(
@@ -2354,8 +2565,18 @@ def _prepare_verification_impl(
                         )
                         reused_keys.add(source_key)
                         safe_change_reused_keys.add(source_key)
+                        if source_key in successor_origins:
+                            _mark_successor_reuse(
+                                source,
+                                successor_origins[source_key],
+                                mode="safe-change",
+                            )
                         not_evaluable_keys.discard(source_key)
-                        reason_codes[source_key] = "safe-change-policy-covered"
+                        reason_codes[source_key] = (
+                            "successor-evidence-safe-change-covered"
+                            if source_key in successor_origins
+                            else "safe-change-policy-covered"
+                        )
                     else:
                         verification_advisories.append(preflight_advisory)
                         binding_reason = _reuse_binding_reason(
@@ -2378,6 +2599,11 @@ def _prepare_verification_impl(
                             reason_codes[source_key] = (
                                 "safe-change-policy-not-covered"
                             )
+
+    for source_key, original in successor_imported.items():
+        if source_key not in reused_keys:
+            sources[source_key].clear()
+            sources[source_key].update(original)
 
     unresolved_keys = {
         key for key in argv_keys if not _evidence_is_current(sources.get(key), revision)
@@ -2414,6 +2640,11 @@ def _prepare_verification_impl(
             for key, source in sources.items()
             if isinstance(source, dict)
             and click_evidence_shards.source_metadata_is_valid(source.get("shard"))
+        }
+        measurement["reuse_origins"] = {
+            key: successor_origins[key]
+            for key in reused_keys
+            if key in successor_origins
         }
 
     if not pending_keys:
@@ -3305,6 +3536,49 @@ def _record_incremental_start(path: Path, digest: str, token: str, source_key: s
         pass  # An unavailable telemetry write cannot execute a second command.
 
 
+def _record_incremental_completion(
+    path: Path,
+    digest: str,
+    token: str,
+    source_key: str,
+    *,
+    status: str,
+    reason: str,
+    duration_ms: int | float | None,
+    completed: bool = True,
+) -> None:
+    """Persist one source result while the claimed batch is still active."""
+    try:
+        with _state_lock():
+            if not _managed_contract_path(path):
+                return
+            state = json.loads(path.read_text(encoding="utf-8"))
+            verification = state.get("verification", {})
+            if (
+                verification.get("status") != "running"
+                or verification.get("last_batch_digest") != digest
+                or not verification.get("runner_claimed_at")
+                or not secrets.compare_digest(
+                    str(verification.get("runner_token_digest", "")),
+                    hashlib.sha256(token.encode()).hexdigest(),
+                )
+            ):
+                return
+            if click_incremental.mark_completed(
+                verification,
+                source_key,
+                status=status,
+                reason=reason,
+                duration_ms=duration_ms,
+                completed=completed,
+            ):
+                state["updated_at"] = int(time.time())
+                _write_json(path, state)
+    except Exception:
+        # Telemetry cannot repeat a check or change evidence authority.
+        pass
+
+
 def _run_verification(
     arguments: list[str],
     *,
@@ -3493,6 +3767,16 @@ def _run_verification(
                         status="interrupted" if exit_code == 130 else "failed" if exit_code != 0 else "passed" if group_completed else "running",
                         reason_code="command-interrupted" if exit_code == 130 else "command-failed" if exit_code != 0 else "command-passed",
                     )
+                    if source_results[source_key]["completed"]:
+                        _record_incremental_completion(
+                            state_path,
+                            batch_digest,
+                            runner_token,
+                            source_key,
+                            status=str(source_results[source_key]["status"]),
+                            reason=str(source_results[source_key]["reason_code"]),
+                            duration_ms=source_durations_ms.get(source_key),
+                        )
                 if exit_code != 0:
                     break
                 succeeded_count += 1
@@ -3502,6 +3786,15 @@ def _run_verification(
                 source_results[source_key].update(
                     status="interrupted", completed=True, reason_code="command-interrupted"
                 )
+                _record_incremental_completion(
+                    state_path,
+                    batch_digest,
+                    runner_token,
+                    source_key,
+                    status="interrupted",
+                    reason="command-interrupted",
+                    duration_ms=source_durations_ms.get(source_key),
+                )
             sys.stderr.write(
                 "[Click] Verification was interrupted. The active check was stopped "
                 "and recorded as non-passing.\n"
@@ -3510,7 +3803,17 @@ def _run_verification(
             exit_code = 2
             if source_key in source_results:
                 source_results[source_key].update(
-                    status="interrupted", completed=False, reason_code="command-error"
+                    status="unknown", completed=False, reason_code="command-error"
+                )
+                _record_incremental_completion(
+                    state_path,
+                    batch_digest,
+                    runner_token,
+                    source_key,
+                    status="unknown",
+                    reason="command-error",
+                    duration_ms=source_durations_ms.get(source_key),
+                    completed=False,
                 )
             sys.stderr.write("[Click] The command boundary failed; no check was repeated.\n")
 

--- a/dist/antigravity/skills/click/references/capability-protocol.md
+++ b/dist/antigravity/skills/click/references/capability-protocol.md
@@ -143,6 +143,15 @@ uses strict receipt v3 with the parent, complete child count, plan, relevant
 entry, inventory, and per-child lineage digests. Offline verification continues
 to accept legacy v1 and unsharded v2, and rejects incomplete v3 shard sets.
 
+A completion that actually reuses evidence requalified from an earlier Evidence
+task in the same host session and workspace uses receipt v4. It records the
+origin batch, origin Evidence session, candidate digest, origin revision, and
+the authoritative requalification mode (`exact`, `dependency`, or
+`safe-change`). If that completion also contains shards, v4 retains the same
+complete shard provenance required by v3. Merely retaining a successor
+candidate never selects v4 and never creates reuse authority. Offline
+verification accepts and validates v4 while retaining legacy v1-v3 support.
+
 If a host omits the working directory selected by a nested execution tool,
 export may recover it only from the sole canonical Git root shared by every
 current argv evidence source. A stale, missing, non-canonical, or conflicting

--- a/dist/antigravity/skills/click/references/evidence-shards-v1.md
+++ b/dist/antigravity/skills/click/references/evidence-shards-v1.md
@@ -113,6 +113,12 @@ parent check digests, shard id and complete shard count, plan, relevant entry,
 and inventory digests. Offline verification accepts legacy v1, unsharded v2,
 and sharded v3, and rejects a missing or inconsistent v3 shard member.
 
+If a later Evidence task actually reuses a requalified result, its completion
+receipt uses v4. A v4 receipt that contains shards preserves every complete
+per-source shard provenance field required by v3 and additionally binds the
+origin Evidence task and requalification lineage. Candidate retention alone is
+not reuse and does not change the receipt version.
+
 ## Deliberate exclusions
 
 Evidence Shards v1 does not provide zero-configuration framework discovery,

--- a/hooks/click_contract_state.py
+++ b/hooks/click_contract_state.py
@@ -26,9 +26,33 @@ else:  # Imported from a directly executed bundled hook.
 EMPTY_CONTRACT_STATE = {"status": "none", "contract_digest": ""}
 
 
-def _history_path(event: dict[str, Any]):
-    path = click_state.contract_path(event)
+def history_path_for_contract(path):
     return path.with_name("efficiency-history-" + path.name.removeprefix("session-contract-"))
+
+
+def _history_path(event: dict[str, Any]):
+    return history_path_for_contract(click_state.contract_path(event))
+
+
+def read_projection_state_path(path) -> dict[str, Any]:
+    """Read current state or an authority-free history-only dashboard state."""
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError, TypeError):
+        value = None
+    if isinstance(value, dict):
+        return value
+    empty = dict(EMPTY_CONTRACT_STATE)
+    try:
+        archived = json.loads(
+            history_path_for_contract(path).read_text(encoding="utf-8")
+        )
+        verification: dict[str, Any] = {}
+        click_incremental.merge_history(archived, verification)
+        empty["verification"] = verification
+    except (OSError, ValueError, TypeError, json.JSONDecodeError):
+        pass
+    return empty
 
 
 def read_contract_state(event: dict[str, Any]) -> dict[str, Any]:
@@ -59,7 +83,7 @@ def save_contract_state(event: dict[str, Any], state: dict[str, Any]) -> None:
     click_state.write_json(click_state.contract_path(event), state)
 
 
-def clear_contract_state(event: dict[str, Any]) -> None:
+def _clear_contract_state_locked(event: dict[str, Any]) -> None:
     try:
         previous = read_contract_state(event).get("verification")
         if isinstance(previous, dict):
@@ -74,3 +98,19 @@ def clear_contract_state(event: dict[str, Any]) -> None:
         click_state.contract_path(event).unlink()
     except OSError:
         pass
+
+
+def clear_contract_state(
+    event: dict[str, Any], *, lock_already_held: bool = False
+) -> None:
+    """Archive measurements and revoke authority without a lost-update window.
+
+    Hook dispatch already owns the global state lock.  Direct callers, including
+    tests and future maintenance commands, acquire it here instead.  Keeping the
+    two cases explicit avoids attempting to recursively acquire the file lock.
+    """
+    if lock_already_held:
+        _clear_contract_state_locked(event)
+        return
+    with click_state.state_lock():
+        _clear_contract_state_locked(event)

--- a/hooks/click_dashboard_projection.py
+++ b/hooks/click_dashboard_projection.py
@@ -99,6 +99,7 @@ _SOURCE_FIELDS = frozenset(
         "shadow_limitations",
         "shadow_outcome",
         "execution_status", "execution_reason_code", "duration_ms", "duration_baseline",
+        "reuse_origin",
     }
 )
 _MAP_FIELDS = frozenset(
@@ -359,6 +360,7 @@ def dashboard_projection(
                 "execution_reason_code": result.get("execution_reason_code", "outcome-unconfirmed"),
                 "duration_ms": result.get("duration_ms"),
                 "duration_baseline": duration_baseline,
+                "reuse_origin": result.get("reuse_origin"),
                 "observer_status": observer_status,
                 "input_count": len(input_keys),
                 "visible_input_count": source_visible,
@@ -561,6 +563,12 @@ def projection_is_valid(value: Any) -> bool:
             or source.get("execution_reason_code") not in click_incremental.EXECUTION_REASONS
             or (source.get("duration_ms") is not None and not click_incremental.is_duration(source["duration_ms"]))
             or (source.get("duration_baseline") is not None and not click_incremental.baseline_is_valid(source["duration_baseline"]))
+            or (
+                source.get("reuse_origin") is not None
+                and not click_incremental.reuse_origin_is_valid(
+                    source["reuse_origin"]
+                )
+            )
             or source.get("observer_status")
             not in click_dependency_cache.SHADOW_OBSERVER_STATUSES
             or any(

--- a/hooks/click_evidence.py
+++ b/hooks/click_evidence.py
@@ -13,6 +13,7 @@ import hashlib
 import json
 import re
 import secrets
+import time
 from typing import Any
 
 if __package__:
@@ -32,6 +33,16 @@ else:  # Executed directly from the bundled hooks directory.
 EVIDENCE_KINDS = ("argv", "browser", "hosted", "manual", "existing")
 EVIDENCE_STATUSES = {"ready", "running", "observed", "passed", "failed", "stale"}
 EVIDENCE_STATE_VERSION = 1
+SUCCESSOR_EVIDENCE_FIELD = "successor_evidence"
+SUCCESSOR_EVIDENCE_VERSION = 1
+MAX_SUCCESSOR_EVIDENCE_BYTES = 2 * 1024 * 1024
+MAX_SUCCESSOR_SOURCES = 256
+_SUCCESSOR_FIELDS = frozenset({
+    "version", "scope_digest", "origin_evidence_session_id",
+    "origin_intent_digest", "origin_revision", "origin_registry_digest",
+    "captured_at", "evidence_state", "origins", "digest",
+})
+_SUCCESSOR_ORIGIN_FIELDS = frozenset({"batch_id", "execution_status"})
 
 
 def evidence_key(evidence_id: str) -> str:
@@ -95,6 +106,13 @@ def _fresh_source(kind: str, dependency_patterns: tuple[str, ...] = ()) -> dict[
         "last_safe_change_paths": [],
         "last_safe_change_path_count": 0,
         "last_safe_change_decision_digest": "",
+        "successor_reuse_count": 0,
+        "last_successor_reused_at": 0,
+        "last_successor_origin_batch_id": "",
+        "last_successor_origin_evidence_session_id": "",
+        "last_successor_candidate_digest": "",
+        "last_successor_origin_revision": -1,
+        "last_successor_mode": "",
     }
 
 
@@ -129,6 +147,188 @@ def fresh_state(contract: dict[str, Any]) -> dict[str, Any]:
         "sources": sources,
         "shard_sets": {},
     }
+
+
+def fresh_successor_evidence() -> dict[str, Any]:
+    return {}
+
+
+def successor_scope_digest(identity: str) -> str:
+    return hashlib.sha256(identity.encode()).hexdigest()
+
+
+def _successor_digest(value: dict[str, Any]) -> str:
+    payload = {key: item for key, item in value.items() if key != "digest"}
+    encoded = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def successor_evidence_is_valid(
+    value: Any,
+    *,
+    expected_contract_schema_version: int,
+    scope_digest: str,
+) -> bool:
+    if (
+        not isinstance(value, dict)
+        or set(value) != _SUCCESSOR_FIELDS
+        or value.get("version") != SUCCESSOR_EVIDENCE_VERSION
+        or value.get("scope_digest") != scope_digest
+        or not isinstance(scope_digest, str)
+        or re.fullmatch(r"[0-9a-f]{64}", scope_digest) is None
+        or not isinstance(value.get("origin_evidence_session_id"), str)
+        or re.fullmatch(r"evs_[0-9a-f]{32}", value["origin_evidence_session_id"])
+        is None
+        or not isinstance(value.get("origin_intent_digest"), str)
+        or re.fullmatch(r"[0-9a-f]{64}", value["origin_intent_digest"]) is None
+        or not isinstance(value.get("origin_revision"), int)
+        or isinstance(value.get("origin_revision"), bool)
+        or value["origin_revision"] < 0
+        or not isinstance(value.get("origin_registry_digest"), str)
+        or re.fullmatch(r"[0-9a-f]{64}", value["origin_registry_digest"]) is None
+        or not isinstance(value.get("captured_at"), int)
+        or isinstance(value.get("captured_at"), bool)
+        or value["captured_at"] <= 0
+        or not isinstance(value.get("origins"), dict)
+        or not isinstance(value.get("evidence_state"), dict)
+        or not isinstance(value.get("digest"), str)
+        or re.fullmatch(r"[0-9a-f]{64}", value["digest"]) is None
+        or not secrets.compare_digest(value["digest"], _successor_digest(value))
+        or len(json.dumps(value, sort_keys=True, separators=(",", ":")).encode())
+        > MAX_SUCCESSOR_EVIDENCE_BYTES
+    ):
+        return False
+    synthetic = {
+        "state_schema_version": expected_contract_schema_version,
+        "evidence_state": value["evidence_state"],
+    }
+    sources = sources_from_state(
+        synthetic,
+        expected_contract_schema_version=expected_contract_schema_version,
+    )
+    if (
+        sources is None
+        or not sources
+        or len(sources) > MAX_SUCCESSOR_SOURCES
+        or registry_digest(sources) != value["origin_registry_digest"]
+        or len(value["origins"]) > len(sources)
+    ):
+        return False
+    for key, origin in value["origins"].items():
+        source = sources.get(key) if isinstance(key, str) else None
+        if (
+            not isinstance(origin, dict)
+            or set(origin) != _SUCCESSOR_ORIGIN_FIELDS
+            or not isinstance(origin.get("batch_id"), str)
+            or re.fullmatch(r"[0-9a-f]{32}", origin["batch_id"]) is None
+            or origin.get("execution_status") not in {"passed", "reused"}
+            or not is_current(source, value["origin_revision"])
+            or source.get("kind") != "argv"
+            or source.get("verified_contract_digest")
+            != value["origin_intent_digest"]
+        ):
+            return False
+    return bool(value["origins"])
+
+
+def carry_successor_evidence(
+    previous: dict[str, Any],
+    current: dict[str, Any],
+    *,
+    origins: dict[str, dict[str, str]],
+    scope_digest: str,
+    expected_contract_schema_version: int,
+    now: int | None = None,
+) -> bool:
+    """Carry one completed Evidence ledger as re-evaluation candidates only."""
+    sources = sources_from_state(
+        previous,
+        expected_contract_schema_version=expected_contract_schema_version,
+    )
+    evidence_state = previous.get("evidence_state")
+    verification = previous.get("verification")
+    revision = (
+        verification.get("mutation_revision")
+        if isinstance(verification, dict)
+        else None
+    )
+    session_id = previous.get("evidence_session_id")
+    intent_digest = previous.get("intent_digest")
+    if (
+        not sources
+        or len(sources) > MAX_SUCCESSOR_SOURCES
+        or not isinstance(evidence_state, dict)
+        or not isinstance(revision, int)
+        or isinstance(revision, bool)
+        or revision < 0
+        or not isinstance(session_id, str)
+        or re.fullmatch(r"evs_[0-9a-f]{32}", session_id) is None
+        or not isinstance(intent_digest, str)
+        or re.fullmatch(r"[0-9a-f]{64}", intent_digest) is None
+    ):
+        return False
+    eligible = {
+        key: dict(origin)
+        for key, origin in origins.items()
+        if key in sources
+        and isinstance(origin, dict)
+        and set(origin) == _SUCCESSOR_ORIGIN_FIELDS
+        and is_current(sources[key], revision)
+    }
+    if not eligible:
+        return False
+    value = {
+        "version": SUCCESSOR_EVIDENCE_VERSION,
+        "scope_digest": scope_digest,
+        "origin_evidence_session_id": session_id,
+        "origin_intent_digest": intent_digest,
+        "origin_revision": revision,
+        "origin_registry_digest": registry_digest(sources),
+        "captured_at": int(time.time()) if now is None else now,
+        "evidence_state": json.loads(json.dumps(evidence_state)),
+        "origins": eligible,
+        "digest": "",
+    }
+    value["digest"] = _successor_digest(value)
+    if not successor_evidence_is_valid(
+        value,
+        expected_contract_schema_version=expected_contract_schema_version,
+        scope_digest=scope_digest,
+    ):
+        return False
+    current[SUCCESSOR_EVIDENCE_FIELD] = value
+    return True
+
+
+def successor_candidate(
+    state: dict[str, Any],
+    source_key: str,
+    *,
+    expected_contract_schema_version: int,
+    scope_digest: str,
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    value = state.get(SUCCESSOR_EVIDENCE_FIELD)
+    if not successor_evidence_is_valid(
+        value,
+        expected_contract_schema_version=expected_contract_schema_version,
+        scope_digest=scope_digest,
+    ):
+        return None
+    assert isinstance(value, dict)
+    origin = value["origins"].get(source_key)
+    source = value["evidence_state"]["sources"].get(source_key)
+    if not isinstance(origin, dict) or not isinstance(source, dict):
+        return None
+    metadata = {
+        "kind": "successor-evidence",
+        "batch_id": origin["batch_id"],
+        "evidence_session_id": value["origin_evidence_session_id"],
+        "candidate_digest": value["digest"],
+        "origin_revision": value["origin_revision"],
+    }
+    return json.loads(json.dumps(source)), metadata
 
 
 def _refresh_registry(evidence_state: dict[str, Any], sources: dict[str, Any]) -> None:
@@ -410,6 +610,40 @@ def _safe_change_fields_are_valid(source: dict[str, Any]) -> bool:
     )
 
 
+def _successor_fields_are_valid(source: dict[str, Any]) -> bool:
+    count = source.get("successor_reuse_count", 0)
+    reused_at = source.get("last_successor_reused_at", 0)
+    origin_revision = source.get("last_successor_origin_revision", -1)
+    batch_id = source.get("last_successor_origin_batch_id", "")
+    session_id = source.get("last_successor_origin_evidence_session_id", "")
+    candidate_digest = source.get("last_successor_candidate_digest", "")
+    mode = source.get("last_successor_mode", "")
+    if any(
+        not isinstance(value, int) or isinstance(value, bool)
+        for value in (count, reused_at, origin_revision)
+    ):
+        return False
+    if count < 0 or reused_at < 0 or origin_revision < -1:
+        return False
+    if not all(isinstance(value, str) for value in (
+        batch_id, session_id, candidate_digest, mode
+    )):
+        return False
+    if count == 0:
+        return bool(
+            reused_at == 0 and origin_revision == -1 and not batch_id
+            and not session_id and not candidate_digest and not mode
+        )
+    return bool(
+        reused_at > 0
+        and origin_revision >= 0
+        and re.fullmatch(r"[0-9a-f]{32}", batch_id)
+        and re.fullmatch(r"evs_[0-9a-f]{32}", session_id)
+        and re.fullmatch(r"[0-9a-f]{64}", candidate_digest)
+        and mode in {"exact", "dependency", "safe-change"}
+    )
+
+
 def sources_from_state(
     state: dict[str, Any],
     *,
@@ -474,6 +708,7 @@ def sources_from_state(
             is None
             or not _dependency_fields_are_valid(source)
             or not _safe_change_fields_are_valid(source)
+            or not _successor_fields_are_valid(source)
             or not _host_coverage_field_is_valid(source)
             or (
                 "reserved_units" in source

--- a/hooks/click_gate.py
+++ b/hooks/click_gate.py
@@ -512,8 +512,7 @@ def _handle_pre_tool(event: dict[str, Any]) -> None:
                     _deny(authorization_error)
                     return
                 click_service.request_stop(event)
-                click_shadow_dashboard.request_stop(event)
-                click_contract_state.clear_contract_state(event)
+                click_contract_state.clear_contract_state(event, lock_already_held=True)
                 click_observation.clear_review_state(event)
                 click_lifecycle.write_state(event, "idle")
                 _allow_rewritten("echo Click active contract cancelled")
@@ -546,7 +545,9 @@ def _handle_pre_tool(event: dict[str, Any]) -> None:
                     normalized != "evidence"
                     and runtime_state.get("status") == "evidence"
                 ):
-                    click_contract_state.clear_contract_state(event)
+                    click_contract_state.clear_contract_state(
+                        event, lock_already_held=True
+                    )
                     click_lifecycle.write_state(event, "idle")
                 label = {
                     "evidence": "Evidence",

--- a/hooks/click_incremental.py
+++ b/hooks/click_incremental.py
@@ -45,6 +45,11 @@ AUTHORITY_SOURCES = frozenset(
 REASON_CODES = frozenset(
     {
         "same-revision-receipt-current",
+        "successor-evidence-current",
+        "successor-evidence-dependencies-unchanged",
+        "successor-evidence-safe-change-covered",
+        "successor-evidence-scope-mismatch",
+        "successor-evidence-integrity-invalid",
         "observed-dependencies-unchanged",
         "safe-change-policy-covered",
         "no-passing-evidence",
@@ -176,6 +181,7 @@ def decision(
 # share the existing age/count/byte budget with legacy planning events.
 BATCH_STATUSES = frozenset({"planned", "running", "passed", "failed", "interrupted", "rejected", "incomplete"})
 SOURCE_STATUSES = frozenset({"planned", "reuse-pending", "running", "passed", "failed", "interrupted", "not-run", "reused", "unknown"})
+REUSE_ORIGIN_KINDS = frozenset({"successor-evidence"})
 EXECUTION_REASONS = frozenset({
     "", "batch-finished", "request-rejected", "runner-admission-rejected",
     "plan-not-created", "reuse-applied", "command-started", "command-passed",
@@ -189,10 +195,15 @@ _BATCH_FIELDS = frozenset({
     "status", "reason_code", "requested_source_count", "sources",
     "prepare_duration_ms", "runner_duration_ms", "request_wall_ms", "measurement_scope",
 })
-_SOURCE_FIELDS = _DECISION_FIELDS | {
+_SOURCE_FIELDS_V1 = _DECISION_FIELDS | {
     "duration_baseline", "label", "status", "started", "completed",
     "duration_ms", "execution_reason_code",
 }
+_SOURCE_FIELDS = _SOURCE_FIELDS_V1 | {"reuse_origin"}
+_REUSE_ORIGIN_FIELDS = frozenset({
+    "kind", "batch_id", "evidence_session_id", "candidate_digest",
+    "origin_revision",
+})
 SUMMARY_FIELDS = (
     "total_source_count", "planned_execution_source_count", "planned_reuse_source_count",
     "executed_source_count", "completed_source_count", "passed_source_count",
@@ -214,14 +225,32 @@ def safe_label(value: Any, fallback: str) -> str:
     ) else fallback
 
 
+def reuse_origin_is_valid(value: Any) -> bool:
+    return bool(
+        isinstance(value, dict)
+        and set(value) == _REUSE_ORIGIN_FIELDS
+        and value.get("kind") in REUSE_ORIGIN_KINDS
+        and isinstance(value.get("batch_id"), str)
+        and re.fullmatch(r"[0-9a-f]{32}", value["batch_id"])
+        and isinstance(value.get("evidence_session_id"), str)
+        and re.fullmatch(r"evs_[0-9a-f]{32}", value["evidence_session_id"])
+        and isinstance(value.get("candidate_digest"), str)
+        and _DIGEST.fullmatch(value["candidate_digest"])
+        and _is_integer(value.get("origin_revision"))
+    )
+
+
 def source_result_is_valid(value: Any) -> bool:
-    if not isinstance(value, dict) or set(value) != _SOURCE_FIELDS:
+    if not isinstance(value, dict) or set(value) not in {
+        _SOURCE_FIELDS_V1, _SOURCE_FIELDS
+    }:
         return False
     planned = {key: value[key] for key in _DECISION_FIELDS | {"duration_baseline"}}
     if planned["decision"] is None:
         planned.update(decision="not-evaluable", reason_code="receipt-invalid")
     if not decision_is_valid(planned):
         return False
+    reuse_origin = value.get("reuse_origin")
     return bool(
         value["label"] == safe_label(value["label"], "")
         and value["label"]
@@ -235,6 +264,8 @@ def source_result_is_valid(value: Any) -> bool:
         and (value["status"] not in {"passed", "failed"} or (value["started"] and value["completed"]))
         and (value["status"] != "running" or (value["started"] and not value["completed"]))
         and (value["started"] or value["duration_ms"] is None)
+        and (reuse_origin is None or reuse_origin_is_valid(reuse_origin))
+        and (reuse_origin is None or value["decision"] in REUSE_DECISIONS)
     )
 
 
@@ -243,7 +274,7 @@ def batch_is_valid(value: Any) -> bool:
         return False
     items = value.get("sources")
     return bool(
-        value.get("event") == BATCH_EVENT and value.get("version") == 1
+        value.get("event") == BATCH_EVENT and value.get("version") in {1, 2}
         and isinstance(value.get("batch_id"), str)
         and re.fullmatch(r"[0-9a-f]{32}", value["batch_id"])
         and _is_integer(value.get("timestamp"), minimum=1)
@@ -254,6 +285,11 @@ def batch_is_valid(value: Any) -> bool:
         and (value.get("requested_source_count") is None or _is_integer(value["requested_source_count"]))
         and isinstance(items, list)
         and all(source_result_is_valid(item) for item in items)
+        and all(
+            (value["version"] == 1 and "reuse_origin" not in item)
+            or (value["version"] == 2 and "reuse_origin" in item)
+            for item in items
+        )
         and len({item["source_key"] for item in items}) == len(items)
         and (value["requested_source_count"] is None or len(items) <= value["requested_source_count"])
         and all(value.get(key) is None or is_duration(value[key]) for key in (
@@ -269,7 +305,9 @@ def batch_is_valid(value: Any) -> bool:
 def new_batch(
     plan: dict[str, Any] | None, *, batch_id: str, revision: int,
     prepared_ms: float | None, requested: list[dict[str, str]] | None = None,
-    labels: dict[str, str] | None = None, now: int | None = None,
+    labels: dict[str, str] | None = None,
+    reuse_origins: dict[str, dict[str, Any]] | None = None,
+    now: int | None = None,
 ) -> dict[str, Any]:
     timestamp = int(time.time()) if now is None else now
     items = plan["decisions"] if plan_is_valid(plan) else [
@@ -282,7 +320,7 @@ def new_batch(
         for item in requested or []
     ]
     batch = {
-        "event": BATCH_EVENT, "version": 1, "batch_id": batch_id,
+        "event": BATCH_EVENT, "version": 2, "batch_id": batch_id,
         "timestamp": timestamp, "finished_at": None, "current_revision": revision,
         "status": "planned", "reason_code": "", "requested_source_count": len(items) if plan or requested is not None else None,
         "sources": [],
@@ -297,6 +335,9 @@ def new_batch(
             label=safe_label((labels or {}).get(item["source_key"]), f"검증 묶음 {index}"),
             status="reuse-pending" if item["decision"] in REUSE_DECISIONS else "planned",
             started=False, completed=False, duration_ms=None, execution_reason_code="",
+            reuse_origin=json.loads(json.dumps((reuse_origins or {}).get(item["source_key"])))
+            if reuse_origin_is_valid((reuse_origins or {}).get(item["source_key"]))
+            else None,
         )
         batch["sources"].append(source)
     if not batch_is_valid(batch):
@@ -392,6 +433,41 @@ def mark_started(verification: dict[str, Any], source_key: str) -> bool:
     return False
 
 
+def mark_completed(
+    verification: dict[str, Any], source_key: str, *, status: str,
+    reason: str, duration_ms: int | float | None, completed: bool = True,
+) -> bool:
+    """Persist one witnessed source outcome before the next source starts."""
+    if status not in {"passed", "failed", "interrupted", "unknown"}:
+        return False
+    if reason not in EXECUTION_REASONS or reason == "":
+        return False
+    if duration_ms is not None and not is_duration(duration_ms):
+        return False
+    batch = current_batch(verification)
+    if batch is None or batch["status"] not in {"planned", "running"}:
+        return False
+    for item in batch["sources"]:
+        if item["source_key"] != source_key or not item["started"]:
+            continue
+        if item["completed"]:
+            return bool(
+                item["status"] == status
+                and item["execution_reason_code"] == reason
+                and item["duration_ms"] == duration_ms
+                and completed
+            )
+        item.update(
+            status=status,
+            completed=completed,
+            duration_ms=duration_ms,
+            execution_reason_code=reason,
+        )
+        batch["status"] = "running"
+        return store_batch(verification, batch)
+    return False
+
+
 def interrupt_batch(verification: dict[str, Any]) -> bool:
     """Cancellation is witnessed; an active child's termination is not assumed."""
     batch = current_batch(verification)
@@ -399,6 +475,10 @@ def interrupt_batch(verification: dict[str, Any]) -> bool:
         return False
     batch.update(status="interrupted", reason_code="user-cancelled", finished_at=int(time.time()))
     for item in batch["sources"]:
+        if item["completed"]:
+            # Cancellation revokes current authority, not the already witnessed
+            # fact that this source finished before the cancellation boundary.
+            continue
         item.update(
             status="interrupted" if item["started"] else "not-run",
             execution_reason_code="user-cancelled", completed=False,
@@ -660,6 +740,10 @@ def record_execution(
     for source in batch["sources"]:
         key = source["source_key"]
         result = source_results.get(key)
+        if source["completed"]:
+            # A source-level completion was already persisted under the claimed
+            # runner. The final batch fold must not roll that fact backward.
+            continue
         if result is not None:
             source.update({
                 "status": result["status"], "started": result["started"],

--- a/hooks/click_lifecycle.py
+++ b/hooks/click_lifecycle.py
@@ -24,6 +24,7 @@ if __package__:
         click_contract,
         click_contract_state,
         click_evidence,
+        click_incremental,
         click_mode,
         click_mutation,
         click_observation,
@@ -41,6 +42,7 @@ else:  # Executed directly from the bundled hooks directory.
     import click_contract
     import click_contract_state
     import click_evidence
+    import click_incremental
     import click_mode
     import click_mutation
     import click_observation
@@ -168,6 +170,9 @@ def _fresh_evidence_state(
         "capability_ledger": click_claims.fresh_state(),
         "verification": click_verification.fresh_state(virtual_contract),
         "evidence_state": click_evidence.fresh_state(virtual_contract),
+        click_evidence.SUCCESSOR_EVIDENCE_FIELD: (
+            click_evidence.fresh_successor_evidence()
+        ),
         "external_evidence": click_evidence.fresh_external_state(),
         "observations": click_observation.fresh_state(),
         "mutation": click_mutation.fresh_state(),
@@ -199,8 +204,34 @@ def _ensure_evidence_state(event: dict[str, Any]) -> tuple[dict[str, Any], bool]
     ):
         return state, False
     recovered = runtime.evidence and not _evidence_state_is_usable(state)
-    if not _evidence_state_is_usable(state) or _contract_is_completed(state):
+    completed_evidence = bool(
+        runtime.evidence
+        and _evidence_state_is_usable(state)
+        and _contract_is_completed(state)
+    )
+    if not _evidence_state_is_usable(state) or completed_evidence:
+        previous = state
         state = _fresh_evidence_state(event, history_complete=not recovered)
+        if completed_evidence:
+            origins: dict[str, dict[str, str]] = {}
+            for batch in click_incremental.batch_history(
+                previous.get("verification")
+            ):
+                for source in batch["sources"]:
+                    if source["status"] in {"passed", "reused"}:
+                        origins[source["source_key"]] = {
+                            "batch_id": batch["batch_id"],
+                            "execution_status": source["status"],
+                        }
+            click_evidence.carry_successor_evidence(
+                previous,
+                state,
+                origins=origins,
+                scope_digest=click_evidence.successor_scope_digest(
+                    str(click_state.contract_path(event).resolve())
+                ),
+                expected_contract_schema_version=CONTRACT_STATE_SCHEMA_VERSION,
+            )
         _save_contract_state(event, state)
         return state, recovered
     if _append_follow_up(event, state):

--- a/hooks/click_receipt.py
+++ b/hooks/click_receipt.py
@@ -18,10 +18,12 @@ from typing import Any
 LEGACY_RECEIPT_VERSION = 1
 RECEIPT_VERSION = 2
 SHARD_RECEIPT_VERSION = 3
+SUCCESSOR_RECEIPT_VERSION = 4
 SUPPORTED_RECEIPT_VERSIONS = {
     LEGACY_RECEIPT_VERSION,
     RECEIPT_VERSION,
     SHARD_RECEIPT_VERSION,
+    SUCCESSOR_RECEIPT_VERSION,
 }
 ENVELOPE_VERSION = 1
 UNSIGNED_ASSURANCE = "unsigned-integrity-only"
@@ -110,6 +112,11 @@ SHARD_PROVIDER = "repository-evidence-shards-v1"
 SHARD_ID_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,31}$")
 EVIDENCE_RESULT_FIELDS = {"status", "exit_code", "completed_at"}
 LINEAGE_FIELDS = {"mode", "from_revision", "dependency_digest"}
+SUCCESSOR_LINEAGE_FIELDS = LINEAGE_FIELDS | {
+    "origin_batch_id",
+    "origin_evidence_session_id",
+    "requalification_mode",
+}
 COVERAGE_FIELDS = {
     "host_assurance",
     "host_coverage_digest",
@@ -338,9 +345,11 @@ def _normalize_capability(
 
 
 def _normalize_lineage(
-    value: Any, *, kind: str, revision: int
+    value: Any, *, kind: str, revision: int, receipt_version: int
 ) -> tuple[dict[str, Any] | None, str]:
-    error = _exact_fields(value, LINEAGE_FIELDS, "evidence.lineage")
+    successor = isinstance(value, dict) and value.get("mode") == "successor-reused"
+    fields = SUCCESSOR_LINEAGE_FIELDS if successor else LINEAGE_FIELDS
+    error = _exact_fields(value, fields, "evidence.lineage")
     if error:
         return None, error
     assert isinstance(value, dict)
@@ -351,7 +360,7 @@ def _normalize_lineage(
         return None, "Completion receipt evidence lineage revision is invalid."
 
     expected_modes = {
-        "argv": {"executed", "dependency-reused"},
+        "argv": {"executed", "dependency-reused", "successor-reused"},
         "browser": {"browser-observed"},
         "hosted": {"attested"},
         "manual": {"attested"},
@@ -359,6 +368,29 @@ def _normalize_lineage(
     }
     if mode not in expected_modes[kind]:
         return None, f"Completion receipt lineage mode is invalid for `{kind}` evidence."
+    if mode == "successor-reused":
+        origin_batch_id = value.get("origin_batch_id")
+        origin_session_id = value.get("origin_evidence_session_id")
+        requalification_mode = value.get("requalification_mode")
+        if (
+            receipt_version != SUCCESSOR_RECEIPT_VERSION
+            or kind != "argv"
+            or not _is_digest(dependency_digest)
+            or not isinstance(origin_batch_id, str)
+            or re.fullmatch(r"[0-9a-f]{32}", origin_batch_id) is None
+            or not isinstance(origin_session_id, str)
+            or re.fullmatch(r"evs_[0-9a-f]{32}", origin_session_id) is None
+            or requalification_mode not in {"exact", "dependency", "safe-change"}
+        ):
+            return None, "Successor-reused evidence lineage is invalid."
+        return {
+            "mode": mode,
+            "from_revision": from_revision,
+            "dependency_digest": dependency_digest,
+            "origin_batch_id": origin_batch_id,
+            "origin_evidence_session_id": origin_session_id,
+            "requalification_mode": requalification_mode,
+        }, ""
     if mode == "dependency-reused":
         if from_revision >= revision or not _is_digest(dependency_digest):
             return (
@@ -425,7 +457,7 @@ def _normalize_evidence(
 ) -> tuple[dict[str, Any] | None, str]:
     fields = (
         SHARDED_EVIDENCE_FIELDS
-        if receipt_version == SHARD_RECEIPT_VERSION
+        if receipt_version in {SHARD_RECEIPT_VERSION, SUCCESSOR_RECEIPT_VERSION}
         else EVIDENCE_FIELDS
     )
     error = _exact_fields(value, fields, "evidence source")
@@ -473,7 +505,8 @@ def _normalize_evidence(
         return None, "Completion receipt evidence result must be a timestamped pass."
 
     lineage, error = _normalize_lineage(
-        value.get("lineage"), kind=str(kind), revision=revision
+        value.get("lineage"), kind=str(kind), revision=revision,
+        receipt_version=receipt_version,
     )
     if error:
         return None, error
@@ -492,7 +525,7 @@ def _normalize_evidence(
         },
         "lineage": lineage,
     }
-    if receipt_version == SHARD_RECEIPT_VERSION:
+    if receipt_version in {SHARD_RECEIPT_VERSION, SUCCESSOR_RECEIPT_VERSION}:
         if kind != "argv" and value.get("shard") is not None:
             return None, "Only argv evidence may carry shard provenance."
         shard, error = _normalize_shard(value.get("shard"), source_key=source_key)
@@ -547,7 +580,11 @@ def validate_receipt(value: Any) -> tuple[dict[str, Any] | None, str]:
     if version not in SUPPORTED_RECEIPT_VERSIONS or isinstance(version, bool):
         return None, "Completion receipt `version` is unsupported."
     authority: dict[str, Any] | None = None
-    if version in {RECEIPT_VERSION, SHARD_RECEIPT_VERSION}:
+    if version in {
+        RECEIPT_VERSION,
+        SHARD_RECEIPT_VERSION,
+        SUCCESSOR_RECEIPT_VERSION,
+    }:
         authority, error = _normalize_authority(value.get("authority"))
         if error:
             return None, error
@@ -614,11 +651,11 @@ def validate_receipt(value: Any) -> tuple[dict[str, Any] | None, str]:
         seen.add(source_key)
         normalized_evidence.append(normalized)
     normalized_evidence.sort(key=lambda source: str(source["source_key"]))
-    if version == SHARD_RECEIPT_VERSION:
+    if version in {SHARD_RECEIPT_VERSION, SUCCESSOR_RECEIPT_VERSION}:
         sharded = [
             source for source in normalized_evidence if source.get("shard") is not None
         ]
-        if not sharded:
+        if version == SHARD_RECEIPT_VERSION and not sharded:
             return None, "Receipt v3 requires at least one sharded evidence source."
         groups: dict[str, list[dict[str, Any]]] = {}
         for source in sharded:
@@ -644,6 +681,11 @@ def validate_receipt(value: Any) -> tuple[dict[str, Any] | None, str]:
                 )
             ):
                 return None, "Completion receipt evidence shard set is incomplete."
+    if version == SUCCESSOR_RECEIPT_VERSION and not any(
+        source["lineage"]["mode"] == "successor-reused"
+        for source in normalized_evidence
+    ):
+        return None, "Receipt v4 requires successor-reused evidence lineage."
 
     workspace = execution["workspace"]
     assert isinstance(workspace, dict)

--- a/hooks/click_receipt_runtime.py
+++ b/hooks/click_receipt_runtime.py
@@ -171,7 +171,28 @@ def _evidence_receipts(
             if source.get("verified_host_coverage") != host_coverage:
                 return None, "The host coverage identity changed after argv evidence completed."
 
-        if kind == "argv" and int(source.get("safe_change_reuse_count", 0)) > 0:
+        if kind == "argv" and int(source.get("successor_reuse_count", 0)) > 0:
+            lineage = {
+                "mode": "successor-reused",
+                "from_revision": int(
+                    source.get("last_successor_origin_revision", -1)
+                ),
+                # This digest binds the carried candidate, including its
+                # authoritative source facts and origin mapping.
+                "dependency_digest": str(
+                    source.get("last_successor_candidate_digest", "")
+                ),
+                "origin_batch_id": str(
+                    source.get("last_successor_origin_batch_id", "")
+                ),
+                "origin_evidence_session_id": str(
+                    source.get("last_successor_origin_evidence_session_id", "")
+                ),
+                "requalification_mode": str(
+                    source.get("last_successor_mode", "")
+                ),
+            }
+        elif kind == "argv" and int(source.get("safe_change_reuse_count", 0)) > 0:
             lineage = {
                 "mode": "dependency-reused",
                 "from_revision": int(
@@ -220,7 +241,10 @@ def _evidence_receipts(
                 },
                 "lineage": lineage,
             }
-        if receipt_version == click_receipt.SHARD_RECEIPT_VERSION:
+        if receipt_version in {
+            click_receipt.SHARD_RECEIPT_VERSION,
+            click_receipt.SUCCESSOR_RECEIPT_VERSION,
+        }:
             metadata = source.get("shard")
             receipt_source["shard"] = (
                 {
@@ -271,8 +295,15 @@ def build_envelope(
     workspace, normalized_root, error = _workspace_receipt(workspace_snapshot)
     if error:
         return None, error
+    has_successor = any(
+        isinstance(source, dict)
+        and int(source.get("successor_reuse_count", 0)) > 0
+        for source in sources.values()
+    )
     receipt_version = (
-        click_receipt.SHARD_RECEIPT_VERSION
+        click_receipt.SUCCESSOR_RECEIPT_VERSION
+        if has_successor
+        else click_receipt.SHARD_RECEIPT_VERSION
         if any(
             click_evidence_shards.source_metadata_is_valid(source.get("shard"))
             for source in sources.values()

--- a/hooks/click_shadow_dashboard.py
+++ b/hooks/click_shadow_dashboard.py
@@ -134,7 +134,7 @@ JS = r"""(() => {
     planned: '실행 예정', 'reuse-pending': '재사용 예정 · 미적용', running: '실행 중',
     passed: '통과', failed: '실패', interrupted: '중단 · 일부 결과 미확정',
     'not-run': '미실행', reused: '재사용 적용', unknown: '측정 정보 없음',
-    rejected: '실행 전 거부', incomplete: '미확정', evidence: 'Evidence', approved: 'Guarded'
+    rejected: '실행 전 거부', incomplete: '미확정', evidence: 'Evidence', approved: 'Guarded', none: '활성 작업 없음'
   };
   const outcomeText = {
     'request-rejected': '요청이 거부되어 시작하지 않았습니다.',
@@ -158,6 +158,11 @@ JS = r"""(() => {
   };
   const reasonText = {
     'same-revision-receipt-current': '같은 revision의 검사 결과가 현재 작업트리와 정확히 일치해 재사용했습니다.',
+    'successor-evidence-current': '이전 Evidence 작업의 실제 통과 결과를 현재 명령·작업트리·환경·실행 파일·호스트 범위에 다시 결합해 재사용했습니다.',
+    'successor-evidence-dependencies-unchanged': '이전 Evidence 작업의 실제 통과 결과를 가져와, 현재 변경 뒤에도 관찰된 입력이 바뀌지 않았음을 다시 확인해 재사용했습니다.',
+    'successor-evidence-safe-change-covered': '이전 Evidence 작업의 실제 통과 결과를 가져와, 현재 커밋된 안전 변경 정책이 이번 변경을 허용하는지 다시 확인해 재사용했습니다.',
+    'successor-evidence-scope-mismatch': '이전 결과가 현재 호스트 세션과 작업 공간의 후속 작업 범위에 속하지 않아 실제 검사를 실행했습니다.',
+    'successor-evidence-integrity-invalid': '이전 실행 사실의 무결성이나 출처를 확인할 수 없어 실제 검사를 실행했습니다.',
     'observed-dependencies-unchanged': '이 검사가 실제로 읽었던 입력이 바뀌지 않아 이전 통과 결과를 재사용했습니다.',
     'safe-change-policy-covered': '저장소 소유자가 미리 허용한 안전 변경 범위 안이라 이전 결과를 재사용했습니다.',
     'no-passing-evidence': '재사용할 수 있는 이전 통과 결과가 없어 실제 검사를 실행했습니다.',
@@ -204,6 +209,7 @@ JS = r"""(() => {
       `계획 ${executionLabels[source.execution_decision]?.[0] || '없음'} · 실제 ${label}`,
       `실행 구간 ${fmt(source.duration_ms)}`,
       source.duration_baseline ? `과거 표본 ${source.duration_baseline.sample_count}개 · revision ${source.duration_baseline.revision} · ${fmt(source.duration_baseline.duration_ms)}` : '과거 시간 표본 없음',
+      source.reuse_origin ? `이전 Evidence 배치 ${source.reuse_origin.batch_id.slice(0,12)} · 출처 revision ${source.reuse_origin.origin_revision}` : '현재 작업 안의 근거',
       `판정 식별자 ${source.reason_code || '없음'}`,
       ...source.shadow_limitations.map(item => `Shadow: ${item}`)
     ];
@@ -362,7 +368,7 @@ JS = r"""(() => {
         execution_decision:item.decision || 'not-planned', reason_code:item.reason_code,
         execution_reason_code:item.execution_reason_code, current_revision:item.current_revision,
         previous_revision:item.previous_revision, duration_ms:item.duration_ms, duration_baseline:item.duration_baseline,
-        authority_source:item.authority_source};
+        authority_source:item.authority_source, reuse_origin:item.reuse_origin};
     }), map: current ? data.map : {nodes:[],edges:[]}};
   }
 
@@ -387,7 +393,7 @@ JS = r"""(() => {
     return batchView(data, activeBatch);
   }
 
-  const scenarios = {'first-run':'첫 실행','unchanged':'변경 없음','docs':'문서 변경','code':'코드 변경','environment':'환경 변경','first-failure':'첫 검사 실패'};
+  const scenarios = {'first-run':'첫 실행','unchanged':'변경 없음','docs':'문서 변경','partial-reuse':'일부 실행 + 일부 재사용','code':'코드 변경','environment':'환경 변경','first-failure':'첫 검사 실패'};
   const criteria = {'same-shards':'같은 샤드 전체 실행','parent-suite':'기존 전체 검증 명령'};
   function readComparison(value) {
     if (value?.version !== 2 || value.kind !== 'click-paired-verification-benchmark' || !Array.isArray(value.samples) || value.samples.length > 240) throw Error('지원하지 않는 비교 형식');
@@ -472,7 +478,8 @@ JS = r"""(() => {
           decision:item.decision,status:item.status,started:item.started,completed:item.completed,reason_code:item.reason_code,
           execution_reason_code:item.execution_reason_code,authority_source:item.authority_source,
           current_revision:item.current_revision,previous_revision:item.previous_revision,duration_ms:item.duration_ms,
-          duration_baseline:item.duration_baseline,estimated_avoided_ms:item.status === 'reused' ? item.duration_baseline?.duration_ms ?? null : 0}))} : null,
+          duration_baseline:item.duration_baseline,reuse_origin:item.reuse_origin,
+          estimated_avoided_ms:item.status === 'reused' ? item.duration_baseline?.duration_ms ?? null : 0}))} : null,
       comparison,shadow:snapshot.summary.shadow,
       notes:['전체 대기시간은 별도 측정값이 없으면 알 수 없음','준비와 runner 구간만 부분 계측 · 호스트 전달·대기·최종 저장·반환 제외',
         '생략 비용은 실제 적용된 재사용의 이전 성공 실행 표본에 기반한 추정','Shadow는 실제 재사용·실측 절약 아님',
@@ -494,7 +501,7 @@ JS = r"""(() => {
     add('p',`생략한 실행 비용 추정: ${fmt(s.estimated_avoided_ms)} · 표본이 있는 ${count(s.estimated_source_count)} / 재사용 ${count(s.authoritative_reuse_count)}개 묶음`);
     add('h2','검증 묶음별 실제 결과');const table=add('table','');
     const heading=add('tr','',table);['이름','계획','실제 결과','시간 / 과거 표본','이유'].forEach(text=>add('th',text,heading));
-    report.batch?.sources.forEach(item=>{const tr=add('tr','',table);[item.label,executionLabels[item.decision]?.[0]||'없음',statusText[item.status],item.status==='reused'?fmt(item.duration_baseline?.duration_ms)+' (과거 표본)':fmt(item.duration_ms),outcomeText[item.execution_reason_code]||reasonText[item.reason_code]||'정보 없음'].forEach(text=>add('td',text,tr));});
+    report.batch?.sources.forEach(item=>{const tr=add('tr','',table);const origin=item.reuse_origin?` · 이전 배치 ${item.reuse_origin.batch_id.slice(0,12)}에서 재판정`:'';[item.label,executionLabels[item.decision]?.[0]||'없음',statusText[item.status],item.status==='reused'?fmt(item.duration_baseline?.duration_ms)+' (과거 표본)':fmt(item.duration_ms),(outcomeText[item.execution_reason_code]||reasonText[item.reason_code]||'정보 없음')+origin].forEach(text=>add('td',text,tr));});
     add('h2','별도 실측 비교');
     if (!report.comparison) add('p','비교 측정 없음. 일상 추정 비용을 실측한 전체 재실행 시간으로 환산하지 않습니다.');
     else {
@@ -522,7 +529,9 @@ JS = r"""(() => {
     snapshot = data;
     $('connection').textContent = '연결됨';
     document.querySelector('.live').classList.add('ok');
-    $('taskline').textContent = `${data.task.runtime_mode === 'guarded' ? 'Guarded' : 'Evidence'} 모드 · 변경 ${data.task.mutation_revision} · ${statusText[data.task.status] || '상태 확인 중'}`;
+    $('taskline').textContent = data.task.runtime_mode === 'unknown'
+      ? '현재 실행 중인 검증이 없습니다. 아래에서 최근 검증 결과를 볼 수 있습니다.'
+      : `${data.task.runtime_mode === 'guarded' ? 'Guarded' : 'Evidence'} 모드 · 변경 ${data.task.mutation_revision} · ${statusText[data.task.status] || '상태 확인 중'}`;
     const view = renderBatch(data);
     const incremental = activeBatch ? summarize(activeBatch) : data.summary.incremental;
     activeSummary = incremental;
@@ -630,6 +639,27 @@ def _dashboard_state(state: Any) -> dict[str, Any]:
     return dict(value) if state_is_valid(value) else fresh_state()
 
 
+def _dashboard_path(state_path: Path) -> Path:
+    return state_path.with_name(
+        "dashboard-" + state_path.name.removeprefix("session-contract-")
+    )
+
+
+def _dashboard_state_for_path(state_path: Path) -> dict[str, Any]:
+    sidecar = _read_state(_dashboard_path(state_path))
+    if state_is_valid(sidecar):
+        return dict(sidecar)
+    # Compatibility for a viewer prepared by v0.80 before the sidecar split.
+    return _dashboard_state(_read_state(state_path))
+
+
+def _write_dashboard_state(state_path: Path, dashboard: dict[str, Any]) -> bool:
+    if not state_is_valid(dashboard):
+        return False
+    click_state.write_json(_dashboard_path(state_path), dashboard)
+    return True
+
+
 def _managed_state_path(path: Path) -> bool:
     return click_state.managed_state_path(path, ("session-contract-",))
 
@@ -674,8 +704,9 @@ def prepare(
     runtime = click_runtime_state.view(state)
     if not runtime.execution_authorized:
         return "", "Start Guarded or Evidence runtime state before opening its dashboard."
-    dashboard = _dashboard_state(state)
-    state_path = str(click_state.contract_path(event).resolve())
+    contract_path = click_state.contract_path(event).resolve()
+    dashboard = _dashboard_state_for_path(contract_path)
+    state_path = str(contract_path)
     if action == "status":
         return runner_command(
             event,
@@ -695,8 +726,7 @@ def prepare(
             ), ""
         dashboard["status"] = "stopping"
         dashboard["stop_requested"] = True
-        state[DASHBOARD_FIELD] = dashboard
-        click_contract_state.save_contract_state(event, state)
+        _write_dashboard_state(contract_path, dashboard)
         return runner_command(
             event,
             "run-dashboard-stop",
@@ -723,8 +753,7 @@ def prepare(
         "stop_requested": False,
         "last_error": "",
     }
-    state[DASHBOARD_FIELD] = dashboard
-    click_contract_state.save_contract_state(event, state)
+    _write_dashboard_state(contract_path, dashboard)
     return runner_command(
         event,
         "run-dashboard-start",
@@ -735,15 +764,13 @@ def prepare(
 
 
 def request_stop(event: dict[str, Any]) -> bool:
-    state = click_contract_state.read_contract_state(event)
-    dashboard = _dashboard_state(state)
+    state_path = click_state.contract_path(event).resolve()
+    dashboard = _dashboard_state_for_path(state_path)
     if dashboard["status"] not in {"starting", "running", "stopping"}:
         return False
     dashboard["status"] = "stopping"
     dashboard["stop_requested"] = True
-    state[DASHBOARD_FIELD] = dashboard
-    click_contract_state.save_contract_state(event, state)
-    return True
+    return _write_dashboard_state(state_path, dashboard)
 
 
 def _read_state(path: Path) -> dict[str, Any] | None:
@@ -757,28 +784,20 @@ def _read_state(path: Path) -> dict[str, Any] | None:
 def _write_dashboard_fields(
     path: Path, instance_id: str, **fields: Any
 ) -> bool:
-    state = _read_state(path)
-    if state is None:
-        return False
-    dashboard = _dashboard_state(state)
+    dashboard = _dashboard_state_for_path(path)
     if dashboard.get("instance_id") != instance_id:
         return False
     dashboard.update(fields)
     if not state_is_valid(dashboard):
         return False
-    state[DASHBOARD_FIELD] = dashboard
-    click_state.write_json(path, state)
-    return True
+    return _write_dashboard_state(path, dashboard)
 
 
 def _snapshot(path: Path, instance_id: str) -> tuple[dict[str, Any] | None, dict[str, Any]]:
-    state = _read_state(path)
-    if state is None:
-        return None, fresh_state()
-    dashboard = _dashboard_state(state)
+    dashboard = _dashboard_state_for_path(path)
     if dashboard.get("instance_id") != instance_id:
         return None, dashboard
-    return state, dashboard
+    return click_contract_state.read_projection_state_path(path), dashboard
 
 
 def run_start(
@@ -893,8 +912,7 @@ def run_status(arguments: list[str]) -> int:
     if not _managed_state_path(state_path):
         return 2
     with click_state.state_lock():
-        state = _read_state(state_path)
-        dashboard = _dashboard_state(state)
+        dashboard = _dashboard_state_for_path(state_path)
     sys.stdout.write(
         json.dumps(
             {
@@ -1061,8 +1079,7 @@ def run_server(arguments: list[str]) -> int:
             with click_state.state_lock():
                 state, dashboard = _snapshot(state_path, instance_id)
             if (
-                state is None
-                or dashboard.get("stop_requested") is True
+                dashboard.get("stop_requested") is True
                 or dashboard.get("status") != "running"
                 or not hmac.compare_digest(
                     str(dashboard.get("access_token_digest", "")), access_digest

--- a/hooks/click_verification.py
+++ b/hooks/click_verification.py
@@ -1001,6 +1001,123 @@ def _reuse_binding_reason(
     return "receipt-invalid"
 
 
+def _successor_binding_reason(
+    previous: dict[str, Any],
+    current: dict[str, Any],
+    *,
+    group_digest: str,
+    git_root: str,
+    environment_digest: str,
+    executable_digest: str,
+    host_coverage: dict[str, Any],
+) -> str:
+    """Validate a prior Evidence fact without pretending it is this lifecycle."""
+    if previous.get("verified_check_digest") != group_digest:
+        return "check-binding-changed"
+    if previous.get("verified_root") != git_root:
+        return "workspace-ambiguous"
+    if previous.get("verified_executable_digest") != executable_digest:
+        return "executable-binding-changed"
+    if previous.get("verified_environment_digest") != environment_digest:
+        return "environment-binding-changed"
+    if (
+        not click_host_coverage.receipt_is_current(host_coverage)
+        or previous.get("verified_host_coverage") != host_coverage
+    ):
+        return "host-coverage-binding-changed"
+    if previous.get("shard") != current.get("shard"):
+        return "check-binding-changed"
+    verified_at = previous.get("verified_at")
+    if (
+        previous.get("status") != "passed"
+        or previous.get("last_exit_code") != 0
+        or not isinstance(verified_at, int)
+        or isinstance(verified_at, bool)
+        or verified_at <= 0
+        or not isinstance(previous.get("verified_tree_digest"), str)
+        or re.fullmatch(r"[0-9a-f]{64}", previous["verified_tree_digest"])
+        is None
+    ):
+        return "successor-evidence-integrity-invalid"
+    return ""
+
+
+def _requalify_successor_baseline(
+    current: dict[str, Any],
+    previous: dict[str, Any],
+    *,
+    contract_digest: str,
+    revision: int,
+    group_digest: str,
+    units: int,
+    tree_digest: str,
+    environment_digest: str,
+    executable_digest: str,
+    host_coverage: dict[str, Any],
+    exact_tree: bool,
+) -> None:
+    """Create a new-lifecycle baseline only after explicit binding checks."""
+    current_shard = current.get("shard")
+    preserved = json.loads(json.dumps(previous))
+    current.clear()
+    current.update(preserved)
+    if current_shard is None:
+        current.pop("shard", None)
+    else:
+        current["shard"] = current_shard
+    current.update(
+        status="passed" if exact_tree else "stale",
+        verified_revision=revision if exact_tree else max(0, revision - 1),
+        attempts=0,
+        unchanged_failure_retries=0,
+        last_exit_code=0,
+        last_check_digest=group_digest,
+        locked_check_digest=group_digest,
+        reserved_units=units,
+        reserved_check_digest=group_digest,
+        verified_contract_digest=contract_digest,
+        verified_check_digest=group_digest,
+        verified_units=units,
+        verified_tree_digest=tree_digest if exact_tree else previous["verified_tree_digest"],
+        verified_environment_digest=environment_digest,
+        verified_executable_digest=executable_digest,
+        verified_host_coverage=dict(host_coverage),
+        dependency_reuse_count=0,
+        last_dependency_reused_at=0,
+        last_dependency_reused_from_revision=-1,
+        safe_change_reuse_count=0,
+        last_safe_change_reused_at=0,
+        last_safe_change_reused_from_revision=-1,
+        last_safe_change_paths=[],
+        last_safe_change_path_count=0,
+        last_safe_change_decision_digest="",
+        successor_reuse_count=0,
+        last_successor_reused_at=0,
+        last_successor_origin_batch_id="",
+        last_successor_origin_evidence_session_id="",
+        last_successor_candidate_digest="",
+        last_successor_origin_revision=-1,
+        last_successor_mode="",
+    )
+
+
+def _mark_successor_reuse(
+    source: dict[str, Any], metadata: dict[str, Any], *, mode: str
+) -> None:
+    source["successor_reuse_count"] = int(
+        source.get("successor_reuse_count", 0)
+    ) + 1
+    source["last_successor_reused_at"] = int(time.time()) or 1
+    source["last_successor_origin_batch_id"] = metadata["batch_id"]
+    source["last_successor_origin_evidence_session_id"] = metadata[
+        "evidence_session_id"
+    ]
+    source["last_successor_candidate_digest"] = metadata["candidate_digest"]
+    source["last_successor_origin_revision"] = metadata["origin_revision"]
+    source["last_successor_mode"] = mode
+    source["verified_at"] = int(time.time()) or 1
+
+
 def _observation_nonreuse_reason(observation: Any) -> str:
     if not click_dependency_cache.dependency_observation_is_valid(observation):
         return "observer-incomplete"
@@ -1798,6 +1915,7 @@ def _prepare_verification(
             trace.get("plan"), batch_id=request_id,
             revision=int(verification.get("mutation_revision", 0)), prepared_ms=elapsed,
             requested=trace.get("requested"), labels=trace.get("labels"),
+            reuse_origins=trace.get("reuse_origins"),
         )
         if click_incremental.store_batch(verification, batch):
             if result[1]:
@@ -2021,6 +2139,21 @@ def _prepare_verification_impl(
         if not str(source.get("reserved_check_digest", "")):
             source["reserved_check_digest"] = group_digests[source_key]
 
+    successor_candidates: dict[str, tuple[dict[str, Any], dict[str, Any]]] = {}
+    if runtime.evidence:
+        scope_digest = click_evidence.successor_scope_digest(
+            str(click_state.contract_path(event).resolve())
+        )
+        for source_key in requested_keys:
+            candidate = click_evidence.successor_candidate(
+                state,
+                source_key,
+                expected_contract_schema_version=CONTRACT_STATE_SCHEMA_VERSION,
+                scope_digest=scope_digest,
+            )
+            if candidate is not None:
+                successor_candidates[source_key] = candidate
+
     previous_revisions: dict[str, int] = {}
     reason_codes: dict[str, str] = {}
     not_evaluable_keys: set[str] = set()
@@ -2100,11 +2233,21 @@ def _prepare_verification_impl(
     reused_keys: set[str] = set()
     dependency_reused_keys: set[str] = set()
     safe_change_reused_keys: set[str] = set()
-    if current_requested or dependency_candidates or safe_change_candidates:
+    successor_origins: dict[str, dict[str, Any]] = {}
+    successor_imported: dict[str, dict[str, Any]] = {}
+    if (
+        current_requested
+        or dependency_candidates
+        or safe_change_candidates
+        or successor_candidates
+    ):
         snapshot = git_workspace_snapshot(workspace)
         if snapshot is None:
             for source_key in (
-                current_requested | dependency_candidates | safe_change_candidates
+                current_requested
+                | dependency_candidates
+                | safe_change_candidates
+                | set(successor_candidates)
             ):
                 reason_codes[source_key] = "workspace-ambiguous"
                 not_evaluable_keys.add(source_key)
@@ -2116,6 +2259,60 @@ def _prepare_verification_impl(
             contract_digest = str(state.get("contract_digest", ""))
             git_root = os.path.normcase(str(snapshot.get("root", "")))
             tree_digest = str(snapshot.get("digest", ""))
+            for source_key, (previous, metadata) in successor_candidates.items():
+                source = sources[source_key]
+                binding_reason = _successor_binding_reason(
+                    previous,
+                    source,
+                    group_digest=group_digests[source_key],
+                    git_root=git_root,
+                    environment_digest=current_environment_digests[source_key],
+                    executable_digest=current_executable_digests[source_key],
+                    host_coverage=host_coverage,
+                )
+                if binding_reason:
+                    reason_codes[source_key] = binding_reason
+                    if binding_reason in {
+                        "workspace-ambiguous",
+                        "successor-evidence-integrity-invalid",
+                    }:
+                        not_evaluable_keys.add(source_key)
+                    continue
+                exact_tree = previous.get("verified_tree_digest") == tree_digest
+                successor_imported[source_key] = json.loads(json.dumps(source))
+                _requalify_successor_baseline(
+                    source,
+                    previous,
+                    contract_digest=contract_digest,
+                    revision=revision,
+                    group_digest=group_digests[source_key],
+                    units=group_units[source_key],
+                    tree_digest=tree_digest,
+                    environment_digest=current_environment_digests[source_key],
+                    executable_digest=current_executable_digests[source_key],
+                    host_coverage=host_coverage,
+                    exact_tree=exact_tree,
+                )
+                previous_revisions[source_key] = metadata["origin_revision"]
+                successor_origins[source_key] = metadata
+                if exact_tree:
+                    current_requested.add(source_key)
+                elif source.get("verified_dependency_provider") in (
+                    click_dependency_cache.PROVIDER_NAMES
+                ):
+                    dependency_candidates.add(source_key)
+                elif (
+                    click_change_policy.receipt_is_valid(
+                        source.get("verified_safe_change_receipt")
+                    )
+                    and not source.get("verified_dependency_observation")
+                ):
+                    safe_change_candidates.add(source_key)
+                else:
+                    reason, not_evaluable = _default_incremental_reason(source)
+                    reason_codes[source_key] = reason
+                    if not_evaluable:
+                        not_evaluable_keys.add(source_key)
             mutation_boundary = verification.get("mutation_boundary")
             if (dependency_candidates or safe_change_candidates) and not (
                 isinstance(mutation_boundary, dict)
@@ -2195,9 +2392,15 @@ def _prepare_verification_impl(
                         host_coverage=host_coverage,
                     ):
                         reused_keys.add(source_key)
-                        reason_codes[source_key] = (
-                            "same-revision-receipt-current"
-                        )
+                        if source_key in successor_origins:
+                            _mark_successor_reuse(
+                                source, successor_origins[source_key], mode="exact"
+                            )
+                            reason_codes[source_key] = "successor-evidence-current"
+                        else:
+                            reason_codes[source_key] = (
+                                "same-revision-receipt-current"
+                            )
                     else:
                         reason_codes[source_key] = _reuse_binding_reason(
                             source,
@@ -2256,9 +2459,17 @@ def _prepare_verification_impl(
                         )
                         reused_keys.add(source_key)
                         dependency_reused_keys.add(source_key)
+                        if source_key in successor_origins:
+                            _mark_successor_reuse(
+                                source,
+                                successor_origins[source_key],
+                                mode="dependency",
+                            )
                         not_evaluable_keys.discard(source_key)
                         reason_codes[source_key] = (
-                            "observed-dependencies-unchanged"
+                            "successor-evidence-dependencies-unchanged"
+                            if source_key in successor_origins
+                            else "observed-dependencies-unchanged"
                         )
                     else:
                         binding_reason = _reuse_binding_reason(
@@ -2354,8 +2565,18 @@ def _prepare_verification_impl(
                         )
                         reused_keys.add(source_key)
                         safe_change_reused_keys.add(source_key)
+                        if source_key in successor_origins:
+                            _mark_successor_reuse(
+                                source,
+                                successor_origins[source_key],
+                                mode="safe-change",
+                            )
                         not_evaluable_keys.discard(source_key)
-                        reason_codes[source_key] = "safe-change-policy-covered"
+                        reason_codes[source_key] = (
+                            "successor-evidence-safe-change-covered"
+                            if source_key in successor_origins
+                            else "safe-change-policy-covered"
+                        )
                     else:
                         verification_advisories.append(preflight_advisory)
                         binding_reason = _reuse_binding_reason(
@@ -2378,6 +2599,11 @@ def _prepare_verification_impl(
                             reason_codes[source_key] = (
                                 "safe-change-policy-not-covered"
                             )
+
+    for source_key, original in successor_imported.items():
+        if source_key not in reused_keys:
+            sources[source_key].clear()
+            sources[source_key].update(original)
 
     unresolved_keys = {
         key for key in argv_keys if not _evidence_is_current(sources.get(key), revision)
@@ -2414,6 +2640,11 @@ def _prepare_verification_impl(
             for key, source in sources.items()
             if isinstance(source, dict)
             and click_evidence_shards.source_metadata_is_valid(source.get("shard"))
+        }
+        measurement["reuse_origins"] = {
+            key: successor_origins[key]
+            for key in reused_keys
+            if key in successor_origins
         }
 
     if not pending_keys:
@@ -3305,6 +3536,49 @@ def _record_incremental_start(path: Path, digest: str, token: str, source_key: s
         pass  # An unavailable telemetry write cannot execute a second command.
 
 
+def _record_incremental_completion(
+    path: Path,
+    digest: str,
+    token: str,
+    source_key: str,
+    *,
+    status: str,
+    reason: str,
+    duration_ms: int | float | None,
+    completed: bool = True,
+) -> None:
+    """Persist one source result while the claimed batch is still active."""
+    try:
+        with _state_lock():
+            if not _managed_contract_path(path):
+                return
+            state = json.loads(path.read_text(encoding="utf-8"))
+            verification = state.get("verification", {})
+            if (
+                verification.get("status") != "running"
+                or verification.get("last_batch_digest") != digest
+                or not verification.get("runner_claimed_at")
+                or not secrets.compare_digest(
+                    str(verification.get("runner_token_digest", "")),
+                    hashlib.sha256(token.encode()).hexdigest(),
+                )
+            ):
+                return
+            if click_incremental.mark_completed(
+                verification,
+                source_key,
+                status=status,
+                reason=reason,
+                duration_ms=duration_ms,
+                completed=completed,
+            ):
+                state["updated_at"] = int(time.time())
+                _write_json(path, state)
+    except Exception:
+        # Telemetry cannot repeat a check or change evidence authority.
+        pass
+
+
 def _run_verification(
     arguments: list[str],
     *,
@@ -3493,6 +3767,16 @@ def _run_verification(
                         status="interrupted" if exit_code == 130 else "failed" if exit_code != 0 else "passed" if group_completed else "running",
                         reason_code="command-interrupted" if exit_code == 130 else "command-failed" if exit_code != 0 else "command-passed",
                     )
+                    if source_results[source_key]["completed"]:
+                        _record_incremental_completion(
+                            state_path,
+                            batch_digest,
+                            runner_token,
+                            source_key,
+                            status=str(source_results[source_key]["status"]),
+                            reason=str(source_results[source_key]["reason_code"]),
+                            duration_ms=source_durations_ms.get(source_key),
+                        )
                 if exit_code != 0:
                     break
                 succeeded_count += 1
@@ -3502,6 +3786,15 @@ def _run_verification(
                 source_results[source_key].update(
                     status="interrupted", completed=True, reason_code="command-interrupted"
                 )
+                _record_incremental_completion(
+                    state_path,
+                    batch_digest,
+                    runner_token,
+                    source_key,
+                    status="interrupted",
+                    reason="command-interrupted",
+                    duration_ms=source_durations_ms.get(source_key),
+                )
             sys.stderr.write(
                 "[Click] Verification was interrupted. The active check was stopped "
                 "and recorded as non-passing.\n"
@@ -3510,7 +3803,17 @@ def _run_verification(
             exit_code = 2
             if source_key in source_results:
                 source_results[source_key].update(
-                    status="interrupted", completed=False, reason_code="command-error"
+                    status="unknown", completed=False, reason_code="command-error"
+                )
+                _record_incremental_completion(
+                    state_path,
+                    batch_digest,
+                    runner_token,
+                    source_key,
+                    status="unknown",
+                    reason="command-error",
+                    duration_ms=source_durations_ms.get(source_key),
+                    completed=False,
                 )
             sys.stderr.write("[Click] The command boundary failed; no check was repeated.\n")
 

--- a/skills/click/references/capability-protocol.md
+++ b/skills/click/references/capability-protocol.md
@@ -143,6 +143,15 @@ uses strict receipt v3 with the parent, complete child count, plan, relevant
 entry, inventory, and per-child lineage digests. Offline verification continues
 to accept legacy v1 and unsharded v2, and rejects incomplete v3 shard sets.
 
+A completion that actually reuses evidence requalified from an earlier Evidence
+task in the same host session and workspace uses receipt v4. It records the
+origin batch, origin Evidence session, candidate digest, origin revision, and
+the authoritative requalification mode (`exact`, `dependency`, or
+`safe-change`). If that completion also contains shards, v4 retains the same
+complete shard provenance required by v3. Merely retaining a successor
+candidate never selects v4 and never creates reuse authority. Offline
+verification accepts and validates v4 while retaining legacy v1-v3 support.
+
 If a host omits the working directory selected by a nested execution tool,
 export may recover it only from the sole canonical Git root shared by every
 current argv evidence source. A stale, missing, non-canonical, or conflicting

--- a/skills/click/references/evidence-shards-v1.md
+++ b/skills/click/references/evidence-shards-v1.md
@@ -113,6 +113,12 @@ parent check digests, shard id and complete shard count, plan, relevant entry,
 and inventory digests. Offline verification accepts legacy v1, unsharded v2,
 and sharded v3, and rejects a missing or inconsistent v3 shard member.
 
+If a later Evidence task actually reuses a requalified result, its completion
+receipt uses v4. A v4 receipt that contains shards preserves every complete
+per-source shard provenance field required by v3 and additionally binds the
+origin Evidence task and requalification lineage. Candidate retention alone is
+not reuse and does not change the receipt version.
+
 ## Deliberate exclusions
 
 Evidence Shards v1 does not provide zero-configuration framework discovery,

--- a/tests/click_gate_test_support.py
+++ b/tests/click_gate_test_support.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import os
 from pathlib import Path
@@ -97,6 +98,11 @@ def split_runner_command(command: str) -> list[str]:
 
 
 class ClickGateTestCase(unittest.TestCase):
+    # Most suites retain the executable boundary.  Large state-machine suites
+    # may opt into the equivalent in-process entry point and leave dedicated
+    # transport tests to cover stdin/stdout and interpreter startup.
+    hook_in_process = False
+
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()
         self.addCleanup(self.temporary.cleanup)
@@ -124,6 +130,31 @@ class ClickGateTestCase(unittest.TestCase):
     def run_hook(
         self, mode: str, event: dict
     ) -> tuple[subprocess.CompletedProcess[str], dict | None]:
+        if self.hook_in_process:
+            standard_input = io.StringIO(json.dumps(event))
+            standard_output = io.StringIO()
+            standard_error = io.StringIO()
+            environment = {
+                "PLUGIN_DATA": str(self.plugin_data),
+                "CLICK_CONFIG_HOME": str(self.plugin_data),
+            }
+            with (
+                mock.patch.dict(os.environ, environment, clear=False),
+                mock.patch.object(sys, "argv", [str(SCRIPT), mode]),
+                mock.patch.object(sys, "stdin", standard_input),
+                mock.patch.object(sys, "stdout", standard_output),
+                mock.patch.object(sys, "stderr", standard_error),
+            ):
+                returncode = CLICK_GATE.main()
+            stdout = standard_output.getvalue()
+            result = subprocess.CompletedProcess(
+                [sys.executable, str(SCRIPT), mode],
+                returncode,
+                stdout,
+                standard_error.getvalue(),
+            )
+            payload = json.loads(stdout) if stdout else None
+            return result, payload
         environment = os.environ.copy()
         environment["PLUGIN_DATA"] = str(self.plugin_data)
         environment["CLICK_CONFIG_HOME"] = str(self.plugin_data)

--- a/tests/test_click_contract_state.py
+++ b/tests/test_click_contract_state.py
@@ -162,6 +162,68 @@ class ClickContractStateTests(unittest.TestCase):
         self.assertIsNone(batch["sources"][0]["duration_ms"])
         self.assertFalse(click_state.contract_path(self.event).exists())
 
+    def test_cancel_keeps_completed_source_and_marks_only_active_and_future_sources(self) -> None:
+        decisions = [
+            click_incremental.decision(
+                source_key=str(index) * 64,
+                check_digest=str(index + 2) * 64,
+                decision="run",
+                reason_code="no-passing-evidence",
+                current_revision=1,
+                previous_revision=-1,
+                authority_source="runner",
+            )
+            for index in (1, 2, 3)
+        ]
+        verification: dict[str, object] = {}
+        click_incremental.store_batch(
+            verification,
+            click_incremental.new_batch(
+                click_incremental.build_plan(decisions, current_revision=1),
+                batch_id="a" * 32,
+                revision=1,
+                prepared_ms=1.5,
+            ),
+        )
+        click_incremental.mark_started(verification, "1" * 64)
+        click_incremental.mark_completed(
+            verification,
+            "1" * 64,
+            status="passed",
+            reason="command-passed",
+            duration_ms=11.25,
+        )
+        click_incremental.mark_started(verification, "2" * 64)
+        state = {
+            "status": "evidence",
+            "contract_digest": "4" * 64,
+            "runner_token": "must-not-survive",
+            "verification": verification,
+        }
+        click_contract_state.save_contract_state(self.event, state)
+
+        click_contract_state.clear_contract_state(self.event)
+
+        self.assertFalse(click_state.contract_path(self.event).exists())
+        archived = click_contract_state.read_contract_state(self.event)
+        self.assertEqual(archived["status"], "none")
+        self.assertNotIn("must-not-survive", json.dumps(archived))
+        batch = click_incremental.current_batch(archived["verification"])
+        assert batch is not None
+        first, second, third = batch["sources"]
+        self.assertEqual(
+            (first["status"], first["completed"], first["duration_ms"]),
+            ("passed", True, 11.25),
+        )
+        self.assertEqual(
+            (second["status"], second["completed"]),
+            ("interrupted", False),
+        )
+        self.assertEqual(
+            (third["status"], third["completed"]),
+            ("not-run", False),
+        )
+
     def test_runtime_domains_share_the_leaf_symbols(self) -> None:
         for module in (
             click_browser,

--- a/tests/test_click_efficiency.py
+++ b/tests/test_click_efficiency.py
@@ -65,10 +65,13 @@ assert.equal(doc.getElementById('mapMeta').textContent,'입력 48개 표시 · 1
 // Explicitly synthetic sensitive-field fixture, not a usable credential.
 const snapshot={generated_at:1000,summary:{shadow:{candidate_count:9}},private_token:'<example-private-value>'};
 const batch=JSON.parse(JSON.stringify(input.batch));batch.sources[0].label='</td><script>alert(1)</script>';
+batch.sources[0].reuse_origin={kind:'successor-evidence',batch_id:'a'.repeat(32),evidence_session_id:'evs_'+'b'.repeat(32),candidate_digest:'c'.repeat(64),origin_revision:7};
 api.setState(snapshot,batch,input.summary,safe);
 const report=api.shareReport();assert(!JSON.stringify(report).includes('<example-private-value>'));
 assert.equal(report.summary.authoritative_reuse_count,input.summary.authoritative_reuse_count);
+assert.equal(report.batch.sources[0].reuse_origin.origin_revision,7);
 const html=api.standaloneReport(report);assert(!html.includes('<script>'));assert(html.includes('&lt;script&gt;'));
+assert(html.includes('이전 배치 aaaaaaaaaaaa에서 재판정'));
 assert(!html.includes('src="http'));assert(!html.includes('href="http'));
 console.log('dashboard calculation, map limit, comparison validation and safe standalone export passed');
 """
@@ -208,6 +211,46 @@ class VerificationEfficiencyTests(unittest.TestCase):
         metrics.merge_history(state, copied)
         self.assertEqual(len(metrics.batch_history(copied)), 1)
         self.assertEqual(metrics.history_totals(copied)["executed_source_count"], 1)
+
+    def test_each_source_completion_is_visible_and_cancel_preserves_it(self):
+        state = self.verification(self.decision(1), self.decision(2))
+        self.assertTrue(metrics.mark_started(state, "1" * 64))
+        self.assertTrue(metrics.mark_completed(
+            state,
+            "1" * 64,
+            status="passed",
+            reason="command-passed",
+            duration_ms=17.5,
+        ))
+        self.assertTrue(metrics.mark_started(state, "2" * 64))
+
+        running = metrics.current_batch(state)
+        first, second = running["sources"]
+        self.assertEqual((first["status"], first["completed"]), ("passed", True))
+        self.assertEqual(first["duration_ms"], 17.5)
+        self.assertEqual((second["status"], second["completed"]), ("running", False))
+
+        self.assertTrue(metrics.interrupt_batch(state))
+        cancelled = metrics.current_batch(state)
+        first, second = cancelled["sources"]
+        self.assertEqual((first["status"], first["completed"]), ("passed", True))
+        self.assertEqual(first["duration_ms"], 17.5)
+        self.assertEqual((second["status"], second["completed"]), ("interrupted", False))
+        self.assertEqual(metrics.summary(state)["passed_source_count"], 1)
+
+    def test_duplicate_source_completion_is_idempotent_and_conflicts_are_rejected(self):
+        state = self.verification(self.decision(1))
+        metrics.mark_started(state, "1" * 64)
+        arguments = {
+            "status": "passed", "reason": "command-passed", "duration_ms": 8.25,
+        }
+        self.assertTrue(metrics.mark_completed(state, "1" * 64, **arguments))
+        original = json.dumps(state, sort_keys=True)
+        self.assertTrue(metrics.mark_completed(state, "1" * 64, **arguments))
+        self.assertEqual(json.dumps(state, sort_keys=True), original)
+        self.assertFalse(metrics.mark_completed(
+            state, "1" * 64, status="failed", reason="command-failed", duration_ms=8.25,
+        ))
 
     def test_storage_does_not_keep_mutable_aliases_or_expired_batches(self):
         state = self.verification(self.decision(1))

--- a/tests/test_click_gate_lifecycle.py
+++ b/tests/test_click_gate_lifecycle.py
@@ -24,6 +24,11 @@ from click_gate_test_support import (
 
 
 class ClickGateLifecycleTests(ClickGateTestCase):
+    # These tests exercise the lifecycle state machine.  The executable and
+    # encoded-runner boundaries remain covered by the dedicated gate/transport
+    # suites, so avoid paying for a fresh Python import on every hook event.
+    hook_in_process = True
+
     def test_manual_default_persists_and_keeps_uninvoked_mutations_fail_open(self) -> None:
         setting = self.set_default("manual")
         self.assertEqual(

--- a/tests/test_click_gate_verification.py
+++ b/tests/test_click_gate_verification.py
@@ -109,6 +109,150 @@ class ClickGateVerificationTests(ClickGateTestCase):
             envelope["receipt"]["authority"]["approval_bound"]
         )
 
+    def test_follow_up_evidence_requalifies_exact_success_and_records_origin(self) -> None:
+        (self.workspace / ".gitignore").write_text(
+            "__pycache__/\n", encoding="utf-8"
+        )
+        self.initialize_git(".gitignore", "verification_fixture.py")
+        command = self.verification_argv()
+        self.prompt_submit("첫 Evidence 작업", "turn-1")
+        first = self.verify_gate([command], "turn-1")
+        self.assertEqual(self.run_rewritten(first).returncode, 0)
+        state_path = next(
+            (self.plugin_data / "gate-state").glob("session-contract-*.json")
+        )
+        previous = json.loads(state_path.read_text(encoding="utf-8"))
+        previous_session = previous["evidence_session_id"]
+        previous_batch = previous["verification"]["incremental_batch_id"]
+
+        self.prompt_submit("후속 Evidence 작업", "turn-2")
+        successor = json.loads(state_path.read_text(encoding="utf-8"))
+        self.assertNotEqual(successor["evidence_session_id"], previous_session)
+        self.assertNotEqual(successor["intent_digest"], previous["intent_digest"])
+        self.assertNotIn("runner_token", successor["verification"])
+
+        reused = self.verify_gate([command], "turn-2")
+        rewritten = split_runner_command(
+            reused["hookSpecificOutput"]["updatedInput"]["command"]
+        )
+        self.assertNotIn("run-verification", rewritten)
+        current = json.loads(state_path.read_text(encoding="utf-8"))
+        plan = current["verification"]["incremental_plan"]
+        self.assertEqual(plan["decisions"][0]["decision"], "reuse-exact")
+        self.assertEqual(
+            plan["decisions"][0]["reason_code"], "successor-evidence-current"
+        )
+        batch = CLICK_VERIFICATION.click_incremental.current_batch(
+            current["verification"]
+        )
+        assert batch is not None
+        self.assertEqual(batch["sources"][0]["status"], "reused")
+        self.assertEqual(
+            batch["sources"][0]["reuse_origin"]["batch_id"], previous_batch
+        )
+        self.assertEqual(
+            batch["sources"][0]["reuse_origin"]["evidence_session_id"],
+            previous_session,
+        )
+
+        receipt = self.pre_tool(
+            "Bash", "click-gate receipt export", "turn-2", submit_prompt=False
+        )
+        assert receipt is not None
+        exported = self.run_rewritten(receipt)
+        self.assertEqual(exported.returncode, 0, exported.stderr)
+        body = json.loads(exported.stdout)["receipt"]
+        self.assertEqual(body["version"], 4)
+        lineage = body["evidence"][0]["lineage"]
+        self.assertEqual(lineage["mode"], "successor-reused")
+        self.assertEqual(lineage["origin_batch_id"], previous_batch)
+        self.assertEqual(lineage["origin_evidence_session_id"], previous_session)
+        self.assertEqual(lineage["requalification_mode"], "exact")
+
+    def test_follow_up_evidence_does_not_reuse_same_revision_for_changed_tree(self) -> None:
+        (self.workspace / ".gitignore").write_text(
+            "__pycache__/\n", encoding="utf-8"
+        )
+        self.initialize_git(".gitignore", "verification_fixture.py")
+        command = self.verification_argv()
+        self.prompt_submit("첫 Evidence 작업", "turn-1")
+        first = self.verify_gate([command], "turn-1")
+        self.assertEqual(self.run_rewritten(first).returncode, 0)
+
+        self.prompt_submit("후속 Evidence 작업", "turn-2")
+        with (self.workspace / "verification_fixture.py").open(
+            "a", encoding="utf-8"
+        ) as handle:
+            handle.write("\n# unobserved workspace drift\n")
+        repeated = self.verify_gate([command], "turn-2")
+        rewritten = split_runner_command(
+            repeated["hookSpecificOutput"]["updatedInput"]["command"]
+        )
+        self.assertIn("run-verification", rewritten)
+        state_path = next(
+            (self.plugin_data / "gate-state").glob("session-contract-*.json")
+        )
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        decision = state["verification"]["incremental_plan"]["decisions"][0]
+        self.assertIn(decision["decision"], {"run", "not-evaluable"})
+        batch = CLICK_VERIFICATION.click_incremental.current_batch(
+            state["verification"]
+        )
+        assert batch is not None
+        self.assertIsNone(batch["sources"][0]["reuse_origin"])
+
+    def test_follow_up_evidence_rechecks_command_binding(self) -> None:
+        (self.workspace / ".gitignore").write_text(
+            "__pycache__/\n", encoding="utf-8"
+        )
+        self.initialize_git(".gitignore", "verification_fixture.py")
+        command = self.verification_argv()
+        self.prompt_submit("첫 Evidence 작업", "turn-1")
+        first = self.verify_gate([command], "turn-1")
+        self.assertEqual(self.run_rewritten(first).returncode, 0)
+        self.prompt_submit("다른 검사 요구", "turn-2")
+
+        changed = [*command, "-v"]
+        repeated = self.verify_gate([changed], "turn-2")
+        self.assertIn(
+            "run-verification",
+            split_runner_command(
+                repeated["hookSpecificOutput"]["updatedInput"]["command"]
+            ),
+        )
+        state_path = next(
+            (self.plugin_data / "gate-state").glob("session-contract-*.json")
+        )
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        decision = state["verification"]["incremental_plan"]["decisions"][0]
+        self.assertEqual(decision["reason_code"], "check-binding-changed")
+
+    def test_follow_up_evidence_rechecks_environment_binding(self) -> None:
+        (self.workspace / ".gitignore").write_text(
+            "__pycache__/\n", encoding="utf-8"
+        )
+        self.initialize_git(".gitignore", "verification_fixture.py")
+        command = self.verification_argv()
+        self.prompt_submit("첫 Evidence 작업", "turn-1")
+        first = self.verify_gate([command], "turn-1")
+        self.assertEqual(self.run_rewritten(first).returncode, 0)
+        self.prompt_submit("환경이 달라진 후속 작업", "turn-2")
+
+        with mock.patch.dict(os.environ, {"CLICK_SUCCESSOR_VARIANT": "changed"}):
+            repeated = self.verify_gate([command], "turn-2")
+        self.assertIn(
+            "run-verification",
+            split_runner_command(
+                repeated["hookSpecificOutput"]["updatedInput"]["command"]
+            ),
+        )
+        state_path = next(
+            (self.plugin_data / "gate-state").glob("session-contract-*.json")
+        )
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        decision = state["verification"]["incremental_plan"]["decisions"][0]
+        self.assertEqual(decision["reason_code"], "environment-binding-changed")
+
     def test_verification_batch_has_no_fixed_check_count_cap(self) -> None:
         checks = [
             {
@@ -1461,6 +1605,144 @@ class ClickGateVerificationTests(ClickGateTestCase):
             self.assertEqual(CLICK_GATE._run_verification(tokens[5:]), 0)
             self.assertEqual(CLICK_GATE._run_verification(tokens[5:]), 2)
         self.assertEqual(execute.call_count, 1)
+
+    def test_runner_persists_each_group_before_starting_the_next_group(self) -> None:
+        (self.workspace / ".gitignore").write_text(
+            "__pycache__/\n", encoding="utf-8"
+        )
+        self.initialize_git(".gitignore", "verification_fixture.py")
+        self.prompt_submit("두 검증 묶음 실행", "turn-1")
+        command = self.verification_argv()
+        payload = self.verify_checks(
+            [
+                {"evidence_id": "E_ALPHA", "argv": command, "class": "targeted"},
+                {"evidence_id": "E_BETA", "argv": command, "class": "targeted"},
+            ],
+            turn_id="turn-1",
+            bind_default=False,
+        )
+        tokens = split_runner_command(
+            payload["hookSpecificOutput"]["updatedInput"]["command"]
+        )
+        state_path = Path(tokens[5])
+        alpha_key = CLICK_EVIDENCE.evidence_key("E_ALPHA")
+        beta_key = CLICK_EVIDENCE.evidence_key("E_BETA")
+        calls = 0
+
+        def execute(
+            _commands: list[list[str]], **_kwargs: object
+        ) -> int:
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                live = json.loads(state_path.read_text(encoding="utf-8"))
+                batch = CLICK_VERIFICATION.click_incremental.current_batch(
+                    live["verification"]
+                )
+                assert batch is not None
+                by_key = {item["source_key"]: item for item in batch["sources"]}
+                self.assertEqual(by_key[alpha_key]["status"], "passed")
+                self.assertTrue(by_key[alpha_key]["completed"])
+                self.assertIsNotNone(by_key[alpha_key]["duration_ms"])
+                self.assertEqual(by_key[beta_key]["status"], "planned")
+            return 0
+
+        environment = {
+            "PLUGIN_DATA": str(self.plugin_data),
+            "CLICK_CONFIG_HOME": str(self.plugin_data),
+        }
+        with (
+            mock.patch.dict(os.environ, environment),
+            mock.patch.object(
+                CLICK_VERIFICATION.Path, "cwd", return_value=self.workspace
+            ),
+        ):
+            result = CLICK_VERIFICATION.run(
+                tokens[5:],
+                file_content_digest=CLICK_VERIFICATION.file_content_digest,
+                git_workspace_snapshot=CLICK_VERIFICATION.git_workspace_snapshot,
+                git_metadata_present=CLICK_INSPECTION.git_metadata_present,
+                execute_commands=execute,
+                git_capture=CLICK_VERIFICATION.git_capture,
+            )
+        self.assertEqual(result, 0)
+        self.assertEqual(calls, 2)
+        completed = json.loads(state_path.read_text(encoding="utf-8"))
+        batch = CLICK_VERIFICATION.click_incremental.current_batch(
+            completed["verification"]
+        )
+        assert batch is not None
+        self.assertEqual(
+            {item["status"] for item in batch["sources"]}, {"passed"}
+        )
+
+    def test_late_completion_from_cancelled_batch_cannot_overwrite_successor_batch(self) -> None:
+        (self.workspace / ".gitignore").write_text(
+            "__pycache__/\n", encoding="utf-8"
+        )
+        self.initialize_git(".gitignore", "verification_fixture.py")
+        command = self.verification_argv()
+        self.prompt_submit("취소될 첫 작업", "turn-1")
+        first = self.verify_gate([command], "turn-1")
+        old_tokens = split_runner_command(
+            first["hookSpecificOutput"]["updatedInput"]["command"]
+        )
+        state_path = Path(old_tokens[5])
+        raw, error = CLICK_CAPABILITY.decode_encoded_request(
+            old_tokens[8], "verification"
+        )
+        self.assertEqual(error, "")
+        source_key = CLICK_EVIDENCE.evidence_key("E1")
+        environment = {
+            "PLUGIN_DATA": str(self.plugin_data),
+            "CLICK_CONFIG_HOME": str(self.plugin_data),
+        }
+        with (
+            mock.patch.dict(os.environ, environment),
+            mock.patch.object(CLICK_GATE.Path, "cwd", return_value=self.workspace),
+        ):
+            with CLICK_STATE.state_lock():
+                batch, claim_error = CLICK_GATE._claim_verification_run(
+                    state_path, raw, old_tokens[6], old_tokens[7]
+                )
+            self.assertEqual(claim_error, "")
+            self.assertIsNotNone(batch)
+            CLICK_VERIFICATION._record_incremental_start(
+                state_path, old_tokens[6], old_tokens[7], source_key
+            )
+            CLICK_GATE.click_contract_state.clear_contract_state(
+                {**self.base_event, "turn_id": "turn-1"}
+            )
+
+        self.prompt_submit("취소 뒤 새 작업", "turn-2")
+        second = self.verify_gate([command], "turn-2")
+        new_tokens = split_runner_command(
+            second["hookSpecificOutput"]["updatedInput"]["command"]
+        )
+        self.assertEqual(Path(new_tokens[5]), state_path)
+        before = state_path.read_bytes()
+
+        with mock.patch.dict(os.environ, environment):
+            CLICK_VERIFICATION._record_incremental_completion(
+                state_path,
+                old_tokens[6],
+                old_tokens[7],
+                source_key,
+                status="passed",
+                reason="command-passed",
+                duration_ms=9.5,
+            )
+
+        self.assertEqual(state_path.read_bytes(), before)
+        current = json.loads(before)
+        self.assertEqual(
+            current["verification"]["last_batch_digest"], new_tokens[6]
+        )
+        current_batch = CLICK_VERIFICATION.click_incremental.current_batch(
+            current["verification"]
+        )
+        assert current_batch is not None
+        self.assertEqual(current_batch["sources"][0]["status"], "planned")
 
     def test_verification_runner_rejects_prepared_workdir_mismatch(self) -> None:
         self.approve_contract()

--- a/tests/test_click_receipt.py
+++ b/tests/test_click_receipt.py
@@ -206,6 +206,43 @@ class ClickReceiptTests(unittest.TestCase):
         self.assertIsNone(rejected)
         self.assertIn("unsupported field", error)
 
+    def test_v4_binds_successor_origin_and_rejects_downgraded_lineage(self) -> None:
+        receipt = _valid_sharded_receipt()
+        receipt["version"] = 4
+        source = receipt["evidence"][0]  # type: ignore[index]
+        source["lineage"] = {
+            "mode": "successor-reused",
+            "from_revision": 9,
+            "dependency_digest": _digest("e"),
+            "origin_batch_id": "a" * 32,
+            "origin_evidence_session_id": "evs_" + "b" * 32,
+            "requalification_mode": "safe-change",
+        }
+
+        normalized, error = click_receipt.validate_receipt(receipt)
+
+        self.assertEqual(error, "")
+        assert normalized is not None
+        lineage = next(
+            item["lineage"]
+            for item in normalized["evidence"]
+            if item["lineage"]["mode"] == "successor-reused"
+        )
+        self.assertEqual(lineage["mode"], "successor-reused")
+        self.assertEqual(lineage["from_revision"], 9)
+
+        missing_origin = copy.deepcopy(receipt)
+        del missing_origin["evidence"][0]["lineage"]["origin_batch_id"]  # type: ignore[index]
+        rejected, error = click_receipt.validate_receipt(missing_origin)
+        self.assertIsNone(rejected)
+        self.assertIn("missing field", error)
+
+        downgraded = copy.deepcopy(receipt)
+        downgraded["version"] = 3
+        rejected, error = click_receipt.validate_receipt(downgraded)
+        self.assertIsNone(rejected)
+        self.assertIn("Successor-reused", error)
+
     def test_unknown_sensitive_or_self_referential_fields_fail_closed(self) -> None:
         for path, field in (
             ((), "runner_token"),

--- a/tests/test_click_shadow_dashboard.py
+++ b/tests/test_click_shadow_dashboard.py
@@ -50,7 +50,8 @@ class ClickShadowDashboardTests(ClickGateTestCase):
         instance_id, runner_token, access_token = tokens[action_index + 2 :]
         self.assertEqual(Path(tokens[action_index + 1]), state_path)
         state = json.loads(state_path.read_text(encoding="utf-8"))
-        dashboard = state[CLICK_SHADOW_DASHBOARD.DASHBOARD_FIELD]
+        dashboard_path = CLICK_SHADOW_DASHBOARD._dashboard_path(state_path)
+        dashboard = json.loads(dashboard_path.read_text(encoding="utf-8"))
 
         self.assertEqual(dashboard["instance_id"], instance_id)
         self.assertEqual(
@@ -89,8 +90,13 @@ class ClickShadowDashboardTests(ClickGateTestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         after = json.loads(state_path.read_text(encoding="utf-8"))
-        self.assertEqual(after["shadow_dashboard"]["status"], "stopping")
-        self.assertTrue(after["shadow_dashboard"]["stop_requested"])
+        dashboard = json.loads(
+            CLICK_SHADOW_DASHBOARD._dashboard_path(state_path).read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(dashboard["status"], "stopping")
+        self.assertTrue(dashboard["stop_requested"])
         self.assertEqual(
             after["verification"]["mutation_revision"],
             before["verification"]["mutation_revision"],
@@ -166,8 +172,9 @@ class ClickShadowDashboardTests(ClickGateTestCase):
         instance_id = "dashboard-instance-12345"
         access_token = hashlib.sha256(instance_id.encode()).hexdigest()
         with CLICK_STATE.state_lock():
-            state = json.loads(state_path.read_text(encoding="utf-8"))
-            state[CLICK_SHADOW_DASHBOARD.DASHBOARD_FIELD] = {
+            CLICK_STATE.write_json(
+                CLICK_SHADOW_DASHBOARD._dashboard_path(state_path),
+                {
                 "version": 1,
                 "status": "starting",
                 "instance_id": instance_id,
@@ -181,8 +188,8 @@ class ClickShadowDashboardTests(ClickGateTestCase):
                 "started_at": int(time.time()),
                 "stop_requested": False,
                 "last_error": "",
-            }
-            CLICK_STATE.write_json(state_path, state)
+                },
+            )
 
         results: list[int] = []
         environment = {
@@ -203,8 +210,11 @@ class ClickShadowDashboardTests(ClickGateTestCase):
         port = 0
         for _ in range(500):
             with CLICK_STATE.state_lock():
-                state = json.loads(state_path.read_text(encoding="utf-8"))
-                dashboard = state[CLICK_SHADOW_DASHBOARD.DASHBOARD_FIELD]
+                dashboard = json.loads(
+                    CLICK_SHADOW_DASHBOARD._dashboard_path(state_path).read_text(
+                        encoding="utf-8"
+                    )
+                )
             if dashboard["status"] == "running":
                 port = int(dashboard["port"])
                 break
@@ -254,13 +264,99 @@ class ClickShadowDashboardTests(ClickGateTestCase):
         self.assertEqual(method.exception.code, 405)
 
         with CLICK_STATE.state_lock():
-            state = json.loads(state_path.read_text(encoding="utf-8"))
-            state[CLICK_SHADOW_DASHBOARD.DASHBOARD_FIELD]["status"] = "stopping"
-            state[CLICK_SHADOW_DASHBOARD.DASHBOARD_FIELD]["stop_requested"] = True
-            CLICK_STATE.write_json(state_path, state)
+            dashboard_path = CLICK_SHADOW_DASHBOARD._dashboard_path(state_path)
+            dashboard = json.loads(dashboard_path.read_text(encoding="utf-8"))
+            dashboard["status"] = "stopping"
+            dashboard["stop_requested"] = True
+            CLICK_STATE.write_json(dashboard_path, dashboard)
         thread.join(timeout=3)
         self.assertFalse(thread.is_alive())
         self.assertEqual(results, [0])
+
+    def test_viewer_survives_next_evidence_task_and_cancel_as_history_only(self) -> None:
+        (self.workspace / ".gitignore").write_text(
+            "__pycache__/\n", encoding="utf-8"
+        )
+        self.initialize_git(".gitignore", "verification_fixture.py")
+        self.prompt_submit("첫 Evidence 작업", "turn-1")
+        start = self.pre_tool(
+            "Bash", "click-gate dashboard start", "turn-1", submit_prompt=False
+        )
+        assert start is not None
+        state_path = next(
+            (self.plugin_data / "gate-state").glob("session-contract-*.json")
+        ).resolve()
+        dashboard_path = CLICK_SHADOW_DASHBOARD._dashboard_path(state_path)
+        dashboard = json.loads(dashboard_path.read_text(encoding="utf-8"))
+        instance_id = dashboard["instance_id"]
+        dashboard.update(
+            status="running", runner_token_digest="", runner_claimed_at=1,
+            port=43219, pid=123,
+        )
+        CLICK_STATE.write_json(dashboard_path, dashboard)
+
+        first = self.verify_gate([self.verification_argv()], "turn-1")
+        self.assertEqual(self.run_rewritten(first).returncode, 0)
+        previous = json.loads(state_path.read_text(encoding="utf-8"))
+        previous_session = previous["evidence_session_id"]
+        previous_batch = previous["verification"]["incremental_batch_id"]
+
+        self.prompt_submit("다음 Evidence 작업", "turn-2")
+        current = json.loads(state_path.read_text(encoding="utf-8"))
+        self.assertNotEqual(current["evidence_session_id"], previous_session)
+        self.assertEqual(
+            json.loads(dashboard_path.read_text(encoding="utf-8"))["instance_id"],
+            instance_id,
+        )
+        projected_state, active = CLICK_SHADOW_DASHBOARD._snapshot(
+            state_path, instance_id
+        )
+        assert projected_state is not None
+        self.assertEqual(active["status"], "running")
+        self.assertEqual(
+            projected_state["verification"]["incremental_batch_id"],
+            previous_batch,
+        )
+
+        environment = {
+            "PLUGIN_DATA": str(self.plugin_data),
+            "CLICK_CONFIG_HOME": str(self.plugin_data),
+        }
+        with mock.patch.dict(os.environ, environment):
+            CLICK_GATE.click_contract_state.clear_contract_state(
+                {**self.base_event, "turn_id": "turn-2"}
+            )
+        history_only, still_active = CLICK_SHADOW_DASHBOARD._snapshot(
+            state_path, instance_id
+        )
+        assert history_only is not None
+        self.assertEqual(history_only["status"], "none")
+        self.assertEqual(still_active["status"], "running")
+        projection = (
+            CLICK_SHADOW_DASHBOARD.click_dashboard_projection.dashboard_projection(
+                history_only
+            )
+        )
+        self.assertTrue(
+            CLICK_SHADOW_DASHBOARD.click_dashboard_projection.projection_is_valid(
+                projection
+            )
+        )
+        self.assertEqual(projection["task"]["runtime_mode"], "unknown")
+        self.assertGreaterEqual(projection["history"]["retained_batch_count"], 1)
+
+        other_event = {
+            **self.base_event,
+            "session_id": "session-2",
+            "turn_id": "turn-1",
+        }
+        with mock.patch.dict(os.environ, environment):
+            other_path = CLICK_STATE.contract_path(other_event).resolve()
+        foreign_state, foreign_dashboard = CLICK_SHADOW_DASHBOARD._snapshot(
+            other_path, instance_id
+        )
+        self.assertIsNone(foreign_state)
+        self.assertEqual(foreign_dashboard, CLICK_SHADOW_DASHBOARD.fresh_state())
 
 
 if __name__ == "__main__":

--- a/tests/test_incremental_benchmark.py
+++ b/tests/test_incremental_benchmark.py
@@ -101,6 +101,52 @@ class IncrementalVerificationBenchmarkTests(unittest.TestCase):
             self.assertEqual(failed["reused_source_count"], 0)
             self.assertEqual(failed["estimated_avoided_ms"], 0)
 
+    def test_partial_reuse_uses_real_successor_evidence_and_runs_the_other_shard(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Fixture(
+                Path(directory), 20, mode="evidence", partial_policy=True
+            )
+            baseline = fixture.verify()
+            self.assertEqual(baseline["status"], "passed")
+            origin_session = fixture.state()["evidence_session_id"]
+
+            fixture.change("partial-reuse")
+            current_session = fixture.state()["evidence_session_id"]
+            self.assertNotEqual(current_session, origin_session)
+            result = fixture.verify()
+
+            self.assertEqual(result["status"], "passed")
+            self.assertEqual(result["executed_source_count"], 1)
+            self.assertEqual(result["reused_source_count"], 1)
+            self.assertEqual(result["not_run_source_count"], 0)
+            decisions = {
+                item["label"]: (
+                    item["decision"], item["status"], item["reason_code"]
+                )
+                for item in result["batch"]["sources"]
+            }
+            self.assertEqual(
+                decisions["alpha"],
+                (
+                    "reuse-safe-change",
+                    "reused",
+                    "successor-evidence-safe-change-covered",
+                ),
+            )
+            self.assertEqual(decisions["beta"][0:2], ("run", "passed"))
+            alpha = next(
+                item for item in result["batch"]["sources"]
+                if item["label"] == "alpha"
+            )
+            self.assertEqual(
+                alpha["reuse_origin"]["evidence_session_id"], origin_session
+            )
+            beta = next(
+                item for item in result["batch"]["sources"]
+                if item["label"] == "beta"
+            )
+            self.assertIsNone(beta["reuse_origin"])
+
     def test_negative_delta_zero_baseline_and_variation(self):
         self.assertEqual(comparison_delta(10, 15), {"delta_ms": -5, "delta_percent": -50})
         self.assertEqual(comparison_delta(0, 2), {"delta_ms": -2, "delta_percent": None})

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -46,7 +46,7 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
             (ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
         )
         self.assertEqual(manifest["name"], "click")
-        self.assertEqual(manifest["version"], "0.80.0")
+        self.assertEqual(manifest["version"], "0.81.0")
         self.assertEqual(manifest["license"], "MIT")
         combined_copy = " ".join(
             (
@@ -72,7 +72,7 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
         self.assertEqual(marketplace["name"], "click")
         self.assertEqual(marketplace["plugins"][0]["name"], "click")
         self.assertEqual(
-            marketplace["plugins"][0]["source"]["ref"], "v0.80.0"
+            marketplace["plugins"][0]["source"]["ref"], "v0.81.0"
         )
 
     def test_readmes_lead_with_incremental_verification_positioning(self) -> None:
@@ -353,13 +353,14 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
 
     def test_release_documents_identify_current_and_preserve_release_history(self) -> None:
         for readme in _readmes().values():
-            self.assertIn("v0.80.0", readme)
+            self.assertIn("v0.81.0", readme)
             self.assertIn("codex plugin marketplace upgrade click", readme)
             self.assertIn("codex plugin add click@click", readme)
             self.assertIn("RELEASE_NOTES.md", readme)
 
         notes = (ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8")
         for marker in (
+            "## v0.81.0",
             "## v0.80.0",
             "## v0.70.0",
             "## v0.60.0",


### PR DESCRIPTION
## Summary

- persist each verification bundle result before the next bundle starts, while preserving witnessed results across cancellation and rejecting late runner writes
- keep the read-only dashboard bound to the host session and workspace across successive Evidence tasks without carrying approval or execution authority
- retain completed Evidence results as candidates and requalify them through the existing authoritative exact, dependency, and committed safe-change rules
- add receipt v4 successor lineage, sanitized dashboard/report provenance, and a real partial-reuse benchmark
- move lifecycle state-machine Hook tests in-process while retaining separate subprocess transport coverage

## Verification

- full local suite: 660 tests passed; 5 platform-conditional skips
- release metadata and repository policy: 41 tests passed
- distribution validation passed
- Python compileall passed
- git diff --check passed

The real partial-reuse fixture produced one executed and one policy-reused bundle in every sample. Its checks are intentionally tiny, so Click overhead made the incremental arm slower; the negative measurements remain in the report and are not presented as a product speed claim.

Actual privileged macOS fs_usage and Windows ETW smoke tests are left to required hosted CI.