### PR TITLE
release: Click v0.81.1 Codex cache metadata

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/grapefruit0205/click.git",
-        "ref": "v0.81.0"
+        "ref": "v0.81.1"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "click",
-  "version": "0.81.0",
+  "version": "0.81.1",
   "description": "Incremental verification for coding agents: rerun affected checks and keep authoritative passing evidence reusable, with optional Guarded approval boundaries.",
   "author": {
     "name": "Junseok Pak",

--- a/README.ko.md
+++ b/README.ko.md
@@ -106,7 +106,7 @@ Guarded를 직접 선택할 수도 있습니다.
 
 ## 업데이트
 
-현재 릴리스: **v0.81.0**
+현재 릴리스: **v0.81.1**
 
 ~~~bash
 codex plugin marketplace upgrade click

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Or explicitly choose Guarded:
 
 ## Update
 
-Current release: **v0.81.0**
+Current release: **v0.81.1**
 
 ~~~bash
 codex plugin marketplace upgrade click

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -108,7 +108,7 @@ Evidence 模式下直接提出普通请求即可：
 
 ## 更新
 
-当前版本：**v0.81.0**
+当前版本：**v0.81.1**
 
 ~~~bash
 codex plugin marketplace upgrade click

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Release notes
 
+## v0.81.1 — 2026-09-06
+
+- Distribution validation now recognizes the exact
+  `+codex.<14-digit timestamp>` metadata used by installed Codex cache builds,
+  while continuing to validate release notes, README labels, and immutable
+  marketplace refs against the underlying stable release.
+- Regression coverage reproduces the installed-cache manifest rewrite and keeps
+  prerelease, generic build, malformed, and shortened Codex metadata rejected.
+
 ## v0.81.0 — 2026-09-05
 
 - Verification runners now persist each verification-group completion and duration

--- a/scripts/validate_distribution.py
+++ b/scripts/validate_distribution.py
@@ -24,9 +24,19 @@ except ModuleNotFoundError:
 
 
 ROOT = Path(__file__).resolve().parents[1]
-SEMVER = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+SEMVER = re.compile(
+    r"^(?P<release>(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*))"
+    r"(?:\+codex\.[0-9]{14})?$"
+)
 SKILL_NAME = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 README_NAMES = ("README.md", "README.ko.md", "README.zh-CN.md")
+
+
+def _release_version(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    match = SEMVER.fullmatch(value)
+    return match.group("release") if match is not None else ""
 
 
 def _release_notes_error(release_notes: str, version: str) -> str:
@@ -204,11 +214,14 @@ def validate(root: Path = ROOT) -> list[str]:
     if not isinstance(manifest, dict):
         return errors
     version = manifest.get("version")
+    release_version = _release_version(version)
     if manifest.get("name") != "click":
         errors.append("plugin name must be `click`")
-    if not isinstance(version, str) or SEMVER.fullmatch(version) is None:
-        errors.append("plugin version must be strict stable semver")
-        version = "invalid"
+    if not release_version:
+        errors.append(
+            "plugin version must be stable semver with optional Codex cache metadata"
+        )
+        release_version = "invalid"
     if manifest.get("license") != "MIT":
         errors.append("plugin license must be MIT")
     if _contains_todo(manifest):
@@ -233,8 +246,10 @@ def validate(root: Path = ROOT) -> list[str]:
             errors.append("marketplace plugin name must be `click`")
         if source.get("url") != "https://github.com/grapefruit0205/click.git":
             errors.append("marketplace must use Click's canonical Git URL")
-        if source.get("ref") != f"v{version}":
-            errors.append(f"marketplace ref must be immutable `v{version}`")
+        if source.get("ref") != f"v{release_version}":
+            errors.append(
+                f"marketplace ref must be immutable `v{release_version}`"
+            )
 
     for skill_name in ("click", "fix"):
         _validate_skill(root, skill_name, errors)
@@ -253,13 +268,13 @@ def validate(root: Path = ROOT) -> list[str]:
         errors.append("hooks/hooks.json must meter the canonical Browser MCP tool")
 
     release_notes = (root / "RELEASE_NOTES.md").read_text(encoding="utf-8")
-    release_error = _release_notes_error(release_notes, str(version))
+    release_error = _release_notes_error(release_notes, release_version)
     if release_error:
         errors.append(release_error)
     for readme_name in README_NAMES:
         readme = (root / readme_name).read_text(encoding="utf-8")
-        if f"v{version}" not in readme:
-            errors.append(f"{readme_name} must identify v{version}")
+        if f"v{release_version}" not in readme:
+            errors.append(f"{readme_name} must identify v{release_version}")
 
     for json_path in root.rglob("*.json"):
         _json(json_path, errors, root)

--- a/tests/test_distribution_validation.py
+++ b/tests/test_distribution_validation.py
@@ -3,12 +3,17 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+import shutil
 import subprocess
 import sys
 import tempfile
 import unittest
 
-from scripts.validate_distribution import _release_notes_error, validate
+from scripts.validate_distribution import (
+    _release_notes_error,
+    _release_version,
+    validate,
+)
 
 
 ROOT = Path(__file__).parents[1]
@@ -17,6 +22,39 @@ ROOT = Path(__file__).parents[1]
 class DistributionValidationTests(unittest.TestCase):
     def test_public_distribution_is_self_consistent(self) -> None:
         self.assertEqual(validate(ROOT), [])
+
+    def test_installed_codex_cache_version_keeps_release_metadata_valid(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            installed = Path(temporary) / "click"
+            shutil.copytree(
+                ROOT,
+                installed,
+                ignore=shutil.ignore_patterns(".git", "__pycache__", "*.pyc"),
+            )
+            manifest_path = installed / ".codex-plugin" / "plugin.json"
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["version"] = (
+                f"{manifest['version']}+codex.20260905161627"
+            )
+            manifest_path.write_text(
+                json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+            )
+
+            self.assertEqual(validate(installed), [])
+
+    def test_only_codex_timestamp_build_metadata_is_accepted(self) -> None:
+        self.assertEqual(_release_version("0.81.1"), "0.81.1")
+        self.assertEqual(
+            _release_version("0.81.1+codex.20260905161627"), "0.81.1"
+        )
+        for invalid in (
+            "0.81.1+codex.latest",
+            "0.81.1+codex.20260905",
+            "0.81.1+build.1",
+            "0.81.1-rc.1",
+        ):
+            with self.subTest(invalid=invalid):
+                self.assertEqual(_release_version(invalid), "")
 
     def test_source_and_antigravity_gate_load_only_sibling_runtime_modules(self) -> None:
         hook_directories = (

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -46,7 +46,7 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
             (ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
         )
         self.assertEqual(manifest["name"], "click")
-        self.assertEqual(manifest["version"], "0.81.0")
+        self.assertEqual(manifest["version"], "0.81.1")
         self.assertEqual(manifest["license"], "MIT")
         combined_copy = " ".join(
             (
@@ -72,7 +72,7 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
         self.assertEqual(marketplace["name"], "click")
         self.assertEqual(marketplace["plugins"][0]["name"], "click")
         self.assertEqual(
-            marketplace["plugins"][0]["source"]["ref"], "v0.81.0"
+            marketplace["plugins"][0]["source"]["ref"], "v0.81.1"
         )
 
     def test_readmes_lead_with_incremental_verification_positioning(self) -> None:
@@ -353,13 +353,14 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
 
     def test_release_documents_identify_current_and_preserve_release_history(self) -> None:
         for readme in _readmes().values():
-            self.assertIn("v0.81.0", readme)
+            self.assertIn("v0.81.1", readme)
             self.assertIn("codex plugin marketplace upgrade click", readme)
             self.assertIn("codex plugin add click@click", readme)
             self.assertIn("RELEASE_NOTES.md", readme)
 
         notes = (ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8")
         for marker in (
+            "## v0.81.1",
             "## v0.81.0",
             "## v0.80.0",
             "## v0.70.0",


### PR DESCRIPTION
## Summary

- accept only the observed installed Codex cache suffix form: +codex.<14-digit timestamp>
- validate release notes, README release labels, and immutable marketplace refs against the underlying stable version
- add installed-cache regression coverage and reject prerelease, generic build, malformed, and shortened suffixes
- prepare the v0.81.1 manifest, marketplace ref, localized README labels, and release notes

## Verification

- python3 -m unittest tests.test_distribution_validation tests.test_repository_policy -q (43 tests passed)
- python3 -m unittest discover -s tests -q (662 tests passed, 5 documented skips)

## Live reproduction

The installed 0.81.0+codex.20260905161627 cache build loaded and passed the Codex host routing suite, but source distribution validation treated the cache suffix as invalid and produced vinvalid release-reference errors. This patch keeps source release metadata pinned to v0.81.1 while making that installed-cache validation path pass.