### PR TITLE
release: Click v0.82.0 guarded verification continuity

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/grapefruit0205/click.git",
-        "ref": "v0.81.1"
+        "ref": "v0.82.0"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "click",
-  "version": "0.81.1",
+  "version": "0.82.0",
   "description": "Incremental verification for coding agents: rerun affected checks and keep authoritative passing evidence reusable, with optional Guarded approval boundaries.",
   "author": {
     "name": "Junseok Pak",

--- a/COMMUNITY_POSTS.md
+++ b/COMMUNITY_POSTS.md
@@ -1,127 +1,90 @@
-# Click community launch posts
+# Click community drafts
 
-These drafts deliberately describe implemented behavior, not unmeasured gains in accuracy, speed, or token use.
-
-## English — Reddit, Discord, forum
-
-### Title
-
-**I built a Codex plugin that binds AI execution to approved intent and evidence**
-
-### Post
-
-Powerful coding models can finish difficult work, but they can also spend too much time rewriting the plan, rereading the same files, rescanning the repository, and running one more test suite.
-
-I built **Click**, an MIT-licensed Codex plugin with a deliberately small workflow:
-
-> Approve the intent once. Bind execution to it. Return evidence for what actually ran.
-
-On first use, you choose **Always ON** or **Manual**.
-
-- Always ON applies Click only to software-changing requests.
-- Manual applies it when you mention `@Click`.
-- Questions, explanations, and simple read-only inspection stay normal.
-- Code review needs no build contract. The read-only guard keeps mutation blocked while fresh repeated observations and distinct broad inventories remain available with non-blocking reuse or narrowing guidance.
-
-For a code change, Click turns the request and repository context into one compact contract: outcome, boundary, must-hold behavior, build approach, verification scale, and a plain-language explanation. It stages and shows that contract, then requires a later user turn for the one approval. After that, the Hook rejects replacement contracts and unauthorized mutations, binds one-use runners to exact requests, and records revision-bound evidence. Plan tools remain available as non-blocking, non-authoritative guidance.
-
-Click v0.21 binds each approved completion source to current-revision Hook state. Every local argv check names the exact evidence ID it proves; Browser work is observed and then explicitly finalized; hosted, manual, and existing sources remain explicit attestations rather than independently proven external events. Once every declared source is current and no managed service remains active, Click stops. A contract with no argv source no longer runs an unrelated local test merely for ceremony. This is a local workflow guard—not a security sandbox or a measured claim of faster or more accurate results.
-
-This is not a claim that Click invents better architecture than the model. The model already knows how to design software. Click's job is narrower: bind observable execution to one approved boundary and return evidence without treating model workflow strategy as authority.
-
-I built it for:
-
-- users who need approval, side-effect authority, and completion evidence to survive long autonomous runs;
-- MVPs, internal tools, automations, and clearly bounded features where minimum design followed by continuous implementation matters more than a large spec process.
-
-What is verified: deterministic Hook behavior, contract structure, and the repository test suite. What is not yet proven: that Click improves accuracy, total time, or token use across real projects. Those product-level effects require independent measurement on unrelated real repositories.
-
-Install:
-
-```bash
-codex plugin marketplace add grapefruit0205/click
-codex plugin add click@click
-```
-
-Already using Click? v0.21 requires an explicit refresh and reinstall:
-
-```bash
-codex plugin marketplace upgrade click
-codex plugin add click@click
-```
-
-Restart the ChatGPT desktop app and start a new task after reviewing the updated Hook.
-
-Repository: https://github.com/grapefruit0205/click
-
-I would especially value feedback from people who need to leave an agent running after one approval. Which authorization or evidence guarantee is still missing, and which advisory feels too opinionated?
-
-## English — Show HN
-
-### Title
-
-**Show HN: Click – bind AI execution to approved intent and return evidence**
-
-### Opening
-
-I built Click, an MIT-licensed Codex plugin for a narrower runtime problem: a capable model can implement the feature, but approval, side-effect authority, and completion evidence still need guarantees outside the model.
-
-Click asks for one compact, plain-language approval before code changes, then uses local lifecycle Hooks to bind a short opaque `contract_id` to the staged digest, reject replacement contracts and unauthorized mutations, and record only the approved completion evidence needed for the current revision. The later approval sends only that id instead of reconstructing the contract JSON. Versioned argv-based inspect, mutate, service, and verify runners make supported command intent explicit and run without a shell. Plan tools remain non-blocking and non-authoritative. Its Always ON mode applies only to software mutations; questions and simple inspection remain normal, while code review gets a separate read-only guard without a build contract.
-
-It is intentionally smaller than a full spec-driven workflow. I am not claiming measured accuracy or token improvements yet; the current evidence is deterministic enforcement and tests. I would like feedback on whether this boundary-first, anti-loop workflow solves a real problem or merely moves prompt ceremony into a plugin.
-
-Repository: https://github.com/grapefruit0205/click
+Local drafts, not published posts. The Guarded successor work described here is
+part of the v0.82.0 release.
+Attach the generated report and its engine/source identity when sharing measured
+results; never substitute an avoided-rerun-cost estimate for a measured saving.
 
 ## 한국어 — 개발자 커뮤니티
 
 ### 제목
 
-**승인한 의도에 AI 실행을 결속하고 증거를 돌려주는 Codex 플러그인을 만들었습니다**
+Click: 시키지 않은 범위 확장은 억제하고, 유효한 검증은 다시 기다리지 않도록
 
 ### 본문
 
-성능 좋은 코딩 모델은 어려운 기능도 구현할 수 있지만, 이미 정한 계획을 다시 만들고 같은 파일을 다시 읽고 저장소 전체를 다시 훑고 테스트를 하나 더 돌리느라 오래 걸릴 때가 있습니다.
+Click은 코딩 에이전트가 실제로 실행한 검증과 현재 적용 가능한 근거를 기록하는
+MIT 라이선스 플러그인입니다. 기본 Evidence 모드는 Click 승인 절차를 추가하지
+않고 호스트의 권한으로 작업합니다. Guarded를 선택하면 결과·포함/제외 범위·불변조건을
+쉬운 계약으로 검토하고, 다음 사용자 턴에서 정확한 계약 ID를 승인합니다.
 
-그래서 **Click**이라는 MIT 라이선스 Codex 플러그인을 만들었습니다.
+v0.82.0은 완료된 계약 A의 성공 결과를 새 계약 B에 **후보로만** 전달합니다.
+B는 별도로 승인해야 하며, 정확한 검사와 코드·환경·실행 파일·알려진 Hook 범위,
+기존 의존성 근거 또는 사전에 커밋한 정책을 다시 확인합니다. 무관 코드 변경에는
+유효한 묶음만 이어받고 관련 입력이나 환경이 바뀌면 실제로 다시 검사합니다.
+승인·runner token·미완료 작업·완료 상태를 넘기는 기능은 아닙니다.
 
-> 의도를 한 번 승인하고, 실행을 그 의도에 결속하고, 실제 수행 증거를 돌려받습니다.
+대시보드 첫 화면에는 이번 약속과 승인, 실제 실행·재사용·실패·미시작, 재실행 비용
+회피 추정과 비교 실측 여부를 함께 표시합니다. 과거 계약의 작업명에서 원본 검증과
+재사용 이유를 펼쳐볼 수 있습니다. 관측된 승인 전 거부와 비차단 지침을 구분하며,
+정책을 느슨하게 만들어 cache hit를 늘리라고 권하지 않습니다.
 
-처음 사용할 때 **Always ON** 또는 **Manual**을 한 번 선택합니다.
+재현 데모는 독립 fixture의 실제 Hook과 runner를 사용합니다. 기존 전체 검증,
+추가 재사용 설정 없는 Guarded, 사전 샤드·무관 코드 정책을 선언한 Guarded의 같은
+일곱 단계를 비교합니다. 최초 실행, 무관/관련 코드 변경, 환경 변경, 실패, 수정 후
+재시도와 변경 없는 반복을 포함하고 매 단계 같은 상태의 전체 검증과 대조합니다.
+fixture의 승인 모사를 개발 세션의 실제 승인으로 쓰지 않습니다.
 
-- Always ON은 소프트웨어를 실제로 바꾸는 요청에만 적용됩니다.
-- Manual은 `@Click`을 멘션했을 때만 적용됩니다.
-- 질문·설명·단순 조회는 평소처럼 처리합니다.
-- 코드 리뷰는 구현 계약 없이 진행합니다. 읽기 전용 안전망은 mutation을 막고 동일 관찰을 재사용하며, 서로 다른 broad inventory에는 비차단 범위 축소 안내를 제공합니다.
+~~~sh
+python3 benchmarks/incremental_verification.py --guarded-workflow --iterations 3 --warmups 1 --workload-rounds 40000 --output /tmp/click-workflow.json --html-output /tmp/click-workflow.html
+~~~
 
-코드 변경 요청에서는 저장소 맥락을 바탕으로 결과, 범위, 반드시 지킬 동작, 최소 구현 경로, 검증 규모, 쉬운 설명을 하나의 축약 계약으로 만듭니다. 계약을 stage해 보여준 뒤 다음 사용자 turn의 승인 한 번을 기다립니다. 승인하면 Hook이 대체 계약과 무권한 mutation을 막고, one-use runner를 정확한 요청에 결속하며, revision에 결속된 evidence를 기록합니다. plan tool은 비차단·비권한 advisory로 계속 사용할 수 있습니다.
+워밍업·반복·OS 캐시 미초기화·추가 승인/준비/감사 비용을 공개하며, 짧은 검사에서
+관리 비용 때문에 느려지는 음수 결과도 그대로 남깁니다. 재사용 그룹 비율은 테스트
+케이스 절감률이 아니며, 부분 계측과 회피 비용 추정을 토큰·요금·개발시간으로
+환산하지 않습니다. 표본이 전체 검증과 일치한 것은 보편적 안전성 증명이 아닙니다.
 
-Click v0.21은 승인한 완료 근거를 현재 코드 revision의 Hook 상태와 각각 연결합니다. local argv check는 자신이 증명하는 evidence ID를 정확히 지정하고, Browser 작업은 관찰된 뒤 명시적으로 finalize합니다. hosted·manual·existing은 외부 사실을 독립적으로 증명하는 장치가 아니라 명시적인 attestation으로 남습니다. 선언된 근거가 모두 current이고 관리 서비스가 활성 상태가 아니면 즉시 멈추며, argv 근거가 없는 계약에 형식적인 local test를 추가하지 않습니다. 모든 도구를 완벽히 막는 보안 샌드박스나 더 빠르고 정확하다는 측정된 주장은 아닙니다.
+Click은 의미적 범위 준수나 과추론을 완전히 차단하는 엔진, OS 보안 샌드박스,
+테스트 충분성 증명이 아닙니다. 관측 가능한 권한·실행·증거 경계를 지키는 도구입니다.
+서명 없는 영수증은 무결성을 검사할 뿐 발행자 신원을 인증하지 않습니다.
 
-Click이 모델보다 더 좋은 아키텍처를 발명한다고 주장하지는 않습니다. 모델은 이미 소프트웨어 설계를 할 수 있습니다. Click의 역할은 더 좁습니다. **사용자가 승인한 경계에 관찰 가능한 실행을 결속하고 실제 수행 evidence를 돌려주는 것**입니다.
+어떤 승인·검증 경계가 실제 작업에 도움이 되고, 어떤 비용이 더 드는지 피드백을
+듣고 싶습니다. [저장소](https://github.com/grapefruit0205/click) ·
+[측정 조건과 한계](VERIFICATION_EFFICIENCY.md)
 
-주요 대상은 다음과 같습니다.
+## English — forum / Show HN
 
-- 승인 한 번 후에도 권한·side effect·완료 evidence가 보존되는 장시간 자율 실행이 필요한 사용자
-- 큰 명세 절차보다 최소설계 뒤 바로 구현하는 MVP·내부 도구·자동화·명확한 기능 추가가 중요한 사용자
+### Title
 
-현재 결정적 Hook 동작, 계약 구조, 저장소 테스트는 검증했습니다. 하지만 실제 프로젝트 전반에서 정확도·전체 시간·토큰이 개선되는지는 아직 증명하지 않았으며, 서로 관련 없는 실제 저장소에서 독립적으로 측정해야 합니다.
+Click: keep work in its approved boundary and carry valid verification forward
 
-설치:
+### Post
 
-```bash
-codex plugin marketplace add grapefruit0205/click
-codex plugin add click@click
-```
+Click records what a coding agent actually verified. Evidence is the default:
+host-authorized work without a Click approval ceremony. Opt-in Guarded presents
+one readable scope contract and requires its exact id in a later approval turn.
 
-기존 Click 사용자는 v0.21을 사용하려면 명시적으로 마켓플레이스를 갱신하고 플러그인을 다시 설치해야 합니다.
+The v0.82.0 release lets a completed Guarded contract A supply successful
+check candidates to a separately approved B. B requests and requalifies them
+against current execution bindings and existing dependency evidence or an
+unchanged policy committed before the baseline. Unrelated code can allow partial
+reuse; related inputs, changed environments, and new checks run. Approval,
+tokens, unfinished commands, and completion do not carry forward.
 
-```bash
-codex plugin marketplace upgrade click
-codex plugin add click@click
-```
+The result-first dashboard separates real group outcomes, prior-contract
+provenance, estimated avoided rerun cost, partial request timing, and independently
+measured comparisons. Observed denials are not semantic scope judgments.
 
-갱신된 Hook을 검토한 뒤 ChatGPT 데스크톱 앱을 다시 시작하고 새 작업을 시작하세요.
+The command above compares no Click, Guarded with default reuse configuration,
+and explicit precommitted shards/policy in independent real Hook/runner fixtures.
+It includes failure and repair, rotates configuration order, records warmups and
+extra setup/transition/audit costs, and checks every state with the full suite.
+Negative differences remain visible: short checks can be slower with Click.
 
-저장소: https://github.com/grapefruit0205/click
+This is a workflow guardrail, not a sandbox or a claim to prevent all overthinking,
+scope drift, or incorrect code. Fixture agreement is not universal safety;
+avoided-cost estimates are not measured net savings, tokens, fees, or developer
+time. Please share the generated report with its conditions and unsigned source
+identity, not an unsupported speed claim.
 
-비슷한 문제를 겪어 보셨다면 어떤 안전망은 유용하고 어떤 부분은 지나치게 제한적인지 솔직한 의견을 듣고 싶습니다.
+[Source](https://github.com/grapefruit0205/click) · [Measurement reference](VERIFICATION_EFFICIENCY.md)

--- a/GUARD_CLASSIFICATION.md
+++ b/GUARD_CLASSIFICATION.md
@@ -11,6 +11,12 @@ not claim that every hard gate has already been moved to its target layer.
 
 ## CORE
 
+Guarded successor candidate capture and current-contract requalification are
+Core evidence boundaries (`click_lifecycle`, `click_evidence`,
+`click_verification`, receipt v5). They never convey approval or runner claims.
+Display summaries, observed denial/advisory counts, group rates and partial
+timing are non-authoritative telemetry, not semantic scope enforcement.
+
 | Guard or invariant | Current owner | Why it remains Core |
 | --- | --- | --- |
 | Authority-mode identity, Evidence intent/follow-up lineage, and Guarded contract validation, digest, ID, later-turn approval, session and working-directory identity | `hooks/click_contract.py`; typed scalar projection in `hooks/click_runtime_state.py`; mode and authority lifecycle in `hooks/click_lifecycle.py` | Prevents receipts from claiming approval in Evidence and prevents mutation under a substituted or unapproved Guarded intent |

--- a/PRODUCT_CONSTITUTION.md
+++ b/PRODUCT_CONSTITUTION.md
@@ -107,6 +107,14 @@ In **Guarded authority**, Core additionally guarantees:
 Host adapters may normalize host events and output formats. They may not weaken
 the Core identity, authorization, runner-binding, or receipt invariants.
 
+Completed Guarded work may carry successful candidates, never approval,
+runner tokens, unfinished work or completion, into a separately approved
+successor contract. Current check/input/environment/coverage and existing
+dependency or precommitted policy bindings must requalify every applied reuse.
+Receipt v5 records that lineage without changing Evidence or legacy authority.
+Local display summaries, observed control-event telemetry and partial timing
+remain HEURISTIC: they neither judge semantic scope nor authorize execution.
+
 ## Outside Core
 
 The following are not Click Core responsibilities:

--- a/README.ko.md
+++ b/README.ko.md
@@ -7,9 +7,11 @@
 [![CI](https://github.com/grapefruit0205/click/actions/workflows/ci.yml/badge.svg)](https://github.com/grapefruit0205/click/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-> 코드가 조금 바뀔 때마다 전체 검증 대신 영향을 받은 검사만 다시 실행합니다.
+> 시키지 않은 범위 확장은 억제하고, 유효한 검증은 다시 기다리지 않도록.
 
-Click의 핵심은 **Incremental verification for coding agents**입니다. 통과한 검사가 의존하는 코드가 실제로 바뀔 때까지 그 결과를 재사용할 수 있게 관리합니다. 이 판단은 모델의 추측이 아니라 **revision-aware evidence**에 남습니다.
+Click은 코딩 에이전트를 위한 증분 검증(Incremental verification)을 제공합니다. Guarded 계약으로 승인 범위를 명확히 하고, **revision-aware evidence**로 새 작업에서도 유효한 검증을 이어갑니다. 변경 뒤 재사용하려면 실행 조건 일치와 완전한 의존성 관찰 또는 기준 실행 전에 커밋한 명시적 정책이 필요합니다. 근거가 없으면 실제로 다시 실행하며 의존성을 자동 발견했다고 주장하지 않습니다.
+
+릴리스 안내: v0.82.0에는 여기 설명한 Guarded 후속 계약 재검증·영수증 v5·결과 중심 대시보드가 포함됩니다.
 
 Click은 코드가 올바르거나 선택한 테스트가 충분하다고 증명하지 않습니다. 기존 검증 결과가 현재 코드에도 적용되는지만 추적합니다.
 
@@ -106,7 +108,7 @@ Guarded를 직접 선택할 수도 있습니다.
 
 ## 업데이트
 
-현재 릴리스: **v0.81.1**
+현재 릴리스: **v0.82.0**
 
 ~~~bash
 codex plugin marketplace upgrade click
@@ -184,7 +186,19 @@ click-gate receipt export
 click-gate receipt verify ./completion-receipt.json
 ~~~
 
-영수증에는 요청 흐름, mutation revision, 최종 workspace, 검사 결과, 환경, 실행 파일, host coverage, 재사용 이력이 묶입니다. 후속 Evidence 작업에서 재판정해 재사용한 경우 v4 lineage가 원래 Evidence session과 batch, 재판정 방식 및 후보 digest를 기록합니다.
+영수증에는 요청 흐름, mutation revision, 최종 workspace, 검사 결과, 환경, 실행 파일, host coverage, 재사용 이력이 묶입니다. Evidence 후속 재사용은 v4, Guarded 후속 재사용은 v5로 원본 계약·검증 배치·revision·재판정 방식·후보 digest를 기록합니다. 후보 보관만으로 v5가 되지는 않으며 v1–v4 호환성과 완전한 shard 계보를 유지합니다.
+
+## 새 계약에서도 유효한 검증 이어받기
+
+A가 완전히 끝난 후 B를 새 ID로 stage하고 별도 사용자 턴에서 승인합니다. 과거 성공은 후보일 뿐이며 B의 정확한 요청과 현재 조건으로 재판정합니다. 사전 정책이 허용한 무관 코드 변경에는 일부 재사용, 관련 입력·환경 변경과 신규 검사에는 실제 실행으로 돌아갑니다. 승인·runner token·미완료 작업·완료 상태는 승계하지 않습니다. 의미적 범위 준수나 과추론을 완전히 막는 엔진은 아닙니다.
+
+~~~sh
+python3 benchmarks/incremental_verification.py --guarded-workflow --iterations 3 --warmups 1 --workload-rounds 40000 --output /tmp/click-workflow.json --html-output /tmp/click-workflow.html
+~~~
+
+독립 fixture에서 기존 전체 검증·추가 재사용 설정 없는 Guarded·사전 정책과 샤드를 선언한 Guarded를 비교합니다. 제품의 기본 모드는 여전히 Evidence입니다. 최초 실행, 무관/관련 코드, 환경, 실패/수정/재시도를 모두 수행하며 매 단계 같은 상태의 전체 검증과 대조합니다. v3 세 구성 결과는 독립 HTML로 열고, 기존 dashboard importer는 v2 쌍별 비교 JSON을 받습니다. 워밍업·반복·추가 비용·음수 결과를 숨기지 않으며 개발 세션 승인이나 보편적 안전성 증명이 아닙니다.
+
+첫 화면에는 약속·승인·그룹 결과·재실행 비용 회피 추정·비교 실측 여부를 표시합니다. 로컬에는 제한된 계약 표시 문구가 남지만 권한 판단에 쓰지 않고, 공유본에서는 계약 문구·원시 명령·입력 경로·환경 값을 제외합니다. 표시 필터를 완전한 비밀 탐지기로 간주하지 마세요. 요청 시간은 Hook 진입→결과 기록의 부분 계측이며 호스트 전체 대기가 아닙니다. [계측 조건과 한계](VERIFICATION_EFFICIENCY.md).
 
 현재 검증 결과는 **unsigned-integrity-only**입니다. 영수증이 바뀌었는지는 확인하지만 발행자 신원까지 증명하지는 않습니다.
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@
 
 English | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)
 
-> Incremental verification for coding agents.
+> Keep work inside the approved boundary, and keep valid verification reusable.
 
-Click keeps passing checks reusable until the code they depend on actually changes. Its **revision-aware evidence** lets the runtime rerun only the checks affected by the current edit instead of blindly repeating the whole verification set.
+Click provides incremental verification for coding agents. It helps constrain unrequested scope expansion through a reviewed Guarded contract, while **revision-aware evidence** lets valid checks survive a new task. Reuse requires matching execution bindings and, after changes, a complete dependency observation or an explicit policy committed before the baseline. Missing authority means a real rerun, not automatic dependency inference.
+
+Release note: v0.82.0 adds Guarded successor requalification, receipt v5, and the result-first dashboard described here.
 
 Click does not prove that the code is correct or that the selected tests are sufficient. It tracks whether existing verification evidence still applies to the current code.
 
@@ -75,6 +77,8 @@ The original canonical JSON stays hidden unless the user requests the original c
 
 Approve, request changes, cancel, and view original are all available. Approval happens in a later user turn, and work inside the approved boundary continues without repeated approval prompts.
 
+After A completes, B receives a **new contract id and separate approval**. A's successful checks are candidates only: B must request and requalify them. Unrelated code can permit partial reuse under an unchanged precommitted policy; related inputs, changed environment, and new checks run. Approval, runner tokens, unfinished work, and completion do not transfer. The Hook does not semantically prove that every implementation stayed in scope.
+
 ## Install
 
 ~~~bash
@@ -106,7 +110,7 @@ Or explicitly choose Guarded:
 
 ## Update
 
-Current release: **v0.81.1**
+Current release: **v0.82.0**
 
 ~~~bash
 codex plugin marketplace upgrade click
@@ -185,7 +189,17 @@ click-gate receipt export
 click-gate receipt verify ./completion-receipt.json
 ~~~
 
-The receipt binds request lineage, mutation revision, final workspace, checks, environment, executable identity, host coverage, and reuse lineage. When a later Evidence task requalifies and applies an earlier success, receipt v4 records `successor-reused` lineage with the origin Evidence session and batch, origin revision, requalification mode, and candidate digest.
+The receipt binds request lineage, mutation revision, final workspace, checks, environment, executable identity, host coverage, and reuse lineage. Evidence successors use v4; an applied Guarded successor uses v5 with the origin contract, batch, revision, requalification mode and candidate digest. Merely retaining candidates does not select v5. Legacy v1–v4 remain readable; v5 retains complete shard provenance when present.
+
+## Reproduce a completed Guarded A → B workflow
+
+~~~sh
+python3 benchmarks/incremental_verification.py --guarded-workflow --iterations 3 --warmups 1 --workload-rounds 40000 --output /tmp/click-workflow.json --html-output /tmp/click-workflow.html
+~~~
+
+This uses independent real Hook/runner fixtures, not approval in your development session. It compares no Click, explicitly selected Guarded with default reuse settings, and Guarded with precommitted shards/sibling-code policy. Evidence remains the product default mode. The fixed flow includes first run, unrelated/related code, environment change, failure, repair and unchanged retry; every step is audited against the same-state full suite. Warmups, rotating execution order, setup/transition/audit costs and negative timing differences are retained. The offline HTML is the v3 three-configuration report; the existing dashboard importer accepts the older v2 paired report. Neither sample results nor unsigned exports prove universal safety or total development-time savings.
+
+The result-first dashboard shows promises and approval, group outcomes, prior-contract provenance, estimated avoided rerun cost and whether a separate comparison exists. A bounded local display copy of contract summaries is retained; it is not an authority source or guaranteed secret redactor. Shared exports omit contract prose, raw commands, input paths and environment values. Request timing is partial (`hook-entry-to-result-recording`), not the full host wait. [Detailed measurement and privacy boundaries](VERIFICATION_EFFICIENCY.md).
 
 Receipt verification currently reports **unsigned-integrity-only**. It detects accidental or uncoordinated changes to the receipt, but it does not yet prove the publisher's identity.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -108,7 +108,7 @@ Evidence 模式下直接提出普通请求即可：
 
 ## 更新
 
-当前版本：**v0.81.1**
+当前版本：**v0.82.0**
 
 ~~~bash
 codex plugin marketplace upgrade click
@@ -178,6 +178,12 @@ exact/dependency/policy 复用、根据最近运行估算的避免时间，以�
 运行 `python3 benchmarks/incremental_verification.py --iterations 3 --warmups 1 --output /tmp/click-comparison.json` 可通过真实 Hook 和 runner 进行本地配对比较，再在 Dashboard 中选择 JSON。界面按“验证组”区分计划、实际执行、复用和未执行，提供批次时间线与 JSON/独立 HTML 导出；局部实测、未测量的完整等待时间、历史成本估算和 Shadow 分开显示。短检查可能因管理成本而变慢。详见[计量范围与使用说明](VERIFICATION_EFFICIENCY.md)。
 
 ## 完成 receipt
+
+版本说明：v0.82.0 已包含以下 Guarded 后续合约重新验证、receipt v5 和结果优先界面。
+
+Guarded 的已完成合约 A 可以把真实成功结果作为候选交给新合约 B，但 B 必须使用新 ID 并在独立用户轮次中批准。重新核对当前请求、环境与既有策略后才能复用；批准、runner token、未完成工作和完成状态不会继承。实际应用跨合约复用时使用 receipt v5，保留原合约、检查批次、revision 和重新判定来源；旧版 v1–v4 继续兼容。Evidence 仍是默认模式。
+
+运行 `python3 benchmarks/incremental_verification.py --guarded-workflow --iterations 3 --warmups 1 --output /tmp/click-workflow.json --html-output /tmp/click-workflow.html` 可比较不使用 Click、Guarded 默认复用设置与预先提交策略/分片的配置。包含代码与环境变化、失败重试及每步完整验证对照。v3 使用独立 HTML，现有仪表板仍导入 v2 双路径报告。负数差异和额外成本不会隐藏；局部测量与避免重跑成本估计不是总开发时间节省。
 
 当前代码所需的 evidence 完整后，可以导出并验证 receipt：
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,32 @@
 # Release notes
 
+## v0.82.0 — 2026-09-06
+
+- A completed Guarded contract can now provide successful verification results
+  as candidates to a separately approved successor contract. The successor
+  receives no inherited approval, runner token, completion state, or unfinished
+  work; every candidate is requalified against its current request, tree,
+  mutation, environment, executable, host coverage, dependency, and committed
+  safe-change bindings before reuse.
+- Completion receipt v5 records strict cross-contract lineage back to the source
+  contract, batch, revision, and requalification authority. Legacy receipt
+  versions v1-v4 and existing Evidence Shards remain compatible.
+- Verification batches now preserve honest per-group outcomes, control events,
+  measured processing segments, command-invocation durations, and partial host
+  request timing. Interrupted, failed, not-run, applied-reuse, and legacy-unknown
+  states remain distinct.
+- The result-first dashboard surfaces the approved promise, actual execution and
+  reuse, successor provenance, failures, estimates, and independently measured
+  comparisons. Local presentation is bounded, shared JSON/HTML exports are
+  sanitized, and older histories retain explicit provenance instead of gaining
+  invented certainty.
+- The real three-configuration Guarded benchmark covers code and environment
+  changes, failure and repair, unchanged reruns, and same-state full-suite audits.
+  Negative results stay visible: the bundled short fixture can be slower when
+  verification-management overhead exceeds avoided execution cost.
+- Documentation, tests, and the generated Antigravity distribution are kept in
+  parity with the canonical Codex implementation.
+
 ## v0.81.1 — 2026-09-06
 
 - Distribution validation now recognizes the exact

--- a/VERIFICATION_EFFICIENCY.md
+++ b/VERIFICATION_EFFICIENCY.md
@@ -19,6 +19,9 @@ history-only 상태로 보여줍니다. `dashboard stop`, SessionEnd, 기존 최
 viewer를 종료합니다. 다른 host 세션이나 작업 공간은 별도 바인딩이므로 연결되지 않습니다.
 
 상단은 선택한 배치의 **검증 묶음** 수입니다. 개별 테스트 케이스 수나 시간 절감률이 아닙니다.
+현재 계약의 약속과 승인도 함께 표시하며, 새 계약에 현재 배치가 없으면 이전 배치를
+새 계약의 결과로 선택하지 않습니다. 과거 계약에서 재판정한 결과와 같은 계약 재사용은
+구분합니다. 원시 계약·검증 ID와 Evidence Map·Shadow는 펼치는 상세입니다.
 최근 배치를 선택하면 계획, 실제 시작·완료·통과·실패·중단·미실행, 재사용 적용,
 영어 reason code와 한국어 설명, 이전 성공 실행 표본을 확인할 수 있습니다.
 각 묶음이 끝나는 즉시 다음 묶음이 시작되기 전에 완료 상태와 실행 구간을 저장하므로,
@@ -32,6 +35,10 @@ Evidence Map은 최신 배치의 상세 분석이며 과거 배치의 입력 그
 화면의 **JSON 내보내기**, **독립형 HTML 내보내기**는 선택한 실제 배치와 가져온 비교 측정을
 브라우저 다운로드로 저장합니다. HTML은 외부 스크립트·자산·분석 서비스 없이 열립니다.
 공유본은 원시 명령·파일 내용·입력 파일 경로·절대경로·환경 값·runner/access token을 제외합니다.
+계약 문구도 공유본에서 제외합니다. 로컬 상태에는 제한된 name/promises/범위/불변조건과
+최근 8개 계약의 표시용 이력이 남습니다. 제한·필터는 완전한 비밀 탐지기가 아닙니다.
+공유본에는 현재/원본 계약과 check digest, 계측 조건, 엔진 버전·파일 digest가 남지만
+어느 것도 서명된 발행자 증명은 아닙니다. 표시 데이터는 실행 권한에 역으로 쓰지 않습니다.
 검증을 실행하거나 재사용 권한을 바꾸지 않습니다. 서명이나 발행자 인증이 있는 receipt는 아닙니다.
 사용자 문자열은 DOM textContent로 표시하여 HTML로 실행하지 않습니다.
 
@@ -39,7 +46,7 @@ Evidence Map은 최신 배치의 상세 분석이며 과거 배치의 입력 그
 
 | 값 | 의미와 계측 경계 |
 | --- | --- |
-| 전체 검증 대기시간 `request_wall_ms` | 요청 처리부터 반환까지. 현재 제품의 분리된 Hook/runner 구조는 전체 경계를 관찰하지 못하므로 **null / 측정 정보 없음**. 0ms로 채우지 않습니다. |
+| 부분 요청 구간 `request_wall_ms` | Hook 검증 준비 진입부터 결과 기록까지. 같은 monotonic 구현과 배치 바인딩을 확인할 때만 기록합니다. 호스트 큐·Hook 초기 로딩·최종 저장과 호스트 반환은 제외하므로 전체 대기가 아닙니다. 옛 데이터·시계 불일치·미확정 종료는 **null / 미측정**이며 0ms로 채우지 않습니다. |
 | 부분 처리 구간 `measured_processing_ms` | 준비 함수 진입부터 기존 판정·상태 저장 직후까지, 그리고 runner 진입부터 결과 기록 중 계측 저장 직전까지의 **각 프로세스 로컬 경과시간 합계**. 서로 다른 monotonic 원점을 빼지 않습니다. 호스트 대기·전달, 계측 자체의 최종 저장, host 최종 반환은 제외합니다. |
 | 검사 실행 구간 `executed_duration_ms` | 실제 시작이 관찰된 묶음의 명령 호출 구간 합계. spawn/시작 기록과 Observer 준비·수집·정리 비용이 이 호출 안에 있으면 포함됩니다. 순수 테스트 CPU 시간이 아닙니다. |
 | 생략한 비용 `estimated_avoided_ms` | **실제로 적용된 재사용**의 최근 성공 실행 표본을 합한 추정치. 실행하지 않은 현재 명령의 반사실적 시간은 알 수 없으며 실측 절약이라고 부르지 않습니다. |
@@ -57,6 +64,45 @@ Evidence Map은 최신 배치의 상세 분석이며 과거 배치의 입력 그
 옛 정수 시간 필드만 있는 데이터는 정확한 출처가 없으므로 새 추정 근거로 꾸미지 않습니다.
 Observer overhead는 별도 Shadow 정보이며 위 실행 구간에 다시 더하거나 빼지 않습니다.
 tracing slowdown은 비교 측정하지 않았으며 Shadow 후보를 실제 재사용 수나 실측 절약에 합치지 않습니다.
+
+재사용률은 보관 이력의 **재사용 그룹 요청 수 / 전체 그룹 요청 수**와 기간을 공개합니다.
+별도 재시도는 실제 새 요청이므로 분모에 포함되지만 같은 배치의 재전송과 화면 새로고침은
+중복 누적하지 않습니다. 분모가 불명확하거나 0이면 비율은 null입니다. 시간 표본이 없는
+재사용 그룹 수도 별도로 남깁니다. 승인 전 거부·ID 불일치 등 실제 관측 사건은 blocked,
+검증 지침은 advisory이며 문구 의미 분석이나 숨은 추론 감시로 만든 사건은 없습니다.
+
+## Guarded A → B · 세 구성의 고정 작업 흐름
+
+```sh
+python3 benchmarks/incremental_verification.py --guarded-workflow --iterations 3 --warmups 1 --workload-rounds 40000 --output /tmp/click-workflow.json --html-output /tmp/click-workflow.html
+```
+
+새 출력 파일에만 기록합니다. 이 v3 세 구성 보고서는 독립 HTML로 열고, 아래의 기존
+v2 쌍별 보고서만 현재 dashboard importer에 입력합니다. 새 프레임워크나 서비스가 필요 없습니다.
+
+- baseline: Click Hook 없이 동일한 unittest discover 전체 실행.
+- click-default: Guarded를 명시적으로 선택하고 추가 shard/dependency/reuse 설정 없이 실행.
+- explicit-reuse: 같은 코드와 테스트를 두 샤드로 나누고 서로 독립인 sibling 코드 변경을
+  허용하는 정책을 최초 baseline 전에 커밋. 정책은 관찰기나 자동 의존성 발견이 아닙니다.
+
+제품 기본 모드는 Evidence 그대로입니다. 각 구성은 독립 임시 Git root와 receipt를 사용하며
+첫 실행→beta 코드 변경→alpha 코드 변경→환경 변경→alpha 실패→수정 후 재시도→변경 없음의
+같은 일곱 단계를 진행합니다. 테스트·코드 digest를 매 단계 구성 간 대조합니다. A 완료 뒤
+B를 새 ID로 stage하고 별도 fixture 턴에서 승인합니다. 이후 완료된 단계도 별도 계약을
+사용하고 실패·수정은 같은 미완료 계약 안에서 처리합니다. 승인 전 수정·같은 턴 승인·잘못된
+ID가 실제로 거부되는지 확인합니다. 개발 세션의 승인이나 Hook 설정은 변경하지 않습니다.
+
+각 단계의 primary 요청 뒤 동일 상태의 전체 suite를 직접 실행하여 PASS/FAIL과 exit code를
+대조합니다. 이 감사는 별도 추가 비용이며 Click의 성공 기록을 만들지 않습니다. 마지막 전체
+suite가 통과해야 보고서를 생성합니다. B와 최종 영수증은 실제 export와 오프라인 무결성 검사를
+거친 unsigned envelope입니다. 정상 표본의 일치는 모든 프로젝트에서 안전하다는 증명이 아닙니다.
+
+워밍업은 전체 workflow 반복을 제외하며 반복마다 새 checkout을 만듭니다. 세 구성 실행 순서를
+회전하고 bytecode는 비활성화하지만 OS 캐시·스케줄러는 초기화/제어하지 않습니다. 일곱 요청 합계의
+차이와 비율은 기대된 실패·재시도도 포함하고 음수를 보존합니다. Click 요청에는 Hook·runner
+시작 비용도 포함됩니다. Git·첫 fixture 승인 setup, 이후 승인/수정 transition, 추가 full audit를
+별도 기록합니다. 영수증 export·보고서 직렬화 비용은 제외됩니다. Scripted 승인 시간은 사람의
+의사결정 시간이 아니며 검증 시간 차이를 토큰·요금·전체 개발시간 절감으로 환산하지 않습니다.
 
 ## 실제 비교 벤치마크
 
@@ -131,3 +177,9 @@ history, 공유 리포트와 Shadow record를 authoritative evidence로 역변�
 후속 Evidence 재사용이 있는 completion receipt는 v4 `successor-reused` lineage로 원래 batch와
 Evidence session, 원래 revision, 재판정 방식(exact/dependency/safe-change), 후보 digest를
 기록합니다. 이것은 여전히 `unsigned-integrity-only`이며 발행자 신원 인증은 아닙니다.
+
+Guarded A가 완전히 끝난 뒤 B가 별도 승인되면 같은 조건으로 성공 후보를 재판정할 수 있습니다.
+B의 의존성 선언이 달라지면 A 선언을 물려받지 않고 실제로 다시 실행합니다. 실제 적용된
+Guarded 후속 재사용은 receipt v5에서 원본 contract id를 기록합니다. 실패한 B 결과를 A 후보로
+덮어씌우지 않으며 B에서 다시 실제 실행한 그룹은 과거 successor 표시를 지웁니다. 기존 v1–v4와
+Evidence의 호스트 권한은 보존됩니다.

--- a/benchmarks/incremental_verification.py
+++ b/benchmarks/incremental_verification.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import html
 import json
 import os
 from pathlib import Path
@@ -24,7 +25,7 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
-from hooks import click_dashboard_projection, click_incremental  # noqa: E402
+from hooks import click_dashboard_projection, click_incremental, click_receipt  # noqa: E402
 
 GATE = ROOT / "hooks" / "click_gate.py"
 SCENARIOS = (
@@ -37,6 +38,8 @@ SCENARIOS = (
     "first-failure",
 )
 COMPARISONS = ("same-shards", "parent-suite")
+WORKFLOW_CONFIGS = ("baseline", "click-default", "explicit-reuse")
+WORKFLOW_STEPS = ("first-run", "unrelated-code", "related-code", "environment", "failure", "retry", "unchanged")
 DEFAULT_ITERATIONS = 3
 DEFAULT_WORKLOAD_ROUNDS = 40_000
 MAX_ITERATIONS = 10
@@ -92,7 +95,12 @@ class Fixture:
         mode: str = "evidence",
         *,
         partial_policy: bool = False,
+        configuration: str = "legacy",
     ):
+        if configuration not in {"legacy", *WORKFLOW_CONFIGS}:
+            raise ValueError("invalid-workflow-configuration")
+        self.configuration = configuration
+        self.controls: list[dict[str, Any]] = []
         self.root = directory / "repository"
         self.data = directory / "runtime"
         self.root.mkdir(parents=True)
@@ -122,6 +130,15 @@ class Fixture:
                         "    def test_work(self):\n"
                         "        hashlib.pbkdf2_hmac('sha256', b'click', b'fixture', ROUNDS)\n"
                         "        self.assertEqual(VALUE, 1)\n")
+            if configuration != "legacy":
+                self._write(f"component_{name}.py", "VALUE = 1\n")
+                self._write(f"tests/test_{name}.py",
+                            "import hashlib\nimport unittest\nfrom implementation import ROUNDS\n"
+                            f"from component_{name} import VALUE\n"
+                            "class Check(unittest.TestCase):\n"
+                            "    def test_work(self):\n"
+                            "        hashlib.pbkdf2_hmac('sha256', b'click', b'fixture', ROUNDS)\n"
+                            "        self.assertGreater(VALUE, 0)\n")
         shards = {"version": 1, "entries": [{
             "checks": [self.parent], "inventory": ["tests/test*.py"],
             "shards": [{"id": name, "checks": [argv], "covers": [f"tests/test_{name}.py"]}
@@ -140,14 +157,26 @@ class Fixture:
                 for name, argv in zip(("alpha", "beta"), self.children)
             ],
         }
-        self._write(".click/evidence-shards.json", json.dumps(shards))
-        self._write(".click/evidence-reuse.json", json.dumps(policy))
+        if configuration == "explicit-reuse":
+            # Repository-owner policy exists BEFORE the baseline. The test
+            # imports only its own component; a sibling code change is allowed.
+            for entry, sibling in zip(policy["entries"], ("beta", "alpha")):
+                entry["reuse_if_only_changed"] = [f"component_{sibling}.py"]
+        if configuration in {"legacy", "explicit-reuse"}:
+            self._write(".click/evidence-shards.json", json.dumps(shards))
+            self._write(".click/evidence-reuse.json", json.dumps(policy))
         for args in (["git", "init", "-q"], ["git", "add", "."],
                      ["git", "-c", "user.name=Click Benchmark", "-c",
                       "user.email=benchmark@example.invalid", "-c", "commit.gpgsign=false",
                       "commit", "-q", "-m", "Committed benchmark policy and inventory"]):
             if self._run(args).returncode:
                 raise RuntimeError("fixture-git-preparation-failed")
+        if configuration == "baseline":
+            return  # Ordinary validation: no Hook, policy, or receipt ledger.
+        if configuration != "legacy":
+            self.begin_contract("A · 최초 기준 검증")
+            self._control("default guarded")  # Isolated fixture configuration only.
+            return
         self._hook("prompt-submit", {"hook_event_name": "UserPromptSubmit",
                                     "prompt": "Measure the committed verification fixture in Evidence mode."})
         if mode == "guarded":
@@ -177,6 +206,84 @@ class Fixture:
             approved = self._control("pass " + match.group())
             if approved.get("permissionDecision") == "deny":
                 raise RuntimeError("fixture-contract-not-approved")
+
+    def begin_contract(self, name: str) -> str:
+        """Stage, demonstrate real denials, then approve in a later fixture turn."""
+        self.event["turn_id"] = f"stage-{self.sequence + 1}"
+        self._hook("prompt-submit", {"hook_event_name": "UserPromptSubmit",
+                                    "prompt": "@Click\nStage the next independent integration-fixture contract."})
+        self._control("arm")
+        contract = {
+            "outcome": name,
+            "boundary": {"in_scope": ["독립 fixture의 고정된 코드 변경과 검증"], "out_of_scope": ["개발 세션과 사용자 저장소"]},
+            "must_hold": ["별도 승인 전 실행 금지", "성공 후보만 현재 조건으로 재판정"],
+            "build": {"approach": ["실제 Hook과 one-use runner"], "semantics": ["권한 비승계"], "order": ["승인 후 변경과 검증"]},
+            "verification": {"scale": "focused", "evidence": [{"id": "E-suite", "kind": "argv", "description": "alpha와 beta 전체 동작"}],
+                             "done_when": [{"condition": "두 동작의 유효한 검증", "primary_evidence": "E-suite"}]},
+            "plain_language": "독립 임시 fixture만 별도 승인 뒤 수정하고 두 동작을 검증합니다. 과거 성공은 후보로만 재판정하며 승인과 실행 권한을 넘기지 않습니다. 개발 세션과 사용자 저장소는 바꾸지 않습니다."
+        }
+        if self._control("stage " + shlex.quote(json.dumps(contract))).get("permissionDecision") == "deny":
+            raise RuntimeError("workflow-contract-not-staged")
+        staged = self.state()
+        contract_id = staged["contract_id"]
+        denied = self._control("mutate " + shlex.quote(json.dumps({"version": 1, "argv": [sys.executable, "not-executed.py"]})))
+        same_turn = self._control("pass " + contract_id)
+        self.event["turn_id"] = f"approve-{self.sequence + 1}"
+        self._hook("prompt-submit", {"hook_event_name": "UserPromptSubmit",
+                                    "prompt": "Approve that exact staged contract only in this independent fixture."})
+        self._control("arm")
+        wrong = self._control("pass ctr_" + ("1" if contract_id != "ctr_" + "1" * 32 else "2") * 32)
+        if self._control("pass " + contract_id).get("permissionDecision") == "deny":
+            raise RuntimeError("workflow-contract-not-approved")
+        approved = self.state()
+        control = {"contract_id": contract_id, "preapproval_denied": denied.get("permissionDecision") == "deny",
+                   "same_turn_denied": same_turn.get("permissionDecision") == "deny", "wrong_id_denied": wrong.get("permissionDecision") == "deny",
+                   "fresh_unapproved_state": staged["status"] == "staged" and not staged.get("approved_turn_id"),
+                   "separate_turns": approved["staged_turn_id"] != approved["approved_turn_id"]}
+        if not all(value for key, value in control.items() if key != "contract_id"):
+            raise RuntimeError("workflow-approval-boundary-failed")
+        self.controls.append(control)
+        return contract_id
+
+    def workflow_change(self, scenario: str) -> None:
+        if scenario in {"first-run", "unchanged"}:
+            return
+        if scenario == "environment":
+            self.environment["CLICK_BENCHMARK_VARIANT"] = "changed"
+            return
+        paths = {"unrelated-code": ("component_beta.py", 2), "related-code": ("component_alpha.py", 2),
+                 "failure": ("component_alpha.py", -1), "retry": ("component_alpha.py", 3)}
+        path, value = paths[scenario]
+        self.sequence += 1
+        event = {"tool_name": "apply_patch", "tool_use_id": f"workflow-change-{self.sequence}",
+                 "tool_input": {"patch": f"*** fixture edit {path}: VALUE = {value} ***"}}
+        if self.configuration != "baseline":
+            admission = self._hook("pre-tool", {**event, "hook_event_name": "PreToolUse"})
+            if admission.get("hookSpecificOutput", {}).get("permissionDecision") == "deny":
+                raise RuntimeError("workflow-mutation-denied")
+        self._write(path, f"VALUE = {value}\n")
+        if self.configuration != "baseline":
+            self._hook("post-tool", {**event, "hook_event_name": "PostToolUse", "tool_response": {"success": True, "exit_code": 0}})
+
+    def input_digest(self) -> str:
+        digest = hashlib.sha256()
+        for path in sorted([*self.root.glob("*.py"), *(self.root / "tests").glob("*.py")]):
+            digest.update(path.relative_to(self.root).as_posix().encode() + b"\0" + path.read_bytes())
+        return digest.hexdigest()
+
+    def receipt(self) -> dict[str, Any]:
+        response = self._control("receipt export")
+        command = response.get("updatedInput", {}).get("command")
+        if response.get("permissionDecision") == "deny" or not isinstance(command, str):
+            raise RuntimeError("workflow-receipt-not-exportable")
+        result = self._run(_fixture_runner_argv(command))
+        if result.returncode:
+            raise RuntimeError("workflow-receipt-export-failed")
+        envelope = json.loads(result.stdout)
+        _, error = click_receipt.validate_envelope(envelope)
+        if error:
+            raise RuntimeError("workflow-receipt-integrity-failed: " + error)
+        return envelope
 
     def _control(self, command: str) -> dict[str, Any]:
         self.sequence += 1
@@ -363,6 +470,123 @@ def run_benchmark(*, iterations: int = DEFAULT_ITERATIONS, warmups: int = 1,
                             "different-checkout-roots-have-independent-receipts", "OS-cache-and-scheduler-uncontrolled"]}
 
 
+def run_guarded_workflow_benchmark(*, iterations: int = DEFAULT_ITERATIONS, warmups: int = 1,
+                                   workload_rounds: int = DEFAULT_WORKLOAD_ROUNDS) -> dict[str, Any]:
+    """Three independent configurations, each completing A before approving B.
+
+    The baseline never enters Click. Default means Guarded selected explicitly,
+    with no optional dependency, reuse, or shard configuration. Native caches
+    are not flushed. Full audits are extra work and never manufacture evidence.
+    """
+    if not 1 <= iterations <= MAX_ITERATIONS or not 0 <= warmups <= MAX_ITERATIONS or not 1 <= workload_rounds <= MAX_WORKLOAD_ROUNDS:
+        raise ValueError("invalid-workflow-configuration")
+    samples = []
+    latest_snapshot = None
+    for index in range(warmups + iterations):
+        order = list(WORKFLOW_CONFIGS[index % 3:] + WORKFLOW_CONFIGS[:index % 3])
+        arms = {}
+        with tempfile.TemporaryDirectory(prefix="click-guarded-workflow-") as directory:
+            for config in order:
+                started = time.perf_counter_ns()
+                fixture = Fixture(Path(directory) / config, workload_rounds, "guarded", configuration=config)
+                setup_ms = (time.perf_counter_ns() - started) / 1_000_000
+                steps, successor_receipt = [], None
+                for position, scenario in enumerate(WORKFLOW_STEPS):
+                    started = time.perf_counter_ns()
+                    if config != "baseline" and scenario in {"unrelated-code", "related-code", "environment", "failure"}:
+                        fixture.begin_contract(f"{chr(65 + position)} · {scenario}")
+                    fixture.workflow_change(scenario)
+                    transition_ms = (time.perf_counter_ns() - started) / 1_000_000
+                    result = fixture.full("parent-suite") if config == "baseline" else fixture.verify()
+                    snapshot = result.pop("snapshot", None)
+                    if config == "explicit-reuse" and scenario == "unrelated-code":
+                        latest_snapshot = snapshot
+                    # Same-state full validation after EVERY step, including the
+                    # expected failure. Its time is explicitly outside primary
+                    # request measurements, and it warms native caches uniformly.
+                    audit = fixture.full("parent-suite")
+                    matches = result["exit_code"] == audit["exit_code"] and result["status"] == audit["status"]
+                    expected = "failed" if scenario == "failure" else "passed"
+                    if not matches or result["status"] != expected:
+                        raise RuntimeError(f"workflow-full-audit-mismatch:{config}:{scenario}")
+                    steps.append({"scenario": scenario, "contract_id": None if config == "baseline" else fixture.state()["contract_id"],
+                                  "input_digest": fixture.input_digest(), "transition_ms": transition_ms,
+                                  "validation": result, "audit": audit, "audit_matches": matches})
+                    if config != "baseline" and scenario == "unrelated-code":
+                        successor_receipt = fixture.receipt()
+                final_receipt = None if config == "baseline" else fixture.receipt()
+                arms[config] = {"steps": steps, "controls": fixture.controls, "setup_ms": setup_ms,
+                                "validation_wall_ms": sum(step["validation"]["wall_ms"] for step in steps),
+                                "transition_ms": sum(step["transition_ms"] for step in steps),
+                                "audit_wall_ms": sum(step["audit"]["wall_ms"] for step in steps),
+                                "successor_receipt": successor_receipt, "final_receipt": final_receipt,
+                                "final_input_digest": fixture.input_digest()}
+            for position in range(len(WORKFLOW_STEPS)):
+                if len({arm["steps"][position]["input_digest"] for arm in arms.values()}) != 1:
+                    raise RuntimeError("workflow-inputs-not-equivalent")
+        samples.append({"iteration": index, "warmup": index < warmups, "order": order, "arms": arms})
+    summaries = []
+    for config in WORKFLOW_CONFIGS[1:]:
+        selected = [sample for sample in samples if not sample["warmup"]]
+        deltas = [comparison_delta(sample["arms"]["baseline"]["validation_wall_ms"], sample["arms"][config]["validation_wall_ms"]) for sample in selected]
+        summaries.append({"configuration": config, "samples": len(selected),
+                          "baseline_wall_ms": distribution([sample["arms"]["baseline"]["validation_wall_ms"] for sample in selected]),
+                          "validation_wall_ms": distribution([sample["arms"][config]["validation_wall_ms"] for sample in selected]),
+                          "delta_ms": distribution([value["delta_ms"] for value in deltas]),
+                          "delta_percent": distribution([value["delta_percent"] for value in deltas if value["delta_percent"] is not None]),
+                          "transition_ms": distribution([sample["arms"][config]["transition_ms"] for sample in selected]),
+                          "setup_ms": distribution([sample["arms"][config]["setup_ms"] for sample in selected]),
+                          "extra_audit_ms": distribution([sample["arms"][config]["audit_wall_ms"] for sample in selected])})
+    commit = subprocess.run(["git", "rev-parse", "HEAD"], cwd=ROOT, capture_output=True, text=True, check=False)
+    dirty = subprocess.run(["git", "status", "--porcelain"], cwd=ROOT, capture_output=True, text=True, check=False)
+    source_hash = hashlib.sha256()
+    for path in sorted([*GATE.parent.glob("*.py"), Path(__file__).resolve()]):
+        source_hash.update(path.relative_to(ROOT).as_posix().encode() + b"\0" + hashlib.sha256(path.read_bytes()).digest())
+    return {"version": 3, "kind": "click-guarded-workflow-benchmark",
+            "engine": {"version": json.loads((ROOT / ".codex-plugin/plugin.json").read_text())["version"],
+                       "commit": commit.stdout.strip() if commit.returncode == 0 else None,
+                       "source_digest": source_hash.hexdigest(), "working_tree_modified": bool(dirty.stdout.strip()), "assurance": "unsigned-files-at-measurement"},
+            "environment": {"system": platform.system(), "machine": platform.machine(), "python": platform.python_version()},
+            "conditions": {"iterations": iterations, "warmups": warmups, "workload_rounds": workload_rounds,
+                           "configurations": list(WORKFLOW_CONFIGS), "runtime_mode": "guarded-explicitly-selected; baseline-without-click",
+                           "scope_equivalence": "same-two-unittest-files-and-code-at-every-step", "order": "rotating-three-arm-workflows",
+                           "authority": "real-hooks-and-one-use-runner; distinct-scripted-fixture-approval-turns", "observer": "off",
+                           "cache": "fresh-checkout-per-configuration-and-repetition; OS-cache-not-flushed; bytecode-disabled; full-audit-after-each-step",
+                           "default_configuration": "no-optional-shards-dependencies-or-safe-change-policy; product-default-mode-remains-Evidence",
+                           "explicit_configuration": "committed-two-shard-map-and-sibling-code-safe-change-policy-before-baseline",
+                           "measurement": "sum-of-seven-driver-validation-requests; Click-includes-hook-and-runner-startup; negative-differences-preserved",
+                           "additional_cost": "setup-includes-Git-and-first-scripted-approval; later-approval-and-mutation-transitions-and-audits-separate; receipt-export-and-report-serialization-excluded",
+                           "failure": "one-expected-alpha-failure-and-repair-included-in-workflow-totals; final-full-suite-must-pass"},
+            "samples": samples, "summaries": summaries, "dashboard_snapshot": latest_snapshot,
+            "limitations": ["fixture-only-not-universal-safety-or-performance-proof", "scripted-approvals-not-human-decision-time",
+                            "explicit-policy-is-owner-authority-not-observed-dependency-discovery", "known-Hook-surfaces-only; unsigned-receipts",
+                            "OS-cache-and-scheduler-uncontrolled", "no-token-fee-or-total-development-time-conversion"]}
+
+
+def workflow_report_html(result: dict[str, Any]) -> str:
+    """Small offline measured report; no scripts, raw commands, or private paths."""
+    escape = lambda value: html.escape(str(value), quote=True)
+    rows = []
+    for summary in result["summaries"]:
+        rows.append("<tr>" + "".join(f"<td>{escape(value)}</td>" for value in (
+            summary["configuration"], summary["samples"], round(summary["baseline_wall_ms"]["median"], 2),
+            round(summary["validation_wall_ms"]["median"], 2), round(summary["delta_ms"]["median"], 2),
+            round(summary["delta_percent"]["median"], 2), round(summary["transition_ms"]["median"], 2), round(summary["extra_audit_ms"]["median"], 2))) + "</tr>")
+    last = result["samples"][-1]["arms"]["explicit-reuse"]
+    steps = []
+    for step in last["steps"]:
+        value = step["validation"]
+        origins = [item["reuse_origin"]["kind"] for item in value["batch"]["sources"] if item.get("reuse_origin")]
+        steps.append("<tr>" + "".join(f"<td>{escape(item)}</td>" for item in (step["scenario"], value["status"], value["executed_source_count"], value["reused_source_count"], value["not_run_source_count"], round(value["wall_ms"], 2), step["audit_matches"], ", ".join(origins))) + "</tr>")
+    return ('<!doctype html><html lang="ko"><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>Click · Guarded A→B 실측</title>'
+            '<style>body{font:16px/1.6 system-ui;margin:40px auto;max-width:1100px;padding:0 24px;color:#18322d;background:#f6f8f4}table{border-collapse:collapse;width:100%;font-size:14px;background:white}th,td{padding:10px;border-bottom:1px solid #dce3dd;text-align:left}pre{white-space:pre-wrap;overflow-wrap:anywhere}h1{line-height:1.25}section{margin:32px 0}.scroll{overflow:auto}</style>'
+            '<h1>시키지 않은 범위 확장은 억제하고,<br>유효한 검증은 다시 기다리지 않도록.</h1><p>독립 fixture의 실제 Hook·runner 측정입니다. 개발 세션의 승인이나 보편적 안전성 증명이 아닙니다.</p>'
+            '<section><h2>같은 작업 · 세 구성</h2><p>기준은 Click 없는 전체 검증입니다. Click 기본은 Guarded를 명시적으로 선택하되 추가 재사용 설정이 없습니다. 명시적 구성은 기준 실행 전에 두 샤드와 무관 코드 변경 정책을 커밋했습니다.</p><p>일곱 검증 요청 합계의 반복 중앙값(ms). 양수 차이는 이 표본에서 빠름, 음수는 느림입니다. 최초 실행·실패·재시도도 포함하며 추가 비용과 사람의 판단 시간은 검증 시간 절감으로 합치지 않습니다.</p>'
+            '<div class="scroll"><table><tr><th>구성</th><th>표본</th><th>기준 ms</th><th>Click ms</th><th>차이 ms</th><th>차이 %</th><th>별도 전환 ms</th><th>추가 전체 감사 ms</th></tr>' + ''.join(rows) + '</table></div></section>'
+            '<section><h2>마지막 명시적 구성의 실제 흐름</h2><p>A 승인 → 성공 → B 별도 승인·beta 코드 수정 → alpha 재판정 → alpha 수정 시 재실행. 환경 변경은 재실행, 실패한 alpha는 수정 후 재시도했습니다.</p><div class="scroll"><table><tr><th>단계</th><th>결과</th><th>실행 그룹</th><th>재사용 그룹</th><th>미시작</th><th>요청 ms</th><th>전체 대조 일치</th><th>계보</th></tr>' + ''.join(steps) + '</table></div></section>'
+            '<section><h2>승인 통제 · 출처</h2><p>각 Click 계약에서 승인 전 수정, 같은 턴 승인, 틀린 ID를 실제로 거부한 뒤 다른 fixture 턴에서 정확한 ID로 승인했습니다. 전체 검증 대조는 모든 구성의 모든 단계에서 수행했습니다. 그룹은 테스트 케이스 수가 아닙니다.</p><pre>' + escape(json.dumps({"engine": result["engine"], "environment": result["environment"], "conditions": result["conditions"], "controls": last["controls"], "limitations": result["limitations"]}, ensure_ascii=False, indent=2)) + '</pre></section></html>')
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--iterations", type=int, default=DEFAULT_ITERATIONS)
@@ -371,10 +595,20 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--scenario", action="append", choices=SCENARIOS)
     parser.add_argument("--mode", choices=("evidence", "guarded"), default="evidence")
     parser.add_argument("--output", type=Path, help="Write a new local JSON file (never overwrite).")
+    parser.add_argument("--guarded-workflow", action="store_true", help="Compare baseline, Guarded defaults, and explicit reuse through completed contracts.")
+    parser.add_argument("--html-output", type=Path, help="New offline three-configuration workflow report (requires --guarded-workflow).")
     args = parser.parse_args(argv)
     try:
-        result = run_benchmark(iterations=args.iterations, warmups=args.warmups,
-                               workload_rounds=args.workload_rounds, scenarios=tuple(args.scenario or SCENARIOS), mode=args.mode)
+        if args.html_output and not args.guarded_workflow or args.guarded_workflow and args.scenario:
+            raise ValueError("workflow-requires-fixed-scenarios; html-requires-workflow")
+        for target in (args.output, args.html_output):
+            if target is not None and target.exists():
+                raise ValueError("output-already-exists")
+        if args.guarded_workflow:
+            result = run_guarded_workflow_benchmark(iterations=args.iterations, warmups=args.warmups, workload_rounds=args.workload_rounds)
+        else:
+            result = run_benchmark(iterations=args.iterations, warmups=args.warmups,
+                                   workload_rounds=args.workload_rounds, scenarios=tuple(args.scenario or SCENARIOS), mode=args.mode)
         # JSON escapes preserve Unicode values on legacy Windows stdout,
         # while explicitly UTF-8 output files remain human-readable.
         encoded = json.dumps(result, ensure_ascii=args.output is None,
@@ -382,9 +616,18 @@ def main(argv: list[str] | None = None) -> int:
         if args.output:
             with args.output.open("x", encoding="utf-8") as handle:
                 handle.write(encoded + "\n")
-            print(json.dumps({"output": str(args.output), "samples": len(result["samples"]), "summaries": result["summaries"]}))
+            summary = {"output": str(args.output), "samples": len(result["samples"]), "summaries": result["summaries"]}
+            if args.guarded_workflow:
+                summary["full_audit_matches"] = sum(step["audit_matches"] for sample in result["samples"] for arm in sample["arms"].values() for step in arm["steps"])
+                summary["last_explicit_steps"] = [{"scenario": step["scenario"], "status": step["validation"]["status"],
+                    "executed": step["validation"]["executed_source_count"], "reused": step["validation"]["reused_source_count"]}
+                    for step in result["samples"][-1]["arms"]["explicit-reuse"]["steps"]]
+            print(json.dumps(summary))
         else:
             print(encoded)
+        if args.html_output:
+            with args.html_output.open("x", encoding="utf-8") as handle:
+                handle.write(workflow_report_html(result))
     except (OSError, ValueError, RuntimeError) as error:
         print(f"benchmark failed: {type(error).__name__}: {error}", file=sys.stderr)
         return 2

--- a/dist/antigravity/hooks/click_dashboard_projection.py
+++ b/dist/antigravity/hooks/click_dashboard_projection.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 import re
 import time
 from typing import Any
@@ -32,7 +32,7 @@ else:  # Executed beside the bundled hook modules.
     import click_shadow_intelligence
 
 
-PROJECTION_VERSION = 3
+PROJECTION_VERSION = 4
 PROJECTION_MODE = "incremental-verification"
 MAX_SOURCES = click_shadow_intelligence.MAX_STATE_SOURCES
 MAX_INPUTS = click_shadow_intelligence.MAX_PROJECTION_INPUTS
@@ -52,7 +52,7 @@ _INPUT_STATUSES = frozenset(
 )
 
 _FIELDS = frozenset(
-    {"version", "mode", "generated_at", "task", "summary", "sources", "map", "batches", "history"}
+    {"version", "mode", "generated_at", "task", "summary", "sources", "map", "batches", "history", "accounting", "controls", "engine"}
 )
 _TASK_FIELDS = frozenset(
     {
@@ -61,6 +61,7 @@ _TASK_FIELDS = frozenset(
         "mutation_revision",
         "observer_mode",
         "observer_enabled",
+        "name", "promises", "in_scope", "out_of_scope", "must_hold", "contract_id", "approval_bound",
     }
 )
 _SUMMARY_FIELDS = frozenset({"incremental", "shadow"})
@@ -100,6 +101,7 @@ _SOURCE_FIELDS = frozenset(
         "shadow_outcome",
         "execution_status", "execution_reason_code", "duration_ms", "duration_baseline",
         "reuse_origin",
+        "check_digest", "origin_name", "origin_check_label", "next_action",
     }
 )
 _MAP_FIELDS = frozenset(
@@ -155,6 +157,45 @@ def _safe_relative_path(value: Any, *, directory: bool = False) -> bool:
 def _source_status(value: Any) -> str:
     status = value.get("status") if isinstance(value, dict) else "unknown"
     return status if status in _SOURCE_STATUSES else "unknown"
+
+
+def engine_identity() -> dict[str, Any]:
+    """File provenance only, never a signed or independently trusted identity."""
+    result = {"version": None, "hook_files_digest": None, "assurance": "unsigned-files-at-snapshot"}
+    root = Path(__file__).resolve().parents[1]
+    try:
+        version = json.loads((root / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")).get("version")
+        if isinstance(version, str) and re.fullmatch(r"\d+\.\d+\.\d+(?:\+codex\.\d{14})?", version):
+            result["version"] = version
+    except (OSError, ValueError, TypeError):
+        pass
+    try:
+        digest = hashlib.sha256()
+        for path in sorted((root / "hooks").glob("*.py"))[:256]:
+            content = path.read_bytes()
+            if len(content) > 2 * 1024 * 1024:
+                return result
+            digest.update(path.name.encode() + b"\0" + hashlib.sha256(content).digest())
+        result["hook_files_digest"] = digest.hexdigest()
+    except OSError:
+        pass
+    return result
+
+
+def _next_action(reason: str, status: str) -> str:
+    if status == "passed":
+        return "현재 코드에서 직접 통과했습니다. 다음 관련 변경 전에는 재실행이 필요하지 않습니다."
+    if status == "reused":
+        return "현재 재판정을 통과한 결과입니다. 관련 입력이 바뀌면 다시 검증하세요."
+    if status in {"failed", "interrupted"}:
+        return "실패 또는 중단 원인을 확인한 뒤 승인 범위에서 같은 검증을 다시 실행하세요."
+    if reason == "environment-binding-changed":
+        return "현재 환경에서 실제 검증을 실행해 새 기준 결과를 만드세요."
+    if reason in {"observed-input-changed", "safe-change-policy-not-covered"}:
+        return "관련 입력이 변경됐습니다. 현재 코드로 실제 검증을 실행하세요."
+    if reason in {"observer-incomplete", "policy-unavailable", "mutation-boundary-ambiguous", "workspace-ambiguous"}:
+        return "재사용 근거가 부족합니다. 정책을 완화하지 말고 현재 상태를 실제 검증하세요."
+    return "승인된 검증을 먼저 실행해 현재 상태의 성공 기준을 만드세요."
 
 
 def _intelligence_state(verification: dict[str, Any]) -> dict[str, Any]:
@@ -216,6 +257,7 @@ def dashboard_projection(
     """Build the only state shape exposed to the local dashboard server."""
 
     raw_state = state if isinstance(state, dict) else {}
+    presentation = click_incremental.sanitize_presentation(raw_state.get("presentation"))
     verification = raw_state.get("verification")
     verification = verification if isinstance(verification, dict) else {}
     evidence_state = raw_state.get("evidence_state")
@@ -234,7 +276,8 @@ def dashboard_projection(
     history = click_incremental.batch_history(verification, now=generated_at)
 
     source_keys = sorted(
-        {key for key in evidence_sources if _is_digest(key)}
+        {key for key, source in evidence_sources.items() if _is_digest(key)
+         and isinstance(source, dict) and source.get("kind", "argv") == "argv"}
         | set(observer_records)
         | set(intelligence["sources"])
         | set(decisions)
@@ -248,7 +291,7 @@ def dashboard_projection(
 
     for index, key in enumerate(source_keys, start=1):
         source_id = f"source:{key[:16]}"
-        label = actual[key]["label"] if key in actual else f"검증 묶음 {index}"
+        label = actual[key]["label"] if key in actual else presentation["evidence_labels"].get(key, f"검증 묶음 {index}")
         status = _source_status(evidence_sources.get(key))
         nodes.append(
             {
@@ -277,6 +320,13 @@ def dashboard_projection(
             previous_revision = int(decision["previous_revision"])
             estimated_avoided_ms = None
         result = actual.get(key, {})
+        execution_status = result.get("status", "not-run" if status == "ready" else "unknown")
+        origin = result.get("reuse_origin")
+        origin_contract = origin.get("contract_id", "") if isinstance(origin, dict) else ""
+        presentation_history = raw_state.get("presentation_history", {})
+        origin_presentation = click_incremental.sanitize_presentation(
+            presentation_history.get(origin_contract) if isinstance(presentation_history, dict) else None
+        )
         duration_baseline = result.get("duration_baseline")
         if result.get("status") == "reused" and click_incremental.baseline_is_valid(duration_baseline):
             estimated_avoided_ms = duration_baseline["duration_ms"]
@@ -356,11 +406,15 @@ def dashboard_projection(
                 "current_revision": current_revision,
                 "previous_revision": previous_revision,
                 "estimated_avoided_ms": estimated_avoided_ms,
-                "execution_status": result.get("status", "unknown"),
-                "execution_reason_code": result.get("execution_reason_code", "outcome-unconfirmed"),
+                "execution_status": execution_status,
+                "execution_reason_code": result.get("execution_reason_code", "not-requested" if status == "ready" else "outcome-unconfirmed"),
                 "duration_ms": result.get("duration_ms"),
                 "duration_baseline": duration_baseline,
                 "reuse_origin": result.get("reuse_origin"),
+                "check_digest": decision["check_digest"] if decision else "",
+                "origin_name": origin_presentation["name"] if origin_contract else "이전 Evidence 작업" if origin else "현재 계약",
+                "origin_check_label": origin_presentation["evidence_labels"].get(key, label),
+                "next_action": _next_action(reason_code, execution_status),
                 "observer_status": observer_status,
                 "input_count": len(input_keys),
                 "visible_input_count": source_visible,
@@ -422,7 +476,15 @@ def dashboard_projection(
             "mutation_revision": revision,
             "observer_mode": observer_control["mode"],
             "observer_enabled": observer_control["enabled"],
+            **{key: presentation[key] for key in ("name", "promises", "in_scope", "out_of_scope", "must_hold")},
+            "contract_id": raw_state.get("contract_id") if re.fullmatch(r"ctr_[0-9a-f]{32}", str(raw_state.get("contract_id", ""))) else "",
+            "approval_bound": bool(runtime_mode == "guarded" and status == "approved"
+                                   and raw_state.get("approved_turn_id")
+                                   and raw_state.get("approved_turn_id") != raw_state.get("staged_turn_id")),
         },
+        "accounting": click_incremental.history_accounting(verification),
+        "controls": click_incremental.control_events(raw_state),
+        "engine": engine_identity(),
         "summary": {
             "incremental": incremental,
             "shadow": _shadow_metrics(intelligence),
@@ -472,6 +534,14 @@ def projection_is_valid(value: Any) -> bool:
     ):
         return False
     task = value.get("task")
+    engine = value.get("engine")
+    if (
+        not isinstance(engine, dict) or set(engine) != {"version", "hook_files_digest", "assurance"}
+        or engine["assurance"] != "unsigned-files-at-snapshot"
+        or engine["version"] is not None and (not isinstance(engine["version"], str) or re.fullmatch(r"\d+\.\d+\.\d+(?:\+codex\.\d{14})?", engine["version"]) is None)
+        or engine["hook_files_digest"] is not None and not _is_digest(engine["hook_files_digest"])
+    ):
+        return False
     summary = value.get("summary")
     sources = value.get("sources")
     map_value = value.get("map")
@@ -485,6 +555,16 @@ def projection_is_valid(value: Any) -> bool:
         or task.get("observer_mode") not in click_observer_control.MODES
         or task.get("observer_enabled")
         != (task.get("observer_mode") == "shadow")
+        or task.get("name") != click_incremental.safe_display_text(task.get("name"), "")
+        or not isinstance(task.get("approval_bound"), bool)
+        or not isinstance(task.get("contract_id"), str)
+        or task["contract_id"] and re.fullmatch(r"ctr_[0-9a-f]{32}", task["contract_id"]) is None
+        or any(not isinstance(task.get(key), list) or len(task[key]) > 8
+               or any(item != click_incremental.safe_display_text(item, "") for item in task[key])
+               for key in ("promises", "in_scope", "out_of_scope", "must_hold"))
+        or not click_incremental.accounting_is_valid(value.get("accounting"))
+        or not isinstance(value.get("controls"), list)
+        or value["controls"] != click_incremental.control_events({"control_events": value["controls"]})
         or not isinstance(summary, dict)
         or set(summary) != _SUMMARY_FIELDS
         or not isinstance(sources, list)
@@ -550,6 +630,9 @@ def projection_is_valid(value: Any) -> bool:
             or not isinstance(source.get("label"), str)
             or not source["label"]
             or source["label"] != click_incremental.safe_label(source["label"], "")
+            or source.get("check_digest") != "" and not _is_digest(source.get("check_digest"))
+            or any(source.get(key) != click_incremental.safe_display_text(source.get(key), "")
+                   for key in ("origin_name", "origin_check_label", "next_action"))
             or source.get("status") not in _SOURCE_STATUSES
             or source.get("execution_decision") not in _EXECUTION_DECISIONS
             or source.get("reason_code")

--- a/dist/antigravity/hooks/click_evidence.py
+++ b/dist/antigravity/hooks/click_evidence.py
@@ -35,6 +35,7 @@ EVIDENCE_STATUSES = {"ready", "running", "observed", "passed", "failed", "stale"
 EVIDENCE_STATE_VERSION = 1
 SUCCESSOR_EVIDENCE_FIELD = "successor_evidence"
 SUCCESSOR_EVIDENCE_VERSION = 1
+GUARDED_SUCCESSOR_VERSION = 2
 MAX_SUCCESSOR_EVIDENCE_BYTES = 2 * 1024 * 1024
 MAX_SUCCESSOR_SOURCES = 256
 _SUCCESSOR_FIELDS = frozenset({
@@ -43,6 +44,9 @@ _SUCCESSOR_FIELDS = frozenset({
     "captured_at", "evidence_state", "origins", "digest",
 })
 _SUCCESSOR_ORIGIN_FIELDS = frozenset({"batch_id", "execution_status"})
+_GUARDED_SUCCESSOR_FIELDS = (
+    _SUCCESSOR_FIELDS - {"origin_evidence_session_id"}
+) | {"origin_contract_id"}
 
 
 def evidence_key(evidence_id: str) -> str:
@@ -110,6 +114,7 @@ def _fresh_source(kind: str, dependency_patterns: tuple[str, ...] = ()) -> dict[
         "last_successor_reused_at": 0,
         "last_successor_origin_batch_id": "",
         "last_successor_origin_evidence_session_id": "",
+        "last_successor_origin_contract_id": "",
         "last_successor_candidate_digest": "",
         "last_successor_origin_revision": -1,
         "last_successor_mode": "",
@@ -153,6 +158,14 @@ def fresh_successor_evidence() -> dict[str, Any]:
     return {}
 
 
+def clear_successor_receipt(source: dict[str, Any]) -> None:
+    """A real current-lifecycle execution replaces previously reused lineage."""
+    source.update({
+        key: value for key, value in _fresh_source("argv").items()
+        if key == "successor_reuse_count" or key.startswith("last_successor_")
+    })
+
+
 def successor_scope_digest(identity: str) -> str:
     return hashlib.sha256(identity.encode()).hexdigest()
 
@@ -171,15 +184,19 @@ def successor_evidence_is_valid(
     expected_contract_schema_version: int,
     scope_digest: str,
 ) -> bool:
+    guarded = isinstance(value, dict) and value.get("version") == GUARDED_SUCCESSOR_VERSION
+    identity_field = "origin_contract_id" if guarded else "origin_evidence_session_id"
+    identity_pattern = r"ctr_[0-9a-f]{32}" if guarded else r"evs_[0-9a-f]{32}"
     if (
         not isinstance(value, dict)
-        or set(value) != _SUCCESSOR_FIELDS
-        or value.get("version") != SUCCESSOR_EVIDENCE_VERSION
+        or set(value) != (_GUARDED_SUCCESSOR_FIELDS if guarded else _SUCCESSOR_FIELDS)
+        or value.get("version") not in {SUCCESSOR_EVIDENCE_VERSION, GUARDED_SUCCESSOR_VERSION}
+        or isinstance(value.get("version"), bool)
         or value.get("scope_digest") != scope_digest
         or not isinstance(scope_digest, str)
         or re.fullmatch(r"[0-9a-f]{64}", scope_digest) is None
-        or not isinstance(value.get("origin_evidence_session_id"), str)
-        or re.fullmatch(r"evs_[0-9a-f]{32}", value["origin_evidence_session_id"])
+        or not isinstance(value.get(identity_field), str)
+        or re.fullmatch(identity_pattern, value[identity_field])
         is None
         or not isinstance(value.get("origin_intent_digest"), str)
         or re.fullmatch(r"[0-9a-f]{64}", value["origin_intent_digest"]) is None
@@ -242,7 +259,11 @@ def carry_successor_evidence(
     expected_contract_schema_version: int,
     now: int | None = None,
 ) -> bool:
-    """Carry one completed Evidence ledger as re-evaluation candidates only."""
+    """Carry completed facts, never approval, claims, runner or completion state.
+
+    The lifecycle caller must establish completion before calling this helper.
+    Cross-mode carry is deliberately unsupported.
+    """
     sources = sources_from_state(
         previous,
         expected_contract_schema_version=expected_contract_schema_version,
@@ -254,17 +275,25 @@ def carry_successor_evidence(
         if isinstance(verification, dict)
         else None
     )
-    session_id = previous.get("evidence_session_id")
+    guarded = previous.get("runtime_mode") == "guarded"
+    identity_field = "origin_contract_id" if guarded else "origin_evidence_session_id"
+    session_id = previous.get("contract_id" if guarded else "evidence_session_id")
     intent_digest = previous.get("intent_digest")
     if (
-        not sources
+        current.get("runtime_mode") != previous.get("runtime_mode")
+        or guarded and (
+            previous.get("status") != "approved"
+            or not previous.get("approved_turn_id")
+            or previous.get("approved_turn_id") == previous.get("staged_turn_id")
+        )
+        or not sources
         or len(sources) > MAX_SUCCESSOR_SOURCES
         or not isinstance(evidence_state, dict)
         or not isinstance(revision, int)
         or isinstance(revision, bool)
         or revision < 0
         or not isinstance(session_id, str)
-        or re.fullmatch(r"evs_[0-9a-f]{32}", session_id) is None
+        or re.fullmatch(r"ctr_[0-9a-f]{32}" if guarded else r"evs_[0-9a-f]{32}", session_id) is None
         or not isinstance(intent_digest, str)
         or re.fullmatch(r"[0-9a-f]{64}", intent_digest) is None
     ):
@@ -280,9 +309,9 @@ def carry_successor_evidence(
     if not eligible:
         return False
     value = {
-        "version": SUCCESSOR_EVIDENCE_VERSION,
+        "version": GUARDED_SUCCESSOR_VERSION if guarded else SUCCESSOR_EVIDENCE_VERSION,
         "scope_digest": scope_digest,
-        "origin_evidence_session_id": session_id,
+        identity_field: session_id,
         "origin_intent_digest": intent_digest,
         "origin_revision": revision,
         "origin_registry_digest": registry_digest(sources),
@@ -317,14 +346,27 @@ def successor_candidate(
     ):
         return None
     assert isinstance(value, dict)
+    guarded = value["version"] == GUARDED_SUCCESSOR_VERSION
+    if guarded and not (
+        state.get("runtime_mode") == "guarded"
+        and state.get("status") == "approved"
+        and state.get("approved_turn_id")
+        and state.get("approved_turn_id") != state.get("staged_turn_id")
+        and state.get("contract_id") != value["origin_contract_id"]
+    ):
+        return None
+    if not guarded and state.get("runtime_mode") != "evidence":
+        return None
     origin = value["origins"].get(source_key)
     source = value["evidence_state"]["sources"].get(source_key)
     if not isinstance(origin, dict) or not isinstance(source, dict):
         return None
     metadata = {
-        "kind": "successor-evidence",
+        "kind": "successor-contract" if guarded else "successor-evidence",
         "batch_id": origin["batch_id"],
-        "evidence_session_id": value["origin_evidence_session_id"],
+        ("contract_id" if guarded else "evidence_session_id"): value[
+            "origin_contract_id" if guarded else "origin_evidence_session_id"
+        ],
         "candidate_digest": value["digest"],
         "origin_revision": value["origin_revision"],
     }
@@ -616,6 +658,7 @@ def _successor_fields_are_valid(source: dict[str, Any]) -> bool:
     origin_revision = source.get("last_successor_origin_revision", -1)
     batch_id = source.get("last_successor_origin_batch_id", "")
     session_id = source.get("last_successor_origin_evidence_session_id", "")
+    contract_id = source.get("last_successor_origin_contract_id", "")
     candidate_digest = source.get("last_successor_candidate_digest", "")
     mode = source.get("last_successor_mode", "")
     if any(
@@ -626,19 +669,22 @@ def _successor_fields_are_valid(source: dict[str, Any]) -> bool:
     if count < 0 or reused_at < 0 or origin_revision < -1:
         return False
     if not all(isinstance(value, str) for value in (
-        batch_id, session_id, candidate_digest, mode
+        batch_id, session_id, contract_id, candidate_digest, mode
     )):
         return False
     if count == 0:
         return bool(
             reused_at == 0 and origin_revision == -1 and not batch_id
-            and not session_id and not candidate_digest and not mode
+            and not session_id and not contract_id and not candidate_digest and not mode
         )
     return bool(
         reused_at > 0
         and origin_revision >= 0
         and re.fullmatch(r"[0-9a-f]{32}", batch_id)
-        and re.fullmatch(r"evs_[0-9a-f]{32}", session_id)
+        and (
+            not contract_id and re.fullmatch(r"evs_[0-9a-f]{32}", session_id)
+            or not session_id and re.fullmatch(r"ctr_[0-9a-f]{32}", contract_id)
+        )
         and re.fullmatch(r"[0-9a-f]{64}", candidate_digest)
         and mode in {"exact", "dependency", "safe-change"}
     )

--- a/dist/antigravity/hooks/click_gate.py
+++ b/dist/antigravity/hooks/click_gate.py
@@ -206,7 +206,9 @@ def _emit(payload: dict[str, Any]) -> None:
     _OUTPUT_SINK(payload)
 
 
-def _deny(reason: str) -> None:
+def _deny(reason: str, *, event: dict[str, Any] | None = None, code: str = "") -> None:
+    if event is not None:
+        click_lifecycle.record_control_event(event, code)
     _emit(_OUTPUT_ADAPTER.deny(reason))
 
 
@@ -691,7 +693,8 @@ def _handle_pre_tool(event: dict[str, Any]) -> None:
                 ):
                     _deny(
                         "Pass the approved Click execution contract in the current turn "
-                        "before starting a structured mutation."
+                        "before starting a structured mutation.",
+                        event=event, code="approval-required",
                     )
                     return
                 rewritten, mutation_error = _prepare_mutation(event, value)
@@ -710,7 +713,8 @@ def _handle_pre_tool(event: dict[str, Any]) -> None:
                 ):
                     _deny(
                         "Pass the approved Click execution contract in the current turn "
-                        "before managing its local development service."
+                        "before managing its local development service.",
+                        event=event, code="approval-required",
                     )
                     return
                 rewritten, service_error = _prepare_service(event, value)
@@ -760,7 +764,8 @@ def _handle_pre_tool(event: dict[str, Any]) -> None:
                 ):
                     _deny(
                         "Pass the approved Click execution contract in the current turn "
-                        "before starting its final verification batch."
+                        "before starting its final verification batch.",
+                        event=event, code="approval-required",
                     )
                     return
                 (
@@ -788,7 +793,7 @@ def _handle_pre_tool(event: dict[str, Any]) -> None:
                         event, value
                     )
                 if lifecycle_error:
-                    _deny(lifecycle_error)
+                    _deny(lifecycle_error, event=event, code="contract-lifecycle-rejected")
                     return
                 if action == "stage":
                     contract, projection_error = click_contract.validate_contract(value)
@@ -990,7 +995,8 @@ def _handle_pre_tool(event: dict[str, Any]) -> None:
             "`click-gate bypass` only after the current user turn begins with a recognized "
             "first-line `@Click bypass` directive or trusted Click autocomplete mention. "
             "Use the corresponding `@Click cancel` form plus `click-gate cancel` to discard "
-            "an active contract instead of bypassing it."
+            "an active contract instead of bypassing it.",
+            event=event, code="approval-required",
         )
 
 

--- a/dist/antigravity/hooks/click_incremental.py
+++ b/dist/antigravity/hooks/click_incremental.py
@@ -10,6 +10,7 @@ explaining that batch to read-only consumers.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import math
 import re
@@ -181,7 +182,7 @@ def decision(
 # share the existing age/count/byte budget with legacy planning events.
 BATCH_STATUSES = frozenset({"planned", "running", "passed", "failed", "interrupted", "rejected", "incomplete"})
 SOURCE_STATUSES = frozenset({"planned", "reuse-pending", "running", "passed", "failed", "interrupted", "not-run", "reused", "unknown"})
-REUSE_ORIGIN_KINDS = frozenset({"successor-evidence"})
+REUSE_ORIGIN_KINDS = frozenset({"successor-evidence", "successor-contract"})
 EXECUTION_REASONS = frozenset({
     "", "batch-finished", "request-rejected", "runner-admission-rejected",
     "plan-not-created", "reuse-applied", "command-started", "command-passed",
@@ -189,6 +190,7 @@ EXECUTION_REASONS = frozenset({
     "preceding-check-stopped", "workspace-invalidated", "outcome-unconfirmed",
     "reservation-expired",
     "user-cancelled",
+    "not-requested",
 })
 _BATCH_FIELDS = frozenset({
     "event", "version", "batch_id", "timestamp", "finished_at", "current_revision",
@@ -213,6 +215,83 @@ SUMMARY_FIELDS = (
     "request_wall_ms", "measured_processing_ms", "estimated_avoided_ms",
     "estimated_source_count", "baseline_sample_count",
 )
+CONTROL_CODES = frozenset({
+    "approval-required", "contract-id-mismatch", "contract-lifecycle-rejected",
+    "verification-request-rejected", "verification-guidance",
+})
+CONTROL_FIELDS = frozenset({"event_id", "timestamp", "code", "effect"})
+
+
+def control_events(state: Any) -> list[dict[str, Any]]:
+    values = state.get("control_events", []) if isinstance(state, dict) else []
+    if not isinstance(values, list):
+        return []
+    unique = {}
+    for value in values[-128:]:
+        if (
+            isinstance(value, dict) and set(value) == CONTROL_FIELDS
+            and isinstance(value.get("event_id"), str) and _DIGEST.fullmatch(value["event_id"])
+            and _is_integer(value.get("timestamp"), minimum=1)
+            and value.get("code") in CONTROL_CODES
+            and value.get("effect") == ("advisory" if value["code"] == "verification-guidance" else "blocked")
+        ):
+            unique[value["event_id"]] = dict(value)
+    return list(unique.values())
+
+
+def record_control_event(state: dict[str, Any], event: dict[str, Any], code: str) -> bool:
+    """Prose-free observation only. Never consulted by any authorization check."""
+    if code not in CONTROL_CODES or not event.get("tool_use_id"):
+        return False
+    identity = hashlib.sha256(_canonical_bytes([
+        event.get("session_id"), event.get("turn_id"), event.get("tool_use_id"),
+        event.get("tool_input"), "advisory" if code == "verification-guidance" else "blocked",
+    ])).hexdigest()
+    values = control_events(state)
+    if any(value["event_id"] == identity for value in values):
+        return False
+    values.append({"event_id": identity, "timestamp": int(time.time()) or 1,
+                   "code": code, "effect": "advisory" if code == "verification-guidance" else "blocked"})
+    state["control_events"] = values[-128:]
+    return True
+
+
+def _clock_id() -> str:
+    return time.get_clock_info("monotonic").implementation
+
+
+def start_request_clock(
+    verification: dict[str, Any], batch_id: str, *,
+    started_ns: int | None = None, clock_id: str | None = None,
+) -> None:
+    verification["incremental_request_clock"] = {
+        "batch_id": batch_id, "started_ns": time.monotonic_ns() if started_ns is None else started_ns,
+        "clock_id": _clock_id() if clock_id is None else clock_id,
+    }
+
+
+def complete_request_timing(
+    verification: dict[str, Any], batch: dict[str, Any], *,
+    ended_ns: int | None = None, clock_id: str | None = None,
+) -> None:
+    """Same-host monotonic interval; excludes pre-Hook queue and final return.
+
+    A missing, mismatched or regressed clock stays unknown. Timing is never
+    consulted by runner admission, reuse or contract completion.
+    """
+    clock = verification.get("incremental_request_clock")
+    ended = time.monotonic_ns() if ended_ns is None else ended_ns
+    if not isinstance(clock, dict):
+        return
+    started = clock.get("started_ns")
+    if (
+        clock.get("batch_id") == batch.get("batch_id")
+        and clock.get("clock_id") == (_clock_id() if clock_id is None else clock_id)
+        and _is_integer(started) and _is_integer(ended)
+        and 0 <= ended - started <= 24 * 60 * 60 * 1_000_000_000
+    ):
+        batch.update(version=max(batch.get("version", 2), 3), request_wall_ms=(ended - started) / 1_000_000,
+                     measurement_scope="hook-entry-to-result-recording")
 
 
 def safe_label(value: Any, fallback: str) -> str:
@@ -225,15 +304,69 @@ def safe_label(value: Any, fallback: str) -> str:
     ) else fallback
 
 
+def safe_display_text(value: Any, fallback: str = "승인 계약 원문에서 확인") -> str:
+    """Bounded local display copy, not an approval or a secret-redaction proof."""
+    if (
+        not isinstance(value, str) or not value or len(value) > 240
+        or re.fullmatch(r"[\w가-힣\s.,!?()·→–—-]+", value) is None
+        or re.search(r"(?i)(token|secret|password|bearer|api.?key|비밀번호|비밀키)", value)
+        or any(char in value for char in "\n\r\t")
+    ):
+        return fallback
+    return value
+
+
+def sanitize_presentation(value: Any) -> dict[str, Any]:
+    value = value if isinstance(value, dict) else {}
+    labels = value.get("evidence_labels", {})
+    return {
+        "name": safe_display_text(value.get("name"), "현재 작업"),
+        **{key: [safe_display_text(item) for item in value.get(key, [])[:8]]
+           if isinstance(value.get(key), list) else []
+           for key in ("promises", "in_scope", "out_of_scope", "must_hold")},
+        "evidence_labels": {
+            key: safe_label(label, "검증 묶음") for key, label in list(labels.items())[:256]
+            if isinstance(key, str) and _DIGEST.fullmatch(key)
+        } if isinstance(labels, dict) else {},
+    }
+
+
+def contract_presentation(contract: dict[str, Any]) -> dict[str, Any]:
+    verification = contract.get("verification", {})
+    boundary = contract.get("boundary", {})
+    return sanitize_presentation({
+        "name": contract.get("outcome"),
+        "promises": [item.get("condition") for item in verification.get("done_when", [])],
+        "in_scope": boundary.get("in_scope"), "out_of_scope": boundary.get("out_of_scope"),
+        "must_hold": contract.get("must_hold"),
+        "evidence_labels": {hashlib.sha256(item["id"].encode()).hexdigest(): safe_label(item.get("description"), safe_label(item["id"], "검증 묶음"))
+                            for item in verification.get("evidence", [])},
+    })
+
+
+def batch_task_is_valid(value: Any) -> bool:
+    return bool(
+        isinstance(value, dict) and set(value) == {"mode", "id", "name"}
+        and value.get("mode") in {"guarded", "evidence"}
+        and isinstance(value.get("id"), str)
+        and re.fullmatch(r"ctr_[0-9a-f]{32}" if value["mode"] == "guarded" else r"evs_[0-9a-f]{32}", value["id"])
+        and value.get("name") == safe_display_text(value.get("name"), "")
+        and value["name"]
+    )
+
+
 def reuse_origin_is_valid(value: Any) -> bool:
+    guarded = isinstance(value, dict) and value.get("kind") == "successor-contract"
+    identity_field = "contract_id" if guarded else "evidence_session_id"
+    fields = (_REUSE_ORIGIN_FIELDS - {"evidence_session_id"}) | {identity_field}
     return bool(
         isinstance(value, dict)
-        and set(value) == _REUSE_ORIGIN_FIELDS
+        and set(value) == fields
         and value.get("kind") in REUSE_ORIGIN_KINDS
         and isinstance(value.get("batch_id"), str)
         and re.fullmatch(r"[0-9a-f]{32}", value["batch_id"])
-        and isinstance(value.get("evidence_session_id"), str)
-        and re.fullmatch(r"evs_[0-9a-f]{32}", value["evidence_session_id"])
+        and isinstance(value.get(identity_field), str)
+        and re.fullmatch(r"ctr_[0-9a-f]{32}" if guarded else r"evs_[0-9a-f]{32}", value[identity_field])
         and isinstance(value.get("candidate_digest"), str)
         and _DIGEST.fullmatch(value["candidate_digest"])
         and _is_integer(value.get("origin_revision"))
@@ -270,11 +403,13 @@ def source_result_is_valid(value: Any) -> bool:
 
 
 def batch_is_valid(value: Any) -> bool:
-    if not isinstance(value, dict) or set(value) != _BATCH_FIELDS:
+    if not isinstance(value, dict) or set(value) != (_BATCH_FIELDS | {"task"} if value.get("version") == 4 else _BATCH_FIELDS):
         return False
     items = value.get("sources")
     return bool(
-        value.get("event") == BATCH_EVENT and value.get("version") in {1, 2}
+        value.get("event") == BATCH_EVENT and value.get("version") in {1, 2, 3, 4}
+        and (value["version"] != 4 or batch_task_is_valid(value.get("task")))
+        and not isinstance(value.get("version"), bool)
         and isinstance(value.get("batch_id"), str)
         and re.fullmatch(r"[0-9a-f]{32}", value["batch_id"])
         and _is_integer(value.get("timestamp"), minimum=1)
@@ -287,7 +422,7 @@ def batch_is_valid(value: Any) -> bool:
         and all(source_result_is_valid(item) for item in items)
         and all(
             (value["version"] == 1 and "reuse_origin" not in item)
-            or (value["version"] == 2 and "reuse_origin" in item)
+            or (value["version"] in {2, 3, 4} and "reuse_origin" in item)
             for item in items
         )
         and len({item["source_key"] for item in items}) == len(items)
@@ -295,10 +430,12 @@ def batch_is_valid(value: Any) -> bool:
         and all(value.get(key) is None or is_duration(value[key]) for key in (
             "prepare_duration_ms", "runner_duration_ms", "request_wall_ms"
         ))
-        and value.get("request_wall_ms") is None
-        and value.get("measurement_scope") in {
-            "unknown", "prepare-only", "prepare-and-runner-segments"
-        }
+        and (
+            value.get("request_wall_ms") is None
+            and value.get("measurement_scope") in {"unknown", "prepare-only", "prepare-and-runner-segments"}
+            or value["version"] in {3, 4} and is_duration(value.get("request_wall_ms"))
+            and value.get("measurement_scope") == "hook-entry-to-result-recording"
+        )
     )
 
 
@@ -307,6 +444,7 @@ def new_batch(
     prepared_ms: float | None, requested: list[dict[str, str]] | None = None,
     labels: dict[str, str] | None = None,
     reuse_origins: dict[str, dict[str, Any]] | None = None,
+    task: dict[str, Any] | None = None,
     now: int | None = None,
 ) -> dict[str, Any]:
     timestamp = int(time.time()) if now is None else now
@@ -328,6 +466,8 @@ def new_batch(
         # Host queue/handoff/return is not measured by these separate processes.
         "request_wall_ms": None, "measurement_scope": "prepare-only",
     }
+    if batch_task_is_valid(task):
+        batch.update(version=4, task=dict(task))
     for index, item in enumerate(items, start=1):
         source = dict(item)
         source.setdefault("duration_baseline", None)
@@ -408,6 +548,7 @@ def reject_batch(
         batch.update(runner_duration_ms=runner_duration_ms, measurement_scope="prepare-and-runner-segments")
     for item in batch["sources"]:
         item.update(status="not-run", execution_reason_code=reason)
+    complete_request_timing(verification, batch)
     return store_batch(verification, batch)
 
 
@@ -418,6 +559,7 @@ def finish_reuse(verification: dict[str, Any]) -> bool:
     batch.update(status="passed", reason_code="batch-finished", finished_at=int(time.time()))
     for item in batch["sources"]:
         item.update(status="reused", execution_reason_code="reuse-applied")
+    complete_request_timing(verification, batch)
     return store_batch(verification, batch)
 
 
@@ -483,6 +625,7 @@ def interrupt_batch(verification: dict[str, Any]) -> bool:
             status="interrupted" if item["started"] else "not-run",
             execution_reason_code="user-cancelled", completed=False,
         )
+    complete_request_timing(verification, batch)
     return store_batch(verification, batch)
 
 
@@ -506,6 +649,48 @@ def history_totals(verification: Any) -> dict[str, int]:
         )}}
 
 
+def history_accounting(verification: Any) -> dict[str, Any]:
+    """Count actual group requests, including distinct retries, not test cases."""
+    batches = batch_history(verification)
+    summaries = [batch_summary(batch) for batch in batches]
+    unknown_requests = sum(batch["requested_source_count"] is None for batch in batches)
+    denominator = sum(batch["requested_source_count"] or 0 for batch in batches)
+    numerator = sum(item["authoritative_reuse_count"] for item in summaries)
+    return {
+        "unit": "verification-group-request", "window": "retained-history",
+        "from_timestamp": min((batch["timestamp"] for batch in batches), default=None),
+        "through_timestamp": max((batch["finished_at"] or batch["timestamp"] for batch in batches), default=None),
+        "max_age_seconds": MAX_HISTORY_AGE_SECONDS, "max_events": MAX_HISTORY_EVENTS,
+        "batch_count": len(batches), "unknown_request_batch_count": unknown_requests,
+        "request_denominator": denominator, "reuse_numerator": numerator,
+        "reuse_rate": numerator / denominator if denominator and not unknown_requests else None,
+        "missing_baseline_duration_count": sum(item["authoritative_reuse_count"] - item["estimated_source_count"] for item in summaries),
+        **{key: sum(item[key] for item in summaries) for key in (
+            "executed_source_count", "passed_source_count", "failed_source_count",
+            "interrupted_source_count", "not_run_source_count", "pending_source_count",
+        )},
+    }
+
+
+def accounting_is_valid(value: Any) -> bool:
+    example = history_accounting({})
+    if not isinstance(value, dict) or set(value) != set(example):
+        return False
+    if value["unit"] != example["unit"] or value["window"] != example["window"]:
+        return False
+    for key, item in value.items():
+        if key in {"unit", "window", "reuse_rate"}:
+            continue
+        if key in {"from_timestamp", "through_timestamp"} and item is None:
+            continue
+        if not _is_integer(item):
+            return False
+    denominator, numerator = value["request_denominator"], value["reuse_numerator"]
+    return bool(numerator <= denominator and value["reuse_rate"] == (
+        numerator / denominator if denominator and not value["unknown_request_batch_count"] else None
+    ))
+
+
 def batch_summary(batch: dict[str, Any]) -> dict[str, Any]:
     if not batch_is_valid(batch):
         raise ValueError("invalid verification batch")
@@ -516,7 +701,7 @@ def batch_summary(batch: dict[str, Any]) -> dict[str, Any]:
     planned_runs = sum(item["decision"] in DECISIONS - REUSE_DECISIONS for item in items)
     times = [item["duration_ms"] for item in started]
     prep, runner = batch["prepare_duration_ms"], batch["runner_duration_ms"]
-    measured = prep if batch["measurement_scope"] == "prepare-only" else (
+    measured = prep if runner is None else (
         prep + runner if prep is not None and runner is not None else None
     )
     return {
@@ -541,6 +726,24 @@ def batch_summary(batch: dict[str, Any]) -> dict[str, Any]:
         "estimated_source_count": len(baselines),
         "baseline_sample_count": sum(item["sample_count"] for item in baselines),
     }
+
+
+def host_summary(verification: Any) -> str:
+    batch = current_batch(verification)
+    if batch is None:
+        return ""
+    summary = batch_summary(batch)
+    prior = sum(item["status"] == "reused" and item.get("reuse_origin") is not None for item in batch["sources"])
+    avoided = summary["estimated_avoided_ms"]
+    estimate = "unmeasured" if avoided is None else f"{avoided:.1f}ms"
+    return (
+        f"[Click result] groups requested={summary['total_source_count']} "
+        f"executed={summary['executed_source_count']} passed={summary['passed_source_count']} "
+        f"failed={summary['failed_source_count']} interrupted={summary['interrupted_source_count']} "
+        f"not-started={summary['not_run_source_count']} reused={summary['authoritative_reuse_count']} "
+        f"(requalified-prior-task={prior}); estimated avoided rerun cost={estimate}; "
+        "not measured net savings."
+    )
 
 
 
@@ -762,6 +965,7 @@ def record_execution(
     batch["finished_at"] = int(time.time())
     batch["runner_duration_ms"] = runner_duration_ms
     batch["measurement_scope"] = "prepare-and-runner-segments"
+    complete_request_timing(verification, batch)
     return store_batch(verification, batch)
 
 

--- a/dist/antigravity/hooks/click_lifecycle.py
+++ b/dist/antigravity/hooks/click_lifecycle.py
@@ -90,6 +90,16 @@ def _write_state(
     click_state.write_json(click_state.state_path(event), payload)
 
 
+def record_control_event(event: dict[str, Any], code: str) -> None:
+    """Called within the host's state lock; failures cannot affect admission."""
+    try:
+        state = _read_contract_state(event)
+        if state and click_incremental.record_control_event(state, event, code):
+            _save_contract_state(event, state)
+    except Exception:
+        pass
+
+
 def _read_state(event: dict[str, Any]) -> dict[str, Any]:
     path = click_state.state_path(event)
     try:
@@ -111,9 +121,8 @@ def _write_contract_state(
     event: dict[str, Any], status: str, digest: str, contract: dict[str, Any]
 ) -> str:
     contract_id = f"ctr_{secrets.token_hex(16)}"
-    click_state.write_json(
-        click_state.contract_path(event),
-        {
+    previous = _read_contract_state(event)
+    current = {
             "state_schema_version": CONTRACT_STATE_SCHEMA_VERSION,
             "status": status,
             "contract_digest": digest,
@@ -121,6 +130,7 @@ def _write_contract_state(
             "staged_turn_id": str(event.get("turn_id", "")),
             "approved_turn_id": "",
             "runtime_mode": "guarded",
+            "presentation": click_incremental.contract_presentation(contract),
             "intent_digest": digest,
             "intent_turn_id": str(event.get("turn_id", "")),
             "follow_up_turns": [],
@@ -136,9 +146,52 @@ def _write_contract_state(
                 click_shadow_dashboard.fresh_state()
             ),
             "updated_at": int(time.time()),
-        },
-    )
+        }
+    if (
+        click_runtime_state.view(previous).guarded_approved
+        and _contract_is_completed(previous)
+    ):
+        _carry_completed_candidates(event, previous, current)
+    # Viewer history is deliberately separate from the fresh authority ledger.
+    presentations = previous.get("presentation_history", {})
+    presentations = dict(presentations) if isinstance(presentations, dict) else {}
+    if CONTRACT_ID_PATTERN.fullmatch(str(previous.get("contract_id", ""))):
+        presentations[previous["contract_id"]] = click_incremental.sanitize_presentation(previous.get("presentation"))
+    current["presentation_history"] = dict(list(presentations.items())[-8:])
+    current["verification"][click_incremental.CURRENT_BATCH_FIELD] = None
+    _save_contract_state(event, current)
     return contract_id
+
+
+def _carry_completed_candidates(
+    event: dict[str, Any], previous: dict[str, Any], current: dict[str, Any]
+) -> None:
+    verification = previous.get("verification", {})
+    revision = verification.get("mutation_revision", 0)
+    _, claim_error = click_claims.receipt_entries(previous, settle_through_revision=revision)
+    if claim_error:
+        return
+    sources = _evidence_sources(previous) or {}
+    origins: dict[str, dict[str, str]] = {}
+    for batch in click_incremental.batch_history(previous.get("verification")):
+        for source in batch["sources"]:
+            fact = sources.get(source["source_key"], {})
+            if (
+                source["status"] in {"passed", "reused"}
+                and batch["current_revision"] == revision
+                and source["check_digest"] == fact.get("verified_check_digest")
+            ):
+                origins[source["source_key"]] = {
+                    "batch_id": batch["batch_id"],
+                    "execution_status": source["status"],
+                }
+    click_evidence.carry_successor_evidence(
+        previous, current, origins=origins,
+        scope_digest=click_evidence.successor_scope_digest(
+            str(click_state.contract_path(event).resolve())
+        ),
+        expected_contract_schema_version=CONTRACT_STATE_SCHEMA_VERSION,
+    )
 
 
 def _fresh_evidence_state(
@@ -213,25 +266,7 @@ def _ensure_evidence_state(event: dict[str, Any]) -> tuple[dict[str, Any], bool]
         previous = state
         state = _fresh_evidence_state(event, history_complete=not recovered)
         if completed_evidence:
-            origins: dict[str, dict[str, str]] = {}
-            for batch in click_incremental.batch_history(
-                previous.get("verification")
-            ):
-                for source in batch["sources"]:
-                    if source["status"] in {"passed", "reused"}:
-                        origins[source["source_key"]] = {
-                            "batch_id": batch["batch_id"],
-                            "execution_status": source["status"],
-                        }
-            click_evidence.carry_successor_evidence(
-                previous,
-                state,
-                origins=origins,
-                scope_digest=click_evidence.successor_scope_digest(
-                    str(click_state.contract_path(event).resolve())
-                ),
-                expected_contract_schema_version=CONTRACT_STATE_SCHEMA_VERSION,
-            )
+            _carry_completed_candidates(event, previous, state)
         _save_contract_state(event, state)
         return state, recovered
     if _append_follow_up(event, state):
@@ -712,6 +747,7 @@ def pass_contract(event: dict[str, Any], contract_id: str) -> tuple[str, str]:
             "it explicitly, then stage and show the contract again.",
         )
     if contract_id != expected_id:
+        record_control_event(event, "contract-id-mismatch")
         return (
             "",
             "The contract_id differs from the proposal staged for user approval. "

--- a/dist/antigravity/hooks/click_receipt.py
+++ b/dist/antigravity/hooks/click_receipt.py
@@ -19,11 +19,13 @@ LEGACY_RECEIPT_VERSION = 1
 RECEIPT_VERSION = 2
 SHARD_RECEIPT_VERSION = 3
 SUCCESSOR_RECEIPT_VERSION = 4
+GUARDED_SUCCESSOR_RECEIPT_VERSION = 5
 SUPPORTED_RECEIPT_VERSIONS = {
     LEGACY_RECEIPT_VERSION,
     RECEIPT_VERSION,
     SHARD_RECEIPT_VERSION,
     SUCCESSOR_RECEIPT_VERSION,
+    GUARDED_SUCCESSOR_RECEIPT_VERSION,
 }
 ENVELOPE_VERSION = 1
 UNSIGNED_ASSURANCE = "unsigned-integrity-only"
@@ -117,6 +119,9 @@ SUCCESSOR_LINEAGE_FIELDS = LINEAGE_FIELDS | {
     "origin_evidence_session_id",
     "requalification_mode",
 }
+GUARDED_SUCCESSOR_LINEAGE_FIELDS = (
+    SUCCESSOR_LINEAGE_FIELDS - {"origin_evidence_session_id"}
+) | {"origin_contract_id"}
 COVERAGE_FIELDS = {
     "host_assurance",
     "host_coverage_digest",
@@ -348,7 +353,11 @@ def _normalize_lineage(
     value: Any, *, kind: str, revision: int, receipt_version: int
 ) -> tuple[dict[str, Any] | None, str]:
     successor = isinstance(value, dict) and value.get("mode") == "successor-reused"
-    fields = SUCCESSOR_LINEAGE_FIELDS if successor else LINEAGE_FIELDS
+    guarded = successor and "origin_contract_id" in value
+    fields = (
+        GUARDED_SUCCESSOR_LINEAGE_FIELDS if guarded
+        else SUCCESSOR_LINEAGE_FIELDS if successor else LINEAGE_FIELDS
+    )
     error = _exact_fields(value, fields, "evidence.lineage")
     if error:
         return None, error
@@ -370,16 +379,19 @@ def _normalize_lineage(
         return None, f"Completion receipt lineage mode is invalid for `{kind}` evidence."
     if mode == "successor-reused":
         origin_batch_id = value.get("origin_batch_id")
-        origin_session_id = value.get("origin_evidence_session_id")
+        identity_field = "origin_contract_id" if guarded else "origin_evidence_session_id"
+        origin_session_id = value.get(identity_field)
         requalification_mode = value.get("requalification_mode")
         if (
-            receipt_version != SUCCESSOR_RECEIPT_VERSION
+            receipt_version != (
+                GUARDED_SUCCESSOR_RECEIPT_VERSION if guarded else SUCCESSOR_RECEIPT_VERSION
+            )
             or kind != "argv"
             or not _is_digest(dependency_digest)
             or not isinstance(origin_batch_id, str)
             or re.fullmatch(r"[0-9a-f]{32}", origin_batch_id) is None
             or not isinstance(origin_session_id, str)
-            or re.fullmatch(r"evs_[0-9a-f]{32}", origin_session_id) is None
+            or re.fullmatch(r"ctr_[0-9a-f]{32}" if guarded else r"evs_[0-9a-f]{32}", origin_session_id) is None
             or requalification_mode not in {"exact", "dependency", "safe-change"}
         ):
             return None, "Successor-reused evidence lineage is invalid."
@@ -388,7 +400,7 @@ def _normalize_lineage(
             "from_revision": from_revision,
             "dependency_digest": dependency_digest,
             "origin_batch_id": origin_batch_id,
-            "origin_evidence_session_id": origin_session_id,
+            identity_field: origin_session_id,
             "requalification_mode": requalification_mode,
         }, ""
     if mode == "dependency-reused":
@@ -457,7 +469,7 @@ def _normalize_evidence(
 ) -> tuple[dict[str, Any] | None, str]:
     fields = (
         SHARDED_EVIDENCE_FIELDS
-        if receipt_version in {SHARD_RECEIPT_VERSION, SUCCESSOR_RECEIPT_VERSION}
+        if receipt_version in {SHARD_RECEIPT_VERSION, SUCCESSOR_RECEIPT_VERSION, GUARDED_SUCCESSOR_RECEIPT_VERSION}
         else EVIDENCE_FIELDS
     )
     error = _exact_fields(value, fields, "evidence source")
@@ -525,7 +537,7 @@ def _normalize_evidence(
         },
         "lineage": lineage,
     }
-    if receipt_version in {SHARD_RECEIPT_VERSION, SUCCESSOR_RECEIPT_VERSION}:
+    if receipt_version in {SHARD_RECEIPT_VERSION, SUCCESSOR_RECEIPT_VERSION, GUARDED_SUCCESSOR_RECEIPT_VERSION}:
         if kind != "argv" and value.get("shard") is not None:
             return None, "Only argv evidence may carry shard provenance."
         shard, error = _normalize_shard(value.get("shard"), source_key=source_key)
@@ -584,6 +596,7 @@ def validate_receipt(value: Any) -> tuple[dict[str, Any] | None, str]:
         RECEIPT_VERSION,
         SHARD_RECEIPT_VERSION,
         SUCCESSOR_RECEIPT_VERSION,
+        GUARDED_SUCCESSOR_RECEIPT_VERSION,
     }:
         authority, error = _normalize_authority(value.get("authority"))
         if error:
@@ -651,7 +664,7 @@ def validate_receipt(value: Any) -> tuple[dict[str, Any] | None, str]:
         seen.add(source_key)
         normalized_evidence.append(normalized)
     normalized_evidence.sort(key=lambda source: str(source["source_key"]))
-    if version in {SHARD_RECEIPT_VERSION, SUCCESSOR_RECEIPT_VERSION}:
+    if version in {SHARD_RECEIPT_VERSION, SUCCESSOR_RECEIPT_VERSION, GUARDED_SUCCESSOR_RECEIPT_VERSION}:
         sharded = [
             source for source in normalized_evidence if source.get("shard") is not None
         ]
@@ -686,6 +699,12 @@ def validate_receipt(value: Any) -> tuple[dict[str, Any] | None, str]:
         for source in normalized_evidence
     ):
         return None, "Receipt v4 requires successor-reused evidence lineage."
+    if version == GUARDED_SUCCESSOR_RECEIPT_VERSION and (
+        authority is None or authority["mode"] != "guarded"
+        or not any("origin_contract_id" in source["lineage"] for source in normalized_evidence)
+        or any(source["lineage"].get("origin_contract_id") == contract["id"] for source in normalized_evidence)
+    ):
+        return None, "Receipt v5 requires separately approved Guarded successor lineage."
 
     workspace = execution["workspace"]
     assert isinstance(workspace, dict)

--- a/dist/antigravity/hooks/click_receipt_runtime.py
+++ b/dist/antigravity/hooks/click_receipt_runtime.py
@@ -172,6 +172,7 @@ def _evidence_receipts(
                 return None, "The host coverage identity changed after argv evidence completed."
 
         if kind == "argv" and int(source.get("successor_reuse_count", 0)) > 0:
+            guarded_origin = source.get("last_successor_origin_contract_id", "")
             lineage = {
                 "mode": "successor-reused",
                 "from_revision": int(
@@ -185,8 +186,8 @@ def _evidence_receipts(
                 "origin_batch_id": str(
                     source.get("last_successor_origin_batch_id", "")
                 ),
-                "origin_evidence_session_id": str(
-                    source.get("last_successor_origin_evidence_session_id", "")
+                ("origin_contract_id" if guarded_origin else "origin_evidence_session_id"): str(
+                    guarded_origin or source.get("last_successor_origin_evidence_session_id", "")
                 ),
                 "requalification_mode": str(
                     source.get("last_successor_mode", "")
@@ -244,6 +245,7 @@ def _evidence_receipts(
         if receipt_version in {
             click_receipt.SHARD_RECEIPT_VERSION,
             click_receipt.SUCCESSOR_RECEIPT_VERSION,
+            click_receipt.GUARDED_SUCCESSOR_RECEIPT_VERSION,
         }:
             metadata = source.get("shard")
             receipt_source["shard"] = (
@@ -301,7 +303,9 @@ def build_envelope(
         for source in sources.values()
     )
     receipt_version = (
-        click_receipt.SUCCESSOR_RECEIPT_VERSION
+        click_receipt.GUARDED_SUCCESSOR_RECEIPT_VERSION
+        if has_successor and any(source.get("last_successor_origin_contract_id") for source in sources.values())
+        else click_receipt.SUCCESSOR_RECEIPT_VERSION
         if has_successor
         else click_receipt.SHARD_RECEIPT_VERSION
         if any(

--- a/dist/antigravity/hooks/click_shadow_dashboard.py
+++ b/dist/antigravity/hooks/click_shadow_dashboard.py
@@ -81,25 +81,26 @@ HTML = """<!doctype html>
   </header>
   <main id="main">
     <section class="hero" aria-labelledby="title">
-      <div><p class="eyebrow">검증 효율 · INCREMENTAL VERIFICATION</p><h1 id="title">무엇을 실행했고,<br>얼마나 기다렸나요?</h1><p id="taskline">현재 Click 상태를 불러오는 중…</p><p id="batchHeadline">실제 검증 기록을 기다리고 있습니다.</p></div>
-      <div class="notice"><strong id="observerTitle">Observer 확인 중</strong><span id="observerBody">Dashboard와 Observer는 서로 독립적으로 동작합니다.</span></div>
+      <div><p class="eyebrow">승인한 약속 · 확인된 결과</p><h1 id="title">약속한 범위 안에서,<br>유효한 검증을 이어서.</h1><p id="taskline">현재 Click 상태를 불러오는 중…</p><p id="batchHeadline">실제 검증 기록을 기다리고 있습니다.</p></div>
+      <div class="notice"><strong id="topComparison">비교 실측 없음</strong><span>과거 실행시간은 비용 회피 추정입니다. 실제 순절감률은 동등한 비교 실측이 있어야 계산합니다.</span></div>
     </section>
+    <section class="panel contract-panel"><div class="panel-title"><h2 id="contractName">현재 작업</h2><span id="approvalState" class="pill">승인 상태 확인 중</span></div><div id="contractPromises"></div><details><summary>약속 전체·포함·제외 범위와 유지 조건</summary><div id="allPromises"></div><div id="contractBoundary"></div><p class="muted">로컬 표시용 요약입니다. 전체 약속과 승인 대상은 제시된 계약 원문을 기준으로 합니다. 표시 정보와 viewer 이력은 실행 권한이 아닙니다.</p><code id="contractId"></code></details><p id="controlSummary" class="muted"></p></section>
     <section class="metrics" aria-label="실제 증분 검증 결과">
       <article><span>요청한 검증 묶음</span><strong id="currentChecks">—</strong><small>개별 테스트 케이스 수가 아닙니다</small></article>
       <article><span>실제 실행</span><strong id="executedChecks">—</strong><small id="executionDetail">실제 시작한 검증 묶음</small></article>
       <article><span>실제 재사용</span><strong id="reusedChecks">—</strong><small>권한 규칙을 통과해 적용된 결과</small></article>
-      <article><span>생략한 실행 비용 · 추정</span><strong id="estimatedAvoided">—</strong><small id="estimateCoverage">과거 실행시간 기반 · 실측 절약 아님</small></article>
+      <article><span>재실행 비용 회피 추정</span><strong id="estimatedAvoided">—</strong><small id="estimateCoverage">과거 실행시간 기반 · 실측 절약 아님</small></article>
     </section>
     <section class="metric-split" aria-label="실제 결과와 Shadow 텔레메트리">
-      <article class="panel compact"><p class="eyebrow">실측 · 이번 검증</p><h2>대기시간과 실행 구간</h2><div class="statline"><span>전체 검증 대기시간</span><strong id="requestWall">—</strong></div><div class="statline"><span>측정 가능한 처리 구간</span><strong id="processingDuration">—</strong></div><p class="muted" id="timeScope">호스트 전달·대기·최종 반환은 계측 범위 밖입니다.</p><div class="statline"><span>검사 실행 구간 (Observer 포함)</span><strong id="executedDuration">—</strong></div><div class="statline"><span>동일 상태 / 관찰 입력 / 안전 변경 재사용</span><strong id="reuseBreakdown">—</strong></div></article>
-      <article class="panel compact shadow-card"><p class="eyebrow">SHADOW TELEMETRY · 권한 없음</p><h2>잠재 재사용 관찰</h2><div class="statline"><span>후보 / 확인 / 모순</span><strong id="shadowBreakdown">—</strong></div><div class="statline"><span>잠재 시간 / 관찰기 처리 비용</span><strong id="shadowTiming">—</strong></div><p class="muted" id="tracingSlowdown">추적으로 인한 검사 지연은 별도 측정하지 않았습니다.</p></article>
+      <article class="panel compact"><p class="eyebrow">실측 · 이번 검증</p><h2>측정된 구간과 빠진 구간</h2><div class="statline"><span>Hook 진입 → 결과 기록 · 부분 실측</span><strong id="requestWall">—</strong></div><div class="statline"><span>측정 가능한 처리 구간</span><strong id="processingDuration">—</strong></div><p class="muted" id="timeScope">호스트 요청 전·최종 반환은 계측 범위 밖입니다.</p><div class="statline"><span>검사 실행 구간 (Observer 포함)</span><strong id="executedDuration">—</strong></div><div class="statline"><span>동일 상태 / 관찰 입력 / 안전 변경 재사용</span><strong id="reuseBreakdown">—</strong></div></article>
+      <article class="panel compact"><p class="eyebrow">재사용의 출처와 비교 조건</p><h2 id="comparisonStatus">비교 실측 없음</h2><p id="reuseOrigins"></p><p id="reuseRate" class="muted"></p><p id="zeroReuse" class="muted"></p><p class="muted">과거 성공의 실행시간 합은 추정치입니다. 동등한 비교 실측 없이 순절감률·토큰·요금·전체 개발시간으로 환산하지 않습니다.</p></article>
     </section>
     <section class="panel timeline"><div class="panel-title"><div><p class="eyebrow">변경별 타임라인</p><h2>최근 검증 배치</h2></div><button id="latestBatch" type="button">최신 배치</button></div><label for="batchSelect">상세 결과 선택</label> <select id="batchSelect"></select><p id="batchState" class="muted"></p><p id="historyMeta" class="muted"></p></section>
     <section class="workspace">
       <article class="panel checks"><div class="panel-title"><div><p class="eyebrow">검사 목록</p><h2>실행 또는 재사용 결과</h2></div><span id="sourceCount" class="count">0</span></div><div id="sources" class="source-list"></div></article>
-      <article class="panel map-panel"><div class="panel-title"><div><p class="eyebrow">EVIDENCE MAP · SHADOW 관찰 · 권한 없음</p><h2>선택한 검사의 관찰된 입력</h2></div><span id="mapMeta" class="muted"></span></div><div id="emptyMap" class="empty">검사를 선택하면 현재 입력과 이전 baseline의 관계를 보여줍니다.</div><svg id="map" role="img" aria-label="선택한 검사의 Evidence Map"></svg></article>
     </section>
-    <section class="panel explanation" aria-live="polite"><p class="eyebrow">판정 이유</p><h2 id="whyTitle">검사를 선택하세요</h2><p id="whyBody">왜 실행했거나 재사용했는지 사람말로 설명합니다.</p><div id="limits"></div></section>
+    <section class="panel explanation" aria-live="polite"><p class="eyebrow">판정 이유</p><h2 id="whyTitle">검사를 선택하세요</h2><p id="whyBody">왜 실행했거나 재사용했는지 사람말로 설명합니다.</p><p id="originName"></p><details><summary>원계약·검사·revision·판정 상세</summary><div id="limits"></div></details></section>
+    <details class="panel telemetry"><summary>Evidence Map · Shadow 관찰 상세 · 재사용 권한 없음</summary><p><strong id="observerTitle">Observer 확인 중</strong> · <span id="observerBody">Dashboard와 Observer는 독립적입니다.</span></p><article class="map-panel"><div class="panel-title"><h2>선택한 검사의 관찰된 입력</h2><span id="mapMeta" class="muted"></span></div><div id="emptyMap" class="empty">검사를 선택하면 현재 입력과 이전 baseline의 관계를 보여줍니다.</div><svg id="map" role="img" aria-label="선택한 검사의 Evidence Map"></svg></article><article class="compact shadow-card"><h2>잠재 재사용 관찰</h2><div class="statline"><span>후보 / 확인 / 모순</span><strong id="shadowBreakdown">—</strong></div><div class="statline"><span>잠재 시간 / 관찰기 처리 비용</span><strong id="shadowTiming">—</strong></div><p class="muted" id="tracingSlowdown">추적으로 인한 검사 지연은 별도 측정하지 않았습니다.</p></article></details>
     <section class="panel comparison"><p class="eyebrow">명시적으로 실행한 비교 측정 · 일상 추정치와 별개</p><h2>전체 재실행 기준 vs 증분 실행</h2><p id="comparisonInfo">아직 비교 측정이 없습니다. 아래 명령을 로컬에서 실행한 뒤 JSON을 선택하세요.</p><pre>python3 benchmarks/incremental_verification.py --iterations 3 --warmups 1 --output /tmp/click-comparison.json</pre><label>비교 JSON 선택 <input id="comparisonFile" type="file" accept="application/json,.json"></label><div id="comparisonChart"></div></section>
     <section class="panel exports"><h2>공유 리포트</h2><p class="muted">현재 선택한 배치와 가져온 비교 측정을 내보냅니다. 파일 경로·원시 명령·환경 값·토큰은 제외합니다. 검증은 실행하지 않습니다.</p><button type="button" id="exportJson">JSON 내보내기</button> <button type="button" id="exportHtml">독립형 HTML 내보내기</button><span id="exportStatus" role="status"></span></section>
   </main>
@@ -117,6 +118,10 @@ CSS += """.metric-split{display:grid;grid-template-columns:1fr 1fr;gap:12px;marg
 
 CSS += """.timeline,.comparison,.exports{margin:12px 0}#batchHeadline{font-size:20px;color:var(--text)}button,select,input{font:inherit}select{max-width:100%;background:#141c29;color:var(--text);padding:10px;border:1px solid var(--line);border-radius:9px}button:not(.source){background:#243650;color:var(--text);border:1px solid #456087;padding:10px 14px;border-radius:9px;cursor:pointer}button:focus-visible,input:focus-visible,select:focus-visible{outline:2px solid var(--blue);outline-offset:3px}.comparison pre{overflow:auto;background:#0c111a;padding:14px;border-radius:10px;font-size:12px}.comparison-row{border-top:1px solid var(--line);padding:18px 0}.comparison-row h3{font-size:14px}.comparison-bar{min-width:190px;border-radius:5px;margin:8px 0;padding:8px;font-size:12px;background:#204d76;white-space:nowrap}.comparison-bar.incremental{background:#513575}.comparison-row p{font-size:12px;color:var(--muted)}.comparison-row p.slower{color:var(--red)}.exports h2{margin-bottom:10px}.exports span{font-size:12px;margin-left:12px}.timeline label{font-size:12px}#timeScope{line-height:1.6}#batchState{line-height:1.6}#executionDetail{line-height:1.5}.metrics small{line-height:1.5}"""
 
+CSS += """.contract-panel{margin-bottom:16px}.contract-panel p{line-height:1.6}.contract-panel code{overflow-wrap:anywhere;color:var(--muted);font-size:11px}details summary{cursor:pointer;padding:10px 0;color:var(--blue)}details[open] summary{margin-bottom:12px}.workspace{grid-template-columns:1fr}.source-list{grid-template-columns:repeat(2,minmax(0,1fr));max-height:360px}.telemetry{margin-top:12px}.telemetry .map-panel{min-height:0}.contract-panel .pill{white-space:nowrap}#reuseRate,#zeroReuse,#controlSummary{line-height:1.6}@media(max-width:650px){.source-list{grid-template-columns:1fr}.contract-panel .panel-title{align-items:start;gap:12px;flex-direction:column}}"""
+
+CSS += """main{padding-top:24px}.hero{margin-bottom:16px;align-items:center}h1{font-size:clamp(28px,3.1vw,40px);line-height:1.1}#taskline{margin-top:8px}#batchHeadline{margin:8px 0 0;font-size:17px}.contract-panel{padding:16px 20px}.contract-panel .panel-title{margin-bottom:8px}#contractPromises{display:flex;gap:24px}#contractPromises p{flex:1;margin:4px 0;font-size:13px;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}#controlSummary{margin:6px 0 0}.metrics article{padding:16px}.notice{padding:12px;max-width:300px}.notice span{font-size:11px}@media(max-width:650px){#contractPromises{display:block}.hero{gap:14px}.notice{box-sizing:border-box}}"""
+
 JS = r"""(() => {
   'use strict';
   const $ = id => document.getElementById(id);
@@ -130,11 +135,12 @@ JS = r"""(() => {
   let activeBatch = null;
   let activeSummary = null;
   let comparison = null;
+  let lastSnapshotSignature = '';
   const statusText = {
     planned: '실행 예정', 'reuse-pending': '재사용 예정 · 미적용', running: '실행 중',
     passed: '통과', failed: '실패', interrupted: '중단 · 일부 결과 미확정',
     'not-run': '미실행', reused: '재사용 적용', unknown: '측정 정보 없음',
-    rejected: '실행 전 거부', incomplete: '미확정', evidence: 'Evidence', approved: 'Guarded', none: '활성 작업 없음'
+    rejected: '실행 전 거부', incomplete: '미확정', evidence: 'Evidence', staged: '승인 대기', approved: '승인됨', none: '활성 작업 없음'
   };
   const outcomeText = {
     'request-rejected': '요청이 거부되어 시작하지 않았습니다.',
@@ -146,6 +152,7 @@ JS = r"""(() => {
     'command-error': '실행 경계에서 오류가 발생했습니다. 같은 검사를 다시 실행하지 않았습니다.',
     'command-interrupted': '검사 실행이 중단되었습니다.',
     'outcome-unconfirmed': '종료 결과를 확인하지 못했습니다.'
+    , 'not-requested': '아직 요청되지 않은 검증입니다. 승인 후 기준 검증을 실행하세요.'
   };
 
   const executionLabels = {
@@ -158,9 +165,9 @@ JS = r"""(() => {
   };
   const reasonText = {
     'same-revision-receipt-current': '같은 revision의 검사 결과가 현재 작업트리와 정확히 일치해 재사용했습니다.',
-    'successor-evidence-current': '이전 Evidence 작업의 실제 통과 결과를 현재 명령·작업트리·환경·실행 파일·호스트 범위에 다시 결합해 재사용했습니다.',
-    'successor-evidence-dependencies-unchanged': '이전 Evidence 작업의 실제 통과 결과를 가져와, 현재 변경 뒤에도 관찰된 입력이 바뀌지 않았음을 다시 확인해 재사용했습니다.',
-    'successor-evidence-safe-change-covered': '이전 Evidence 작업의 실제 통과 결과를 가져와, 현재 커밋된 안전 변경 정책이 이번 변경을 허용하는지 다시 확인해 재사용했습니다.',
+    'successor-evidence-current': '이전 작업의 실제 통과 결과를 현재 명령·작업트리·환경·실행 파일·호스트 범위에 다시 결합해 재사용했습니다.',
+    'successor-evidence-dependencies-unchanged': '이전 작업의 실제 통과 결과를 가져와, 현재 변경 뒤에도 관찰된 입력이 바뀌지 않았음을 다시 확인해 재사용했습니다.',
+    'successor-evidence-safe-change-covered': '이전 작업의 실제 통과 결과를 가져와, 사전에 커밋된 안전 변경 정책이 이번 변경을 허용하는지 다시 확인해 재사용했습니다.',
     'successor-evidence-scope-mismatch': '이전 결과가 현재 호스트 세션과 작업 공간의 후속 작업 범위에 속하지 않아 실제 검사를 실행했습니다.',
     'successor-evidence-integrity-invalid': '이전 실행 사실의 무결성이나 출처를 확인할 수 없어 실제 검사를 실행했습니다.',
     'observed-dependencies-unchanged': '이 검사가 실제로 읽었던 입력이 바뀌지 않아 이전 통과 결과를 재사용했습니다.',
@@ -190,6 +197,7 @@ JS = r"""(() => {
   };
 
   function reasonFor(source) {
+    if (source.execution_reason_code === 'user-cancelled' && source.execution_status === 'not-run') return '실행 전에 취소되어 시작하지 않았습니다. 이전 계약의 승인이나 실행 권한은 이어받지 않습니다.';
     if (outcomeText[source.execution_reason_code]) return outcomeText[source.execution_reason_code];
     if (source.execution_status === 'unknown') return '실제 실행 기록이 없는 이전 데이터입니다. 계획을 실행 실적으로 표시하지 않습니다.';
     const planned = source.execution_status === 'planned' || source.execution_status === 'reuse-pending';
@@ -202,14 +210,16 @@ JS = r"""(() => {
     selected = source.id;
     const label = statusText[source.execution_status] || '측정 정보 없음';
     $('whyTitle').textContent = `${source.label} · ${label}`;
-    $('whyBody').textContent = reasonFor(source);
+    $('whyBody').textContent = `${reasonFor(source)} ${source.next_action || ''}`;
+    $('originName').textContent = source.reuse_origin ? `${source.origin_name || '이전 작업'} → 원본 검사 ${source.origin_check_label || source.label} → 현재 계약에서 재판정` : ['passed','failed','interrupted','reused'].includes(source.execution_status) ? '현재 계약 안에서 관측한 결과입니다.' : '아직 실행·재사용 결과가 없습니다.';
     const tags = [
       `현재 revision ${source.current_revision}`,
       source.previous_revision >= 0 ? `이전 성공 revision ${source.previous_revision}` : '이전 성공 없음',
       `계획 ${executionLabels[source.execution_decision]?.[0] || '없음'} · 실제 ${label}`,
       `실행 구간 ${fmt(source.duration_ms)}`,
       source.duration_baseline ? `과거 표본 ${source.duration_baseline.sample_count}개 · revision ${source.duration_baseline.revision} · ${fmt(source.duration_baseline.duration_ms)}` : '과거 시간 표본 없음',
-      source.reuse_origin ? `이전 Evidence 배치 ${source.reuse_origin.batch_id.slice(0,12)} · 출처 revision ${source.reuse_origin.origin_revision}` : '현재 작업 안의 근거',
+      source.reuse_origin ? `원본 ${source.reuse_origin.contract_id || source.reuse_origin.evidence_session_id} · 배치 ${source.reuse_origin.batch_id} · 출처 revision ${source.reuse_origin.origin_revision}` : '현재 작업 안의 근거',
+      `정확한 검사 결합 ${source.check_digest || source.duration_baseline?.check_digest || '정보 없음'}`,
       `판정 식별자 ${source.reason_code || '없음'}`,
       ...source.shadow_limitations.map(item => `Shadow: ${item}`)
     ];
@@ -351,7 +361,7 @@ JS = r"""(() => {
       safe_change_reuse_count: reused.filter(item => item.decision === 'reuse-safe-change').length,
       executed_duration_ms: sum(started.map(item => item.duration_ms)),
       request_wall_ms: batch.request_wall_ms,
-      measured_processing_ms: batch.measurement_scope === 'prepare-only' ? batch.prepare_duration_ms : sum([batch.prepare_duration_ms,batch.runner_duration_ms]),
+      measured_processing_ms: batch.runner_duration_ms === null ? batch.prepare_duration_ms : sum([batch.prepare_duration_ms,batch.runner_duration_ms]),
       estimated_avoided_ms: baselines.length || !reused.length ? sum(baselines.map(item => item.duration_ms)) : null,
       estimated_source_count: baselines.length, baseline_sample_count: baselines.length
     };
@@ -363,12 +373,15 @@ JS = r"""(() => {
     return {...data, sources: batch.sources.map(item => {
       const id = `source:${item.source_key.slice(0,16)}`;
       const source = current ? data.sources.find(source => source.id === id) : null;
+      const originBatch = item.reuse_origin ? data.batches.find(previous=>previous.task?.id === (item.reuse_origin.contract_id || item.reuse_origin.evidence_session_id)) : null;
       return {...(source || {input_count:0, changed_inputs:[], shadow_limitations:[], observer_status:'unavailable'}),
         id, label:item.label, status:item.status, execution_status:item.status,
         execution_decision:item.decision || 'not-planned', reason_code:item.reason_code,
         execution_reason_code:item.execution_reason_code, current_revision:item.current_revision,
         previous_revision:item.previous_revision, duration_ms:item.duration_ms, duration_baseline:item.duration_baseline,
-        authority_source:item.authority_source, reuse_origin:item.reuse_origin};
+        authority_source:item.authority_source, reuse_origin:item.reuse_origin, check_digest:item.check_digest,
+        origin_name:source?.origin_name || originBatch?.task?.name || '보관 범위 밖의 이전 작업',
+        origin_check_label:source?.origin_check_label || originBatch?.sources.find(previous=>previous.source_key===item.source_key)?.label || item.label};
     }), map: current ? data.map : {nodes:[],edges:[]}};
   }
 
@@ -378,10 +391,11 @@ JS = r"""(() => {
     activeBatch = batches.find(batch => batch.batch_id === (selectedBatch || data.history?.current_batch_id)) || null;
     const select = $('batchSelect');
     select.replaceChildren();
+    if (!activeBatch) {const placeholder=document.createElement('option');placeholder.value='';placeholder.textContent='현재 계약 · 검증 요청 기록 없음';placeholder.selected=true;select.append(placeholder);}
     [...batches].reverse().forEach(batch => {
       const option = document.createElement('option');
       option.value = batch.batch_id;
-      option.textContent = `${new Date(batch.timestamp*1000).toLocaleString()} · 변경 ${batch.current_revision} · ${statusText[batch.status]}`;
+      option.textContent = `${batch.task?.name || '이전 검증'} · ${new Date(batch.timestamp*1000).toLocaleString()} · 변경 ${batch.current_revision} · ${statusText[batch.status]}`;
       option.selected = batch.batch_id === activeBatch?.batch_id;
       select.append(option);
     });
@@ -445,6 +459,8 @@ JS = r"""(() => {
   }
 
   function renderComparison() {
+    $('comparisonStatus').textContent = comparison ? '별도 비교 실측 있음 · fixture 조건 한정' : '비교 실측 없음';
+    $('topComparison').textContent=$('comparisonStatus').textContent;
     const root = $('comparisonChart'); root.replaceChildren();
     if (!comparison) return;
     const c = comparison.conditions;
@@ -469,11 +485,14 @@ JS = r"""(() => {
 
   function shareReport() {
     if (!snapshot) throw Error('표시할 실행 기록이 없습니다.');
-    return {version:1,kind:'click-verification-efficiency-report',generated_at:snapshot.generated_at,
+    return {version:2,kind:'click-verification-efficiency-report',generated_at:snapshot.generated_at,
+      projection_version:snapshot.version ?? null,engine:snapshot.engine ?? null,accounting:snapshot.accounting ?? null,controls:snapshot.controls ?? null,
+      task:snapshot.task?{runtime_mode:snapshot.task.runtime_mode,contract_id:snapshot.task.contract_id,approval_bound:snapshot.task.approval_bound}:null,
       unit:'verification-group',summary:activeSummary,
       measurement_scope:activeBatch?.measurement_scope || 'unknown',
       batch:activeBatch ? {batch_id:activeBatch.batch_id,current_revision:activeBatch.current_revision,timestamp:activeBatch.timestamp,
         finished_at:activeBatch.finished_at,status:activeBatch.status,reason_code:activeBatch.reason_code,
+        task:activeBatch.task?{mode:activeBatch.task.mode,id:activeBatch.task.id}:null,
         sources:activeBatch.sources.map(item=>({label:item.label,source_key:item.source_key,check_digest:item.check_digest,
           decision:item.decision,status:item.status,started:item.started,completed:item.completed,reason_code:item.reason_code,
           execution_reason_code:item.execution_reason_code,authority_source:item.authority_source,
@@ -481,7 +500,7 @@ JS = r"""(() => {
           duration_baseline:item.duration_baseline,reuse_origin:item.reuse_origin,
           estimated_avoided_ms:item.status === 'reused' ? item.duration_baseline?.duration_ms ?? null : 0}))} : null,
       comparison,shadow:snapshot.summary.shadow,
-      notes:['전체 대기시간은 별도 측정값이 없으면 알 수 없음','준비와 runner 구간만 부분 계측 · 호스트 전달·대기·최종 저장·반환 제외',
+      notes:['전체 사용자 대기시간은 측정하지 않음','Hook 진입부터 결과 기록 또는 준비와 runner 개별 구간만 부분 계측 · 호스트 요청 전·최종 저장·반환 제외',
         '생략 비용은 실제 적용된 재사용의 이전 성공 실행 표본에 기반한 추정','Shadow는 실제 재사용·실측 절약 아님',
         '입력 파일 경로와 원시 명령·환경·토큰은 공유본에 포함하지 않음','비교 fixture 결과를 일반 저장소 성능으로 일반화할 수 없음']};
   }
@@ -497,8 +516,8 @@ JS = r"""(() => {
     const s=report.summary;
     add('h1','Click · 검증 효율 리포트');
     add('p',`${count(s.total_source_count)}개 검증 묶음 중 ${count(s.executed_source_count)}개 실제 실행 · ${count(s.authoritative_reuse_count)}개 재사용 · ${count(s.not_run_source_count)}개 미실행`);
-    add('p',`전체 대기시간: ${fmt(s.request_wall_ms)} / 부분 처리 구간: ${fmt(s.measured_processing_ms)} / 검사 실행 구간: ${fmt(s.executed_duration_ms)}`);
-    add('p',`생략한 실행 비용 추정: ${fmt(s.estimated_avoided_ms)} · 표본이 있는 ${count(s.estimated_source_count)} / 재사용 ${count(s.authoritative_reuse_count)}개 묶음`);
+    add('p',`Hook 진입 → 결과 기록 부분 실측: ${fmt(s.request_wall_ms)} / 부분 처리 구간: ${fmt(s.measured_processing_ms)} / 검사 실행 구간: ${fmt(s.executed_duration_ms)}`);
+    add('p',`재실행 비용 회피 추정: ${fmt(s.estimated_avoided_ms)} · 표본이 있는 ${count(s.estimated_source_count)} / 재사용 ${count(s.authoritative_reuse_count)}개 묶음`);
     add('h2','검증 묶음별 실제 결과');const table=add('table','');
     const heading=add('tr','',table);['이름','계획','실제 결과','시간 / 과거 표본','이유'].forEach(text=>add('th',text,heading));
     report.batch?.sources.forEach(item=>{const tr=add('tr','',table);const origin=item.reuse_origin?` · 이전 배치 ${item.reuse_origin.batch_id.slice(0,12)}에서 재판정`:'';[item.label,executionLabels[item.decision]?.[0]||'없음',statusText[item.status],item.status==='reused'?fmt(item.duration_baseline?.duration_ms)+' (과거 표본)':fmt(item.duration_ms),(outcomeText[item.execution_reason_code]||reasonText[item.reason_code]||'정보 없음')+origin].forEach(text=>add('td',text,tr));});
@@ -536,17 +555,40 @@ JS = r"""(() => {
     const incremental = activeBatch ? summarize(activeBatch) : data.summary.incremental;
     activeSummary = incremental;
     const shadow = data.summary.shadow;
-    $('batchHeadline').textContent = `${count(incremental.total_source_count)}개 검증 묶음 중 ${count(incremental.executed_source_count)}개 실행 · ${count(incremental.authoritative_reuse_count)}개 재사용`;
+    $('contractName').textContent = data.task.name || '현재 작업';
+    $('approvalState').textContent = data.task.approval_bound ? '별도 승인됨 · Guarded' : data.task.runtime_mode === 'evidence' ? '호스트 권한 · Click 승인 없음' : data.task.status === 'staged' ? '승인 대기 · Guarded' : data.task.status === 'none' ? '활성 계약 없음 · 이력 전용' : '승인 정보 없음';
+    $('contractId').textContent = data.task.contract_id || '승인 계약 ID 없음';
+    const paragraphs = values => values.map(text => {const p=document.createElement('p');p.textContent=text;return p;});
+    $('contractPromises').replaceChildren(...paragraphs(data.task.promises?.length ? data.task.promises.slice(0,2) : ['표시 가능한 약속 요약이 없습니다. 기존 승인 계약 또는 사용자 요청을 확인하세요.']));
+    $('allPromises').replaceChildren(...paragraphs(data.task.promises || []));
+    $('contractBoundary').replaceChildren(...paragraphs([
+      `포함: ${(data.task.in_scope || []).join(' · ') || '원문 확인'}`,
+      `제외: ${(data.task.out_of_scope || []).join(' · ') || '원문 확인'}`,
+      `유지 조건: ${(data.task.must_hold || []).join(' · ') || '원문 확인'}`,
+    ]));
+    const controls=data.controls || [];
+    $('controlSummary').textContent = `이 계약의 관측 통제: 차단 ${controls.filter(item=>item.effect==='blocked').length}건 · 비차단 안내 ${controls.filter(item=>item.effect==='advisory').length}건. 의미적 범위 준수나 숨은 추론을 판정한 수치가 아닙니다.`;
+    if (data.task.status==='none') $('controlSummary').textContent='활성 계약이 없습니다. 보관된 viewer 이력은 승인이나 실행 권한을 전달하지 않습니다.';
+    const reusedItems=(activeBatch?.sources || []).filter(item=>item.status==='reused');
+    const prior=reusedItems.filter(item=>item.reuse_origin).length;
+    $('reuseOrigins').textContent=`선택한 기록: 현재 작업 안의 재사용 ${reusedItems.length-prior} · 이전 작업에서 재판정 ${prior}`;
+    const a=data.accounting;
+    $('reuseRate').textContent=a ? `보관된 검증 그룹 요청 기준: ${a.reuse_numerator} / ${a.request_denominator} · ${a.reuse_rate===null?'비율 미측정':(100*a.reuse_rate).toFixed(1)+'%'} · ${a.from_timestamp?new Date(a.from_timestamp*1000).toLocaleString():'시작 기록 없음'} ~ ${a.through_timestamp?new Date(a.through_timestamp*1000).toLocaleString():'종료 기록 없음'}. 실제 재시도는 별도 요청이며 중복 수신·화면 갱신은 추가 집계하지 않습니다.` : '집계 정보 없음';
+    $('zeroReuse').textContent=reusedItems.length ? `재사용 중 과거 시간 표본 미측정 ${reusedItems.filter(item=>!item.duration_baseline).length}개` : [...new Set(view.sources.map(source=>source.next_action || reasonFor(source)))].slice(0,3).join(' ');
+    $('comparisonStatus').textContent=comparison ? '별도 비교 실측 있음 · fixture 조건 한정' : '비교 실측 없음';
+    $('topComparison').textContent=$('comparisonStatus').textContent;
+    $('batchHeadline').textContent = incremental.total_source_count === null ? '이번 계약의 검증 요청 기록이 아직 없습니다.' : `${count(incremental.total_source_count)}개 검증 묶음 중 ${count(incremental.executed_source_count)}개 실행 · ${count(incremental.authoritative_reuse_count)}개 재사용`;
     $('currentChecks').textContent = count(incremental.total_source_count);
     $('executedChecks').textContent = count(incremental.executed_source_count);
     $('reusedChecks').textContent = count(incremental.authoritative_reuse_count);
     $('executionDetail').textContent = `통과 ${count(incremental.passed_source_count)} · 실패 ${count(incremental.failed_source_count)} · 중단 ${count(incremental.interrupted_source_count)} · 미실행 ${count(incremental.not_run_source_count)} · 대기/미확정 ${count(incremental.pending_source_count)}`;
     $('requestWall').textContent = fmt(incremental.request_wall_ms);
     $('processingDuration').textContent = fmt(incremental.measured_processing_ms);
-    $('timeScope').textContent = activeBatch?.measurement_scope === 'prepare-only' ? '부분 계측: 준비·재사용 판정만 포함. 호스트 대기·전달·최종 저장·반환은 제외합니다.' : '부분 계측: 준비 + runner의 로컬 경과시간 합계. 서로 다른 프로세스의 시계 원점을 빼지 않습니다. 호스트 대기·전달·최종 저장·반환은 제외합니다.';
+    $('timeScope').textContent = activeBatch?.measurement_scope === 'hook-entry-to-result-recording' ? '부분 실측: 같은 호스트의 단조 시계로 Hook 진입부터 결과 기록 직전까지 측정했습니다. Hook 이전 요청 대기·최종 저장·호스트 반환은 제외합니다.' : activeBatch?.measurement_scope === 'prepare-only' ? '부분 계측: 준비·재사용 판정만 포함. 호스트 대기·전달·최종 저장·반환은 제외합니다.' : '부분 계측: 준비 + runner의 개별 경과시간 합계. 호스트 대기·전달·최종 저장·반환은 제외합니다.';
+    if (!activeBatch) $('timeScope').textContent='이 계약의 요청-결과 시간은 아직 측정되지 않았습니다.';
     $('estimateCoverage').textContent = `이전 시간 표본이 있는 ${count(incremental.estimated_source_count)} / 재사용 ${count(incremental.authoritative_reuse_count)}개 묶음 · 실측 절약 아님`;
     $('estimatedAvoided').textContent = fmt(incremental.estimated_avoided_ms);
-    $('reuseBreakdown').textContent = `${incremental.exact_reuse_count} / ${incremental.dependency_reuse_count} / ${incremental.safe_change_reuse_count}`;
+    $('reuseBreakdown').textContent = `${count(incremental.exact_reuse_count)} / ${count(incremental.dependency_reuse_count)} / ${count(incremental.safe_change_reuse_count)}`;
     $('executedDuration').textContent = fmt(incremental.executed_duration_ms);
     $('shadowBreakdown').textContent = `${shadow.candidate_count} / ${shadow.confirmed_candidate_count} / ${shadow.contradiction_count}`;
     $('shadowTiming').textContent = `${fmt(shadow.potential_ms)} / ${fmt(shadow.observer_overhead_ms)}`;
@@ -571,7 +613,10 @@ JS = r"""(() => {
         cache: 'no-store'
       });
       if (!response.ok) throw new Error(String(response.status));
-      render(await response.json());
+      const data=await response.json();
+      const signature=JSON.stringify({...data,generated_at:null});
+      if (signature!==lastSnapshotSignature) {lastSnapshotSignature=signature;render(data);}
+      else { $('connection').textContent='연결됨';document.querySelector('.live').classList.add('ok'); }
     } catch (_) {
       $('connection').textContent = '연결 끊김';
       document.querySelector('.live').classList.remove('ok');

--- a/dist/antigravity/hooks/click_verification.py
+++ b/dist/antigravity/hooks/click_verification.py
@@ -1011,7 +1011,13 @@ def _successor_binding_reason(
     executable_digest: str,
     host_coverage: dict[str, Any],
 ) -> str:
-    """Validate a prior Evidence fact without pretending it is this lifecycle."""
+    """Validate prior facts against the current lifecycle's bindings."""
+    if (
+        previous.get("dependency_patterns", []) != current.get("dependency_patterns", [])
+        or previous.get("dependency_declaration_digest", "")
+        != current.get("dependency_declaration_digest", "")
+    ):
+        return "contract-binding-changed"
     if previous.get("verified_check_digest") != group_digest:
         return "check-binding-changed"
     if previous.get("verified_root") != git_root:
@@ -1058,6 +1064,8 @@ def _requalify_successor_baseline(
 ) -> None:
     """Create a new-lifecycle baseline only after explicit binding checks."""
     current_shard = current.get("shard")
+    current_patterns = list(current.get("dependency_patterns", []))
+    current_declaration = current.get("dependency_declaration_digest", "")
     preserved = json.loads(json.dumps(previous))
     current.clear()
     current.update(preserved)
@@ -1066,6 +1074,8 @@ def _requalify_successor_baseline(
     else:
         current["shard"] = current_shard
     current.update(
+        dependency_patterns=current_patterns,
+        dependency_declaration_digest=current_declaration,
         status="passed" if exact_tree else "stale",
         verified_revision=revision if exact_tree else max(0, revision - 1),
         attempts=0,
@@ -1095,6 +1105,7 @@ def _requalify_successor_baseline(
         last_successor_reused_at=0,
         last_successor_origin_batch_id="",
         last_successor_origin_evidence_session_id="",
+        last_successor_origin_contract_id="",
         last_successor_candidate_digest="",
         last_successor_origin_revision=-1,
         last_successor_mode="",
@@ -1109,9 +1120,8 @@ def _mark_successor_reuse(
     ) + 1
     source["last_successor_reused_at"] = int(time.time()) or 1
     source["last_successor_origin_batch_id"] = metadata["batch_id"]
-    source["last_successor_origin_evidence_session_id"] = metadata[
-        "evidence_session_id"
-    ]
+    source["last_successor_origin_evidence_session_id"] = metadata.get("evidence_session_id", "")
+    source["last_successor_origin_contract_id"] = metadata.get("contract_id", "")
     source["last_successor_candidate_digest"] = metadata["candidate_digest"]
     source["last_successor_origin_revision"] = metadata["origin_revision"]
     source["last_successor_mode"] = mode
@@ -1889,6 +1899,7 @@ def _prepare_verification(
     # A preparation hook and its runner are different processes. Measure their
     # local elapsed segments, not a subtraction of cross-process clock origins.
     started = time.perf_counter_ns()
+    request_started = time.monotonic_ns()
     trace: dict[str, Any] = {}
     result = _prepare_verification_impl(
         event, raw, runner_script=runner_script, render_command=render_command,
@@ -1910,21 +1921,35 @@ def _prepare_verification(
             if isinstance(tool_id, str) and tool_id else secrets.token_hex(16)
         )
         previous_id = verification.get(click_incremental.CURRENT_BATCH_FIELD)
+        previous_clock = verification.get("incremental_request_clock")
         previous_batch = click_incremental.current_batch(verification)
         batch = click_incremental.new_batch(
             trace.get("plan"), batch_id=request_id,
             revision=int(verification.get("mutation_revision", 0)), prepared_ms=elapsed,
             requested=trace.get("requested"), labels=trace.get("labels"),
             reuse_origins=trace.get("reuse_origins"),
+            task={
+                "mode": state.get("runtime_mode"),
+                "id": state.get("contract_id") if state.get("runtime_mode") == "guarded" else state.get("evidence_session_id"),
+                "name": click_incremental.sanitize_presentation(state.get("presentation"))["name"],
+            },
         )
         if click_incremental.store_batch(verification, batch):
+            click_incremental.start_request_clock(verification, request_id, started_ns=request_started)
             if result[1]:
+                click_incremental.record_control_event(state, event, "verification-request-rejected")
                 click_incremental.reject_batch(verification)
                 if previous_batch and previous_batch["status"] in {"planned", "running"}:
                     verification[click_incremental.CURRENT_BATCH_FIELD] = previous_id
+                    if previous_clock is not None:
+                        verification["incremental_request_clock"] = previous_clock
             elif trace.get("all_reused"):
                 click_incremental.finish_reuse(verification)
+            if result[2]:
+                click_incremental.record_control_event(state, event, "verification-guidance")
             _save_contract_state(event, state)
+            if trace.get("all_reused"):
+                result = (result[0], result[1], "\n".join(filter(None, (result[2], click_incremental.host_summary(verification)))))
     except Exception:
         # Measurements cannot admit/reject a command or grant reuse authority.
         pass
@@ -2140,11 +2165,15 @@ def _prepare_verification_impl(
             source["reserved_check_digest"] = group_digests[source_key]
 
     successor_candidates: dict[str, tuple[dict[str, Any], dict[str, Any]]] = {}
-    if runtime.evidence:
+    if runtime.evidence or runtime.guarded_approved:
         scope_digest = click_evidence.successor_scope_digest(
             str(click_state.contract_path(event).resolve())
         )
         for source_key in requested_keys:
+            # A current-lifecycle execution (especially a failure) supersedes a
+            # prior candidate. Never resurrect A over B's observed result.
+            if sources[source_key].get("attempts", 0) or sources[source_key].get("verified_contract_digest"):
+                continue
             candidate = click_evidence.successor_candidate(
                 state,
                 source_key,
@@ -2636,10 +2665,13 @@ def _prepare_verification_impl(
     if measurement is not None:
         measurement["plan"] = incremental_plan
         measurement["labels"] = {
+            **click_incremental.sanitize_presentation(state.get("presentation"))["evidence_labels"],
+            **{
             key: str(source["shard"]["shard_id"])
             for key, source in sources.items()
             if isinstance(source, dict)
             and click_evidence_shards.source_metadata_is_valid(source.get("shard"))
+            },
         }
         measurement["reuse_origins"] = {
             key: successor_origins[key]
@@ -3044,6 +3076,7 @@ def _record_verification_result(
                 source_ran = source_results.get(source_key, {}).get("started") is True
             was_current = _evidence_is_current(source, previous_revision)
             if check_positions and source_ran:
+                click_evidence.clear_successor_receipt(source)
                 source["status"] = "failed"
                 source["attempts"] = int(source.get("attempts", 0)) + 1
                 source["unchanged_failure_retries"] = 1
@@ -3083,6 +3116,7 @@ def _record_verification_result(
             if source_results is not None:
                 source_ran = source_results.get(source_key, {}).get("started") is True
             if source_ran:
+                click_evidence.clear_successor_receipt(source)
                 source["attempts"] = int(source.get("attempts", 0)) + 1
             if all(position < succeeded_count for position in check_positions):
                 source["status"] = "passed"
@@ -3948,6 +3982,13 @@ def _run_verification(
     if not recorded:
         sys.stderr.write("Click could not record the verification result safely.\n")
         return exit_code or 2
+    try:
+        result_state = json.loads(state_path.read_text(encoding="utf-8"))
+        message = click_incremental.host_summary(result_state.get("verification"))
+        if message:
+            print(message, flush=True)
+    except (OSError, ValueError, TypeError):
+        pass  # A display failure cannot change the observed verification result.
     return exit_code
 
 

--- a/dist/antigravity/skills/click/SKILL.md
+++ b/dist/antigravity/skills/click/SKILL.md
@@ -64,6 +64,8 @@ Only in a later turn whose user response explicitly approves the shown proposal,
 
 ## Execute the approved boundary once
 
+A completed Guarded contract may supply successful verification candidates to a new contract in the same host session and workspace. The new contract still requires its own later-turn approval and exact declared checks. Never treat retained facts as inherited execution authority or completion. Requalification and receipt v5 follow the capability protocol; dependency declarations, viewer history and timing cannot authorize reuse by themselves.
+
 Before implementation, read the [anti-loop policy](references/anti-loop-policy.md) and [structured capability protocol](references/capability-protocol.md). Prefer focused follow-up after broad repository context; this is non-blocking strategy guidance, not contract authority. Implement continuously without a replacement plan or contract. Use their canonical inspect, mutate, managed-service, and verify forms rather than duplicating command details here.
 
 Collect each assigned source once after the last mutation that can invalidate it. Reuse successful evidence, keep Browser or hosted work out of a shadow verification suite, and stop verification when each condition has current evidence. Treat repeat, retry, and timing notices as non-authoritative guidance, not permission failures; active runner conflicts, Browser receipt binding, and verification-time repository mutation remain hard. Stop any managed service before declaring completion. A failed or stale source may be repaired or replaced under the documented retry rules; it is not a reason to accumulate another proof path.

--- a/dist/antigravity/skills/click/references/capability-protocol.md
+++ b/dist/antigravity/skills/click/references/capability-protocol.md
@@ -152,6 +152,15 @@ complete shard provenance required by v3. Merely retaining a successor
 candidate never selects v4 and never creates reuse authority. Offline
 verification accepts and validates v4 while retaining legacy v1-v3 support.
 
+An actually applied successor from a completed Guarded contract selects v5
+and records `origin_contract_id` instead of the v4 Evidence session identity.
+The new contract's separate staging and approval remain current authority;
+earlier approval, claims, tokens and unfinished work never transfer. Candidates
+must requalify against current exact declared checks, dependency declaration,
+workspace, environment, executable, known Hook coverage and existing change
+rules. Incomplete or uncertain bindings run the check. v5 retains complete v3
+shard provenance where present; offline validation still accepts v1–v4.
+
 If a host omits the working directory selected by a nested execution tool,
 export may recover it only from the sole canonical Git root shared by every
 current argv evidence source. A stale, missing, non-canonical, or conflicting

--- a/dist/antigravity/skills/click/references/modes.md
+++ b/dist/antigravity/skills/click/references/modes.md
@@ -40,6 +40,8 @@ Show the exact Hook-generated easy contract once as the default approval body, w
 
 After every declared evidence source is current for the final mutation revision and no managed service remains active, a later change may stage a fresh contract. A contract with no argv source needs no ceremonial local batch. Missing, running, failed, or stale evidence—and an active managed service—still block replacement.
 
+That completed contract may retain successful verification candidates for the next Guarded contract, never approval, execution claims, tokens or completion. The successor must be separately approved and request its own declared checks before current-binding requalification. Changing a dependency declaration does not inherit its predecessor's authority. See the capability protocol for v5 lineage and conservative rerun rules.
+
 ## Off
 
 Ordinary work is fail-open while no Guarded contract is active. Apply Guarded when the user selects `@Click` or invokes `$click`; run `click-gate arm` and use the compact-contract workflow. Once staged or approved but incomplete, that contract blocks ordinary mutations across later turns. On approval or resume, pass the same emitted `contract_id`; do not resend the JSON. Ephemeral state may age out, but staged and approved-incomplete contracts are never removed by cleanup.

--- a/dist/antigravity/skills/click/references/shadow-intelligence-v1.md
+++ b/dist/antigravity/skills/click/references/shadow-intelligence-v1.md
@@ -91,6 +91,19 @@ Click lifecycle.
 
 ## Evidence Map and ROI projection
 
+Projection v4 first shows the current contract's bounded display summary,
+approval state, requested/executed/reused/failed/unstarted verification groups,
+and the distinction between an avoided-rerun-cost estimate and a separately
+measured comparison. Evidence Map and Shadow remain collapsed details.
+The local display copy is not authority and is not guaranteed secret detection;
+shared JSON/HTML omit contract prose, raw argv, input paths and environment
+values. Engine version and unsigned source-file digest identify the snapshot,
+not publisher authenticity. Observed approval/id denials and advisory guidance
+are distinct telemetry, not semantic scope judgments. Group reuse rates expose
+their retained-history numerator, denominator and time window; missing timing
+stays null. Hook-entry-to-result-recording is partial request timing, excluding
+host queueing and final return. See the capability protocol for reuse authority.
+
 The dashboard receives a separate, strict, bounded projection instead of the
 raw Click state. Its first summary is the authoritative incremental plan:
 total sources, sources actually executed, exact/dependency/safe-change reuse,

--- a/hooks/click_dashboard_projection.py
+++ b/hooks/click_dashboard_projection.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 import re
 import time
 from typing import Any
@@ -32,7 +32,7 @@ else:  # Executed beside the bundled hook modules.
     import click_shadow_intelligence
 
 
-PROJECTION_VERSION = 3
+PROJECTION_VERSION = 4
 PROJECTION_MODE = "incremental-verification"
 MAX_SOURCES = click_shadow_intelligence.MAX_STATE_SOURCES
 MAX_INPUTS = click_shadow_intelligence.MAX_PROJECTION_INPUTS
@@ -52,7 +52,7 @@ _INPUT_STATUSES = frozenset(
 )
 
 _FIELDS = frozenset(
-    {"version", "mode", "generated_at", "task", "summary", "sources", "map", "batches", "history"}
+    {"version", "mode", "generated_at", "task", "summary", "sources", "map", "batches", "history", "accounting", "controls", "engine"}
 )
 _TASK_FIELDS = frozenset(
     {
@@ -61,6 +61,7 @@ _TASK_FIELDS = frozenset(
         "mutation_revision",
         "observer_mode",
         "observer_enabled",
+        "name", "promises", "in_scope", "out_of_scope", "must_hold", "contract_id", "approval_bound",
     }
 )
 _SUMMARY_FIELDS = frozenset({"incremental", "shadow"})
@@ -100,6 +101,7 @@ _SOURCE_FIELDS = frozenset(
         "shadow_outcome",
         "execution_status", "execution_reason_code", "duration_ms", "duration_baseline",
         "reuse_origin",
+        "check_digest", "origin_name", "origin_check_label", "next_action",
     }
 )
 _MAP_FIELDS = frozenset(
@@ -155,6 +157,45 @@ def _safe_relative_path(value: Any, *, directory: bool = False) -> bool:
 def _source_status(value: Any) -> str:
     status = value.get("status") if isinstance(value, dict) else "unknown"
     return status if status in _SOURCE_STATUSES else "unknown"
+
+
+def engine_identity() -> dict[str, Any]:
+    """File provenance only, never a signed or independently trusted identity."""
+    result = {"version": None, "hook_files_digest": None, "assurance": "unsigned-files-at-snapshot"}
+    root = Path(__file__).resolve().parents[1]
+    try:
+        version = json.loads((root / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")).get("version")
+        if isinstance(version, str) and re.fullmatch(r"\d+\.\d+\.\d+(?:\+codex\.\d{14})?", version):
+            result["version"] = version
+    except (OSError, ValueError, TypeError):
+        pass
+    try:
+        digest = hashlib.sha256()
+        for path in sorted((root / "hooks").glob("*.py"))[:256]:
+            content = path.read_bytes()
+            if len(content) > 2 * 1024 * 1024:
+                return result
+            digest.update(path.name.encode() + b"\0" + hashlib.sha256(content).digest())
+        result["hook_files_digest"] = digest.hexdigest()
+    except OSError:
+        pass
+    return result
+
+
+def _next_action(reason: str, status: str) -> str:
+    if status == "passed":
+        return "현재 코드에서 직접 통과했습니다. 다음 관련 변경 전에는 재실행이 필요하지 않습니다."
+    if status == "reused":
+        return "현재 재판정을 통과한 결과입니다. 관련 입력이 바뀌면 다시 검증하세요."
+    if status in {"failed", "interrupted"}:
+        return "실패 또는 중단 원인을 확인한 뒤 승인 범위에서 같은 검증을 다시 실행하세요."
+    if reason == "environment-binding-changed":
+        return "현재 환경에서 실제 검증을 실행해 새 기준 결과를 만드세요."
+    if reason in {"observed-input-changed", "safe-change-policy-not-covered"}:
+        return "관련 입력이 변경됐습니다. 현재 코드로 실제 검증을 실행하세요."
+    if reason in {"observer-incomplete", "policy-unavailable", "mutation-boundary-ambiguous", "workspace-ambiguous"}:
+        return "재사용 근거가 부족합니다. 정책을 완화하지 말고 현재 상태를 실제 검증하세요."
+    return "승인된 검증을 먼저 실행해 현재 상태의 성공 기준을 만드세요."
 
 
 def _intelligence_state(verification: dict[str, Any]) -> dict[str, Any]:
@@ -216,6 +257,7 @@ def dashboard_projection(
     """Build the only state shape exposed to the local dashboard server."""
 
     raw_state = state if isinstance(state, dict) else {}
+    presentation = click_incremental.sanitize_presentation(raw_state.get("presentation"))
     verification = raw_state.get("verification")
     verification = verification if isinstance(verification, dict) else {}
     evidence_state = raw_state.get("evidence_state")
@@ -234,7 +276,8 @@ def dashboard_projection(
     history = click_incremental.batch_history(verification, now=generated_at)
 
     source_keys = sorted(
-        {key for key in evidence_sources if _is_digest(key)}
+        {key for key, source in evidence_sources.items() if _is_digest(key)
+         and isinstance(source, dict) and source.get("kind", "argv") == "argv"}
         | set(observer_records)
         | set(intelligence["sources"])
         | set(decisions)
@@ -248,7 +291,7 @@ def dashboard_projection(
 
     for index, key in enumerate(source_keys, start=1):
         source_id = f"source:{key[:16]}"
-        label = actual[key]["label"] if key in actual else f"검증 묶음 {index}"
+        label = actual[key]["label"] if key in actual else presentation["evidence_labels"].get(key, f"검증 묶음 {index}")
         status = _source_status(evidence_sources.get(key))
         nodes.append(
             {
@@ -277,6 +320,13 @@ def dashboard_projection(
             previous_revision = int(decision["previous_revision"])
             estimated_avoided_ms = None
         result = actual.get(key, {})
+        execution_status = result.get("status", "not-run" if status == "ready" else "unknown")
+        origin = result.get("reuse_origin")
+        origin_contract = origin.get("contract_id", "") if isinstance(origin, dict) else ""
+        presentation_history = raw_state.get("presentation_history", {})
+        origin_presentation = click_incremental.sanitize_presentation(
+            presentation_history.get(origin_contract) if isinstance(presentation_history, dict) else None
+        )
         duration_baseline = result.get("duration_baseline")
         if result.get("status") == "reused" and click_incremental.baseline_is_valid(duration_baseline):
             estimated_avoided_ms = duration_baseline["duration_ms"]
@@ -356,11 +406,15 @@ def dashboard_projection(
                 "current_revision": current_revision,
                 "previous_revision": previous_revision,
                 "estimated_avoided_ms": estimated_avoided_ms,
-                "execution_status": result.get("status", "unknown"),
-                "execution_reason_code": result.get("execution_reason_code", "outcome-unconfirmed"),
+                "execution_status": execution_status,
+                "execution_reason_code": result.get("execution_reason_code", "not-requested" if status == "ready" else "outcome-unconfirmed"),
                 "duration_ms": result.get("duration_ms"),
                 "duration_baseline": duration_baseline,
                 "reuse_origin": result.get("reuse_origin"),
+                "check_digest": decision["check_digest"] if decision else "",
+                "origin_name": origin_presentation["name"] if origin_contract else "이전 Evidence 작업" if origin else "현재 계약",
+                "origin_check_label": origin_presentation["evidence_labels"].get(key, label),
+                "next_action": _next_action(reason_code, execution_status),
                 "observer_status": observer_status,
                 "input_count": len(input_keys),
                 "visible_input_count": source_visible,
@@ -422,7 +476,15 @@ def dashboard_projection(
             "mutation_revision": revision,
             "observer_mode": observer_control["mode"],
             "observer_enabled": observer_control["enabled"],
+            **{key: presentation[key] for key in ("name", "promises", "in_scope", "out_of_scope", "must_hold")},
+            "contract_id": raw_state.get("contract_id") if re.fullmatch(r"ctr_[0-9a-f]{32}", str(raw_state.get("contract_id", ""))) else "",
+            "approval_bound": bool(runtime_mode == "guarded" and status == "approved"
+                                   and raw_state.get("approved_turn_id")
+                                   and raw_state.get("approved_turn_id") != raw_state.get("staged_turn_id")),
         },
+        "accounting": click_incremental.history_accounting(verification),
+        "controls": click_incremental.control_events(raw_state),
+        "engine": engine_identity(),
         "summary": {
             "incremental": incremental,
             "shadow": _shadow_metrics(intelligence),
@@ -472,6 +534,14 @@ def projection_is_valid(value: Any) -> bool:
     ):
         return False
     task = value.get("task")
+    engine = value.get("engine")
+    if (
+        not isinstance(engine, dict) or set(engine) != {"version", "hook_files_digest", "assurance"}
+        or engine["assurance"] != "unsigned-files-at-snapshot"
+        or engine["version"] is not None and (not isinstance(engine["version"], str) or re.fullmatch(r"\d+\.\d+\.\d+(?:\+codex\.\d{14})?", engine["version"]) is None)
+        or engine["hook_files_digest"] is not None and not _is_digest(engine["hook_files_digest"])
+    ):
+        return False
     summary = value.get("summary")
     sources = value.get("sources")
     map_value = value.get("map")
@@ -485,6 +555,16 @@ def projection_is_valid(value: Any) -> bool:
         or task.get("observer_mode") not in click_observer_control.MODES
         or task.get("observer_enabled")
         != (task.get("observer_mode") == "shadow")
+        or task.get("name") != click_incremental.safe_display_text(task.get("name"), "")
+        or not isinstance(task.get("approval_bound"), bool)
+        or not isinstance(task.get("contract_id"), str)
+        or task["contract_id"] and re.fullmatch(r"ctr_[0-9a-f]{32}", task["contract_id"]) is None
+        or any(not isinstance(task.get(key), list) or len(task[key]) > 8
+               or any(item != click_incremental.safe_display_text(item, "") for item in task[key])
+               for key in ("promises", "in_scope", "out_of_scope", "must_hold"))
+        or not click_incremental.accounting_is_valid(value.get("accounting"))
+        or not isinstance(value.get("controls"), list)
+        or value["controls"] != click_incremental.control_events({"control_events": value["controls"]})
         or not isinstance(summary, dict)
         or set(summary) != _SUMMARY_FIELDS
         or not isinstance(sources, list)
@@ -550,6 +630,9 @@ def projection_is_valid(value: Any) -> bool:
             or not isinstance(source.get("label"), str)
             or not source["label"]
             or source["label"] != click_incremental.safe_label(source["label"], "")
+            or source.get("check_digest") != "" and not _is_digest(source.get("check_digest"))
+            or any(source.get(key) != click_incremental.safe_display_text(source.get(key), "")
+                   for key in ("origin_name", "origin_check_label", "next_action"))
             or source.get("status") not in _SOURCE_STATUSES
             or source.get("execution_decision") not in _EXECUTION_DECISIONS
             or source.get("reason_code")

--- a/hooks/click_evidence.py
+++ b/hooks/click_evidence.py
@@ -35,6 +35,7 @@ EVIDENCE_STATUSES = {"ready", "running", "observed", "passed", "failed", "stale"
 EVIDENCE_STATE_VERSION = 1
 SUCCESSOR_EVIDENCE_FIELD = "successor_evidence"
 SUCCESSOR_EVIDENCE_VERSION = 1
+GUARDED_SUCCESSOR_VERSION = 2
 MAX_SUCCESSOR_EVIDENCE_BYTES = 2 * 1024 * 1024
 MAX_SUCCESSOR_SOURCES = 256
 _SUCCESSOR_FIELDS = frozenset({
@@ -43,6 +44,9 @@ _SUCCESSOR_FIELDS = frozenset({
     "captured_at", "evidence_state", "origins", "digest",
 })
 _SUCCESSOR_ORIGIN_FIELDS = frozenset({"batch_id", "execution_status"})
+_GUARDED_SUCCESSOR_FIELDS = (
+    _SUCCESSOR_FIELDS - {"origin_evidence_session_id"}
+) | {"origin_contract_id"}
 
 
 def evidence_key(evidence_id: str) -> str:
@@ -110,6 +114,7 @@ def _fresh_source(kind: str, dependency_patterns: tuple[str, ...] = ()) -> dict[
         "last_successor_reused_at": 0,
         "last_successor_origin_batch_id": "",
         "last_successor_origin_evidence_session_id": "",
+        "last_successor_origin_contract_id": "",
         "last_successor_candidate_digest": "",
         "last_successor_origin_revision": -1,
         "last_successor_mode": "",
@@ -153,6 +158,14 @@ def fresh_successor_evidence() -> dict[str, Any]:
     return {}
 
 
+def clear_successor_receipt(source: dict[str, Any]) -> None:
+    """A real current-lifecycle execution replaces previously reused lineage."""
+    source.update({
+        key: value for key, value in _fresh_source("argv").items()
+        if key == "successor_reuse_count" or key.startswith("last_successor_")
+    })
+
+
 def successor_scope_digest(identity: str) -> str:
     return hashlib.sha256(identity.encode()).hexdigest()
 
@@ -171,15 +184,19 @@ def successor_evidence_is_valid(
     expected_contract_schema_version: int,
     scope_digest: str,
 ) -> bool:
+    guarded = isinstance(value, dict) and value.get("version") == GUARDED_SUCCESSOR_VERSION
+    identity_field = "origin_contract_id" if guarded else "origin_evidence_session_id"
+    identity_pattern = r"ctr_[0-9a-f]{32}" if guarded else r"evs_[0-9a-f]{32}"
     if (
         not isinstance(value, dict)
-        or set(value) != _SUCCESSOR_FIELDS
-        or value.get("version") != SUCCESSOR_EVIDENCE_VERSION
+        or set(value) != (_GUARDED_SUCCESSOR_FIELDS if guarded else _SUCCESSOR_FIELDS)
+        or value.get("version") not in {SUCCESSOR_EVIDENCE_VERSION, GUARDED_SUCCESSOR_VERSION}
+        or isinstance(value.get("version"), bool)
         or value.get("scope_digest") != scope_digest
         or not isinstance(scope_digest, str)
         or re.fullmatch(r"[0-9a-f]{64}", scope_digest) is None
-        or not isinstance(value.get("origin_evidence_session_id"), str)
-        or re.fullmatch(r"evs_[0-9a-f]{32}", value["origin_evidence_session_id"])
+        or not isinstance(value.get(identity_field), str)
+        or re.fullmatch(identity_pattern, value[identity_field])
         is None
         or not isinstance(value.get("origin_intent_digest"), str)
         or re.fullmatch(r"[0-9a-f]{64}", value["origin_intent_digest"]) is None
@@ -242,7 +259,11 @@ def carry_successor_evidence(
     expected_contract_schema_version: int,
     now: int | None = None,
 ) -> bool:
-    """Carry one completed Evidence ledger as re-evaluation candidates only."""
+    """Carry completed facts, never approval, claims, runner or completion state.
+
+    The lifecycle caller must establish completion before calling this helper.
+    Cross-mode carry is deliberately unsupported.
+    """
     sources = sources_from_state(
         previous,
         expected_contract_schema_version=expected_contract_schema_version,
@@ -254,17 +275,25 @@ def carry_successor_evidence(
         if isinstance(verification, dict)
         else None
     )
-    session_id = previous.get("evidence_session_id")
+    guarded = previous.get("runtime_mode") == "guarded"
+    identity_field = "origin_contract_id" if guarded else "origin_evidence_session_id"
+    session_id = previous.get("contract_id" if guarded else "evidence_session_id")
     intent_digest = previous.get("intent_digest")
     if (
-        not sources
+        current.get("runtime_mode") != previous.get("runtime_mode")
+        or guarded and (
+            previous.get("status") != "approved"
+            or not previous.get("approved_turn_id")
+            or previous.get("approved_turn_id") == previous.get("staged_turn_id")
+        )
+        or not sources
         or len(sources) > MAX_SUCCESSOR_SOURCES
         or not isinstance(evidence_state, dict)
         or not isinstance(revision, int)
         or isinstance(revision, bool)
         or revision < 0
         or not isinstance(session_id, str)
-        or re.fullmatch(r"evs_[0-9a-f]{32}", session_id) is None
+        or re.fullmatch(r"ctr_[0-9a-f]{32}" if guarded else r"evs_[0-9a-f]{32}", session_id) is None
         or not isinstance(intent_digest, str)
         or re.fullmatch(r"[0-9a-f]{64}", intent_digest) is None
     ):
@@ -280,9 +309,9 @@ def carry_successor_evidence(
     if not eligible:
         return False
     value = {
-        "version": SUCCESSOR_EVIDENCE_VERSION,
+        "version": GUARDED_SUCCESSOR_VERSION if guarded else SUCCESSOR_EVIDENCE_VERSION,
         "scope_digest": scope_digest,
-        "origin_evidence_session_id": session_id,
+        identity_field: session_id,
         "origin_intent_digest": intent_digest,
         "origin_revision": revision,
         "origin_registry_digest": registry_digest(sources),
@@ -317,14 +346,27 @@ def successor_candidate(
     ):
         return None
     assert isinstance(value, dict)
+    guarded = value["version"] == GUARDED_SUCCESSOR_VERSION
+    if guarded and not (
+        state.get("runtime_mode") == "guarded"
+        and state.get("status") == "approved"
+        and state.get("approved_turn_id")
+        and state.get("approved_turn_id") != state.get("staged_turn_id")
+        and state.get("contract_id") != value["origin_contract_id"]
+    ):
+        return None
+    if not guarded and state.get("runtime_mode") != "evidence":
+        return None
     origin = value["origins"].get(source_key)
     source = value["evidence_state"]["sources"].get(source_key)
     if not isinstance(origin, dict) or not isinstance(source, dict):
         return None
     metadata = {
-        "kind": "successor-evidence",
+        "kind": "successor-contract" if guarded else "successor-evidence",
         "batch_id": origin["batch_id"],
-        "evidence_session_id": value["origin_evidence_session_id"],
+        ("contract_id" if guarded else "evidence_session_id"): value[
+            "origin_contract_id" if guarded else "origin_evidence_session_id"
+        ],
         "candidate_digest": value["digest"],
         "origin_revision": value["origin_revision"],
     }
@@ -616,6 +658,7 @@ def _successor_fields_are_valid(source: dict[str, Any]) -> bool:
     origin_revision = source.get("last_successor_origin_revision", -1)
     batch_id = source.get("last_successor_origin_batch_id", "")
     session_id = source.get("last_successor_origin_evidence_session_id", "")
+    contract_id = source.get("last_successor_origin_contract_id", "")
     candidate_digest = source.get("last_successor_candidate_digest", "")
     mode = source.get("last_successor_mode", "")
     if any(
@@ -626,19 +669,22 @@ def _successor_fields_are_valid(source: dict[str, Any]) -> bool:
     if count < 0 or reused_at < 0 or origin_revision < -1:
         return False
     if not all(isinstance(value, str) for value in (
-        batch_id, session_id, candidate_digest, mode
+        batch_id, session_id, contract_id, candidate_digest, mode
     )):
         return False
     if count == 0:
         return bool(
             reused_at == 0 and origin_revision == -1 and not batch_id
-            and not session_id and not candidate_digest and not mode
+            and not session_id and not contract_id and not candidate_digest and not mode
         )
     return bool(
         reused_at > 0
         and origin_revision >= 0
         and re.fullmatch(r"[0-9a-f]{32}", batch_id)
-        and re.fullmatch(r"evs_[0-9a-f]{32}", session_id)
+        and (
+            not contract_id and re.fullmatch(r"evs_[0-9a-f]{32}", session_id)
+            or not session_id and re.fullmatch(r"ctr_[0-9a-f]{32}", contract_id)
+        )
         and re.fullmatch(r"[0-9a-f]{64}", candidate_digest)
         and mode in {"exact", "dependency", "safe-change"}
     )

--- a/hooks/click_gate.py
+++ b/hooks/click_gate.py
@@ -206,7 +206,9 @@ def _emit(payload: dict[str, Any]) -> None:
     _OUTPUT_SINK(payload)
 
 
-def _deny(reason: str) -> None:
+def _deny(reason: str, *, event: dict[str, Any] | None = None, code: str = "") -> None:
+    if event is not None:
+        click_lifecycle.record_control_event(event, code)
     _emit(_OUTPUT_ADAPTER.deny(reason))
 
 
@@ -691,7 +693,8 @@ def _handle_pre_tool(event: dict[str, Any]) -> None:
                 ):
                     _deny(
                         "Pass the approved Click execution contract in the current turn "
-                        "before starting a structured mutation."
+                        "before starting a structured mutation.",
+                        event=event, code="approval-required",
                     )
                     return
                 rewritten, mutation_error = _prepare_mutation(event, value)
@@ -710,7 +713,8 @@ def _handle_pre_tool(event: dict[str, Any]) -> None:
                 ):
                     _deny(
                         "Pass the approved Click execution contract in the current turn "
-                        "before managing its local development service."
+                        "before managing its local development service.",
+                        event=event, code="approval-required",
                     )
                     return
                 rewritten, service_error = _prepare_service(event, value)
@@ -760,7 +764,8 @@ def _handle_pre_tool(event: dict[str, Any]) -> None:
                 ):
                     _deny(
                         "Pass the approved Click execution contract in the current turn "
-                        "before starting its final verification batch."
+                        "before starting its final verification batch.",
+                        event=event, code="approval-required",
                     )
                     return
                 (
@@ -788,7 +793,7 @@ def _handle_pre_tool(event: dict[str, Any]) -> None:
                         event, value
                     )
                 if lifecycle_error:
-                    _deny(lifecycle_error)
+                    _deny(lifecycle_error, event=event, code="contract-lifecycle-rejected")
                     return
                 if action == "stage":
                     contract, projection_error = click_contract.validate_contract(value)
@@ -990,7 +995,8 @@ def _handle_pre_tool(event: dict[str, Any]) -> None:
             "`click-gate bypass` only after the current user turn begins with a recognized "
             "first-line `@Click bypass` directive or trusted Click autocomplete mention. "
             "Use the corresponding `@Click cancel` form plus `click-gate cancel` to discard "
-            "an active contract instead of bypassing it."
+            "an active contract instead of bypassing it.",
+            event=event, code="approval-required",
         )
 
 

--- a/hooks/click_incremental.py
+++ b/hooks/click_incremental.py
@@ -10,6 +10,7 @@ explaining that batch to read-only consumers.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import math
 import re
@@ -181,7 +182,7 @@ def decision(
 # share the existing age/count/byte budget with legacy planning events.
 BATCH_STATUSES = frozenset({"planned", "running", "passed", "failed", "interrupted", "rejected", "incomplete"})
 SOURCE_STATUSES = frozenset({"planned", "reuse-pending", "running", "passed", "failed", "interrupted", "not-run", "reused", "unknown"})
-REUSE_ORIGIN_KINDS = frozenset({"successor-evidence"})
+REUSE_ORIGIN_KINDS = frozenset({"successor-evidence", "successor-contract"})
 EXECUTION_REASONS = frozenset({
     "", "batch-finished", "request-rejected", "runner-admission-rejected",
     "plan-not-created", "reuse-applied", "command-started", "command-passed",
@@ -189,6 +190,7 @@ EXECUTION_REASONS = frozenset({
     "preceding-check-stopped", "workspace-invalidated", "outcome-unconfirmed",
     "reservation-expired",
     "user-cancelled",
+    "not-requested",
 })
 _BATCH_FIELDS = frozenset({
     "event", "version", "batch_id", "timestamp", "finished_at", "current_revision",
@@ -213,6 +215,83 @@ SUMMARY_FIELDS = (
     "request_wall_ms", "measured_processing_ms", "estimated_avoided_ms",
     "estimated_source_count", "baseline_sample_count",
 )
+CONTROL_CODES = frozenset({
+    "approval-required", "contract-id-mismatch", "contract-lifecycle-rejected",
+    "verification-request-rejected", "verification-guidance",
+})
+CONTROL_FIELDS = frozenset({"event_id", "timestamp", "code", "effect"})
+
+
+def control_events(state: Any) -> list[dict[str, Any]]:
+    values = state.get("control_events", []) if isinstance(state, dict) else []
+    if not isinstance(values, list):
+        return []
+    unique = {}
+    for value in values[-128:]:
+        if (
+            isinstance(value, dict) and set(value) == CONTROL_FIELDS
+            and isinstance(value.get("event_id"), str) and _DIGEST.fullmatch(value["event_id"])
+            and _is_integer(value.get("timestamp"), minimum=1)
+            and value.get("code") in CONTROL_CODES
+            and value.get("effect") == ("advisory" if value["code"] == "verification-guidance" else "blocked")
+        ):
+            unique[value["event_id"]] = dict(value)
+    return list(unique.values())
+
+
+def record_control_event(state: dict[str, Any], event: dict[str, Any], code: str) -> bool:
+    """Prose-free observation only. Never consulted by any authorization check."""
+    if code not in CONTROL_CODES or not event.get("tool_use_id"):
+        return False
+    identity = hashlib.sha256(_canonical_bytes([
+        event.get("session_id"), event.get("turn_id"), event.get("tool_use_id"),
+        event.get("tool_input"), "advisory" if code == "verification-guidance" else "blocked",
+    ])).hexdigest()
+    values = control_events(state)
+    if any(value["event_id"] == identity for value in values):
+        return False
+    values.append({"event_id": identity, "timestamp": int(time.time()) or 1,
+                   "code": code, "effect": "advisory" if code == "verification-guidance" else "blocked"})
+    state["control_events"] = values[-128:]
+    return True
+
+
+def _clock_id() -> str:
+    return time.get_clock_info("monotonic").implementation
+
+
+def start_request_clock(
+    verification: dict[str, Any], batch_id: str, *,
+    started_ns: int | None = None, clock_id: str | None = None,
+) -> None:
+    verification["incremental_request_clock"] = {
+        "batch_id": batch_id, "started_ns": time.monotonic_ns() if started_ns is None else started_ns,
+        "clock_id": _clock_id() if clock_id is None else clock_id,
+    }
+
+
+def complete_request_timing(
+    verification: dict[str, Any], batch: dict[str, Any], *,
+    ended_ns: int | None = None, clock_id: str | None = None,
+) -> None:
+    """Same-host monotonic interval; excludes pre-Hook queue and final return.
+
+    A missing, mismatched or regressed clock stays unknown. Timing is never
+    consulted by runner admission, reuse or contract completion.
+    """
+    clock = verification.get("incremental_request_clock")
+    ended = time.monotonic_ns() if ended_ns is None else ended_ns
+    if not isinstance(clock, dict):
+        return
+    started = clock.get("started_ns")
+    if (
+        clock.get("batch_id") == batch.get("batch_id")
+        and clock.get("clock_id") == (_clock_id() if clock_id is None else clock_id)
+        and _is_integer(started) and _is_integer(ended)
+        and 0 <= ended - started <= 24 * 60 * 60 * 1_000_000_000
+    ):
+        batch.update(version=max(batch.get("version", 2), 3), request_wall_ms=(ended - started) / 1_000_000,
+                     measurement_scope="hook-entry-to-result-recording")
 
 
 def safe_label(value: Any, fallback: str) -> str:
@@ -225,15 +304,69 @@ def safe_label(value: Any, fallback: str) -> str:
     ) else fallback
 
 
+def safe_display_text(value: Any, fallback: str = "승인 계약 원문에서 확인") -> str:
+    """Bounded local display copy, not an approval or a secret-redaction proof."""
+    if (
+        not isinstance(value, str) or not value or len(value) > 240
+        or re.fullmatch(r"[\w가-힣\s.,!?()·→–—-]+", value) is None
+        or re.search(r"(?i)(token|secret|password|bearer|api.?key|비밀번호|비밀키)", value)
+        or any(char in value for char in "\n\r\t")
+    ):
+        return fallback
+    return value
+
+
+def sanitize_presentation(value: Any) -> dict[str, Any]:
+    value = value if isinstance(value, dict) else {}
+    labels = value.get("evidence_labels", {})
+    return {
+        "name": safe_display_text(value.get("name"), "현재 작업"),
+        **{key: [safe_display_text(item) for item in value.get(key, [])[:8]]
+           if isinstance(value.get(key), list) else []
+           for key in ("promises", "in_scope", "out_of_scope", "must_hold")},
+        "evidence_labels": {
+            key: safe_label(label, "검증 묶음") for key, label in list(labels.items())[:256]
+            if isinstance(key, str) and _DIGEST.fullmatch(key)
+        } if isinstance(labels, dict) else {},
+    }
+
+
+def contract_presentation(contract: dict[str, Any]) -> dict[str, Any]:
+    verification = contract.get("verification", {})
+    boundary = contract.get("boundary", {})
+    return sanitize_presentation({
+        "name": contract.get("outcome"),
+        "promises": [item.get("condition") for item in verification.get("done_when", [])],
+        "in_scope": boundary.get("in_scope"), "out_of_scope": boundary.get("out_of_scope"),
+        "must_hold": contract.get("must_hold"),
+        "evidence_labels": {hashlib.sha256(item["id"].encode()).hexdigest(): safe_label(item.get("description"), safe_label(item["id"], "검증 묶음"))
+                            for item in verification.get("evidence", [])},
+    })
+
+
+def batch_task_is_valid(value: Any) -> bool:
+    return bool(
+        isinstance(value, dict) and set(value) == {"mode", "id", "name"}
+        and value.get("mode") in {"guarded", "evidence"}
+        and isinstance(value.get("id"), str)
+        and re.fullmatch(r"ctr_[0-9a-f]{32}" if value["mode"] == "guarded" else r"evs_[0-9a-f]{32}", value["id"])
+        and value.get("name") == safe_display_text(value.get("name"), "")
+        and value["name"]
+    )
+
+
 def reuse_origin_is_valid(value: Any) -> bool:
+    guarded = isinstance(value, dict) and value.get("kind") == "successor-contract"
+    identity_field = "contract_id" if guarded else "evidence_session_id"
+    fields = (_REUSE_ORIGIN_FIELDS - {"evidence_session_id"}) | {identity_field}
     return bool(
         isinstance(value, dict)
-        and set(value) == _REUSE_ORIGIN_FIELDS
+        and set(value) == fields
         and value.get("kind") in REUSE_ORIGIN_KINDS
         and isinstance(value.get("batch_id"), str)
         and re.fullmatch(r"[0-9a-f]{32}", value["batch_id"])
-        and isinstance(value.get("evidence_session_id"), str)
-        and re.fullmatch(r"evs_[0-9a-f]{32}", value["evidence_session_id"])
+        and isinstance(value.get(identity_field), str)
+        and re.fullmatch(r"ctr_[0-9a-f]{32}" if guarded else r"evs_[0-9a-f]{32}", value[identity_field])
         and isinstance(value.get("candidate_digest"), str)
         and _DIGEST.fullmatch(value["candidate_digest"])
         and _is_integer(value.get("origin_revision"))
@@ -270,11 +403,13 @@ def source_result_is_valid(value: Any) -> bool:
 
 
 def batch_is_valid(value: Any) -> bool:
-    if not isinstance(value, dict) or set(value) != _BATCH_FIELDS:
+    if not isinstance(value, dict) or set(value) != (_BATCH_FIELDS | {"task"} if value.get("version") == 4 else _BATCH_FIELDS):
         return False
     items = value.get("sources")
     return bool(
-        value.get("event") == BATCH_EVENT and value.get("version") in {1, 2}
+        value.get("event") == BATCH_EVENT and value.get("version") in {1, 2, 3, 4}
+        and (value["version"] != 4 or batch_task_is_valid(value.get("task")))
+        and not isinstance(value.get("version"), bool)
         and isinstance(value.get("batch_id"), str)
         and re.fullmatch(r"[0-9a-f]{32}", value["batch_id"])
         and _is_integer(value.get("timestamp"), minimum=1)
@@ -287,7 +422,7 @@ def batch_is_valid(value: Any) -> bool:
         and all(source_result_is_valid(item) for item in items)
         and all(
             (value["version"] == 1 and "reuse_origin" not in item)
-            or (value["version"] == 2 and "reuse_origin" in item)
+            or (value["version"] in {2, 3, 4} and "reuse_origin" in item)
             for item in items
         )
         and len({item["source_key"] for item in items}) == len(items)
@@ -295,10 +430,12 @@ def batch_is_valid(value: Any) -> bool:
         and all(value.get(key) is None or is_duration(value[key]) for key in (
             "prepare_duration_ms", "runner_duration_ms", "request_wall_ms"
         ))
-        and value.get("request_wall_ms") is None
-        and value.get("measurement_scope") in {
-            "unknown", "prepare-only", "prepare-and-runner-segments"
-        }
+        and (
+            value.get("request_wall_ms") is None
+            and value.get("measurement_scope") in {"unknown", "prepare-only", "prepare-and-runner-segments"}
+            or value["version"] in {3, 4} and is_duration(value.get("request_wall_ms"))
+            and value.get("measurement_scope") == "hook-entry-to-result-recording"
+        )
     )
 
 
@@ -307,6 +444,7 @@ def new_batch(
     prepared_ms: float | None, requested: list[dict[str, str]] | None = None,
     labels: dict[str, str] | None = None,
     reuse_origins: dict[str, dict[str, Any]] | None = None,
+    task: dict[str, Any] | None = None,
     now: int | None = None,
 ) -> dict[str, Any]:
     timestamp = int(time.time()) if now is None else now
@@ -328,6 +466,8 @@ def new_batch(
         # Host queue/handoff/return is not measured by these separate processes.
         "request_wall_ms": None, "measurement_scope": "prepare-only",
     }
+    if batch_task_is_valid(task):
+        batch.update(version=4, task=dict(task))
     for index, item in enumerate(items, start=1):
         source = dict(item)
         source.setdefault("duration_baseline", None)
@@ -408,6 +548,7 @@ def reject_batch(
         batch.update(runner_duration_ms=runner_duration_ms, measurement_scope="prepare-and-runner-segments")
     for item in batch["sources"]:
         item.update(status="not-run", execution_reason_code=reason)
+    complete_request_timing(verification, batch)
     return store_batch(verification, batch)
 
 
@@ -418,6 +559,7 @@ def finish_reuse(verification: dict[str, Any]) -> bool:
     batch.update(status="passed", reason_code="batch-finished", finished_at=int(time.time()))
     for item in batch["sources"]:
         item.update(status="reused", execution_reason_code="reuse-applied")
+    complete_request_timing(verification, batch)
     return store_batch(verification, batch)
 
 
@@ -483,6 +625,7 @@ def interrupt_batch(verification: dict[str, Any]) -> bool:
             status="interrupted" if item["started"] else "not-run",
             execution_reason_code="user-cancelled", completed=False,
         )
+    complete_request_timing(verification, batch)
     return store_batch(verification, batch)
 
 
@@ -506,6 +649,48 @@ def history_totals(verification: Any) -> dict[str, int]:
         )}}
 
 
+def history_accounting(verification: Any) -> dict[str, Any]:
+    """Count actual group requests, including distinct retries, not test cases."""
+    batches = batch_history(verification)
+    summaries = [batch_summary(batch) for batch in batches]
+    unknown_requests = sum(batch["requested_source_count"] is None for batch in batches)
+    denominator = sum(batch["requested_source_count"] or 0 for batch in batches)
+    numerator = sum(item["authoritative_reuse_count"] for item in summaries)
+    return {
+        "unit": "verification-group-request", "window": "retained-history",
+        "from_timestamp": min((batch["timestamp"] for batch in batches), default=None),
+        "through_timestamp": max((batch["finished_at"] or batch["timestamp"] for batch in batches), default=None),
+        "max_age_seconds": MAX_HISTORY_AGE_SECONDS, "max_events": MAX_HISTORY_EVENTS,
+        "batch_count": len(batches), "unknown_request_batch_count": unknown_requests,
+        "request_denominator": denominator, "reuse_numerator": numerator,
+        "reuse_rate": numerator / denominator if denominator and not unknown_requests else None,
+        "missing_baseline_duration_count": sum(item["authoritative_reuse_count"] - item["estimated_source_count"] for item in summaries),
+        **{key: sum(item[key] for item in summaries) for key in (
+            "executed_source_count", "passed_source_count", "failed_source_count",
+            "interrupted_source_count", "not_run_source_count", "pending_source_count",
+        )},
+    }
+
+
+def accounting_is_valid(value: Any) -> bool:
+    example = history_accounting({})
+    if not isinstance(value, dict) or set(value) != set(example):
+        return False
+    if value["unit"] != example["unit"] or value["window"] != example["window"]:
+        return False
+    for key, item in value.items():
+        if key in {"unit", "window", "reuse_rate"}:
+            continue
+        if key in {"from_timestamp", "through_timestamp"} and item is None:
+            continue
+        if not _is_integer(item):
+            return False
+    denominator, numerator = value["request_denominator"], value["reuse_numerator"]
+    return bool(numerator <= denominator and value["reuse_rate"] == (
+        numerator / denominator if denominator and not value["unknown_request_batch_count"] else None
+    ))
+
+
 def batch_summary(batch: dict[str, Any]) -> dict[str, Any]:
     if not batch_is_valid(batch):
         raise ValueError("invalid verification batch")
@@ -516,7 +701,7 @@ def batch_summary(batch: dict[str, Any]) -> dict[str, Any]:
     planned_runs = sum(item["decision"] in DECISIONS - REUSE_DECISIONS for item in items)
     times = [item["duration_ms"] for item in started]
     prep, runner = batch["prepare_duration_ms"], batch["runner_duration_ms"]
-    measured = prep if batch["measurement_scope"] == "prepare-only" else (
+    measured = prep if runner is None else (
         prep + runner if prep is not None and runner is not None else None
     )
     return {
@@ -541,6 +726,24 @@ def batch_summary(batch: dict[str, Any]) -> dict[str, Any]:
         "estimated_source_count": len(baselines),
         "baseline_sample_count": sum(item["sample_count"] for item in baselines),
     }
+
+
+def host_summary(verification: Any) -> str:
+    batch = current_batch(verification)
+    if batch is None:
+        return ""
+    summary = batch_summary(batch)
+    prior = sum(item["status"] == "reused" and item.get("reuse_origin") is not None for item in batch["sources"])
+    avoided = summary["estimated_avoided_ms"]
+    estimate = "unmeasured" if avoided is None else f"{avoided:.1f}ms"
+    return (
+        f"[Click result] groups requested={summary['total_source_count']} "
+        f"executed={summary['executed_source_count']} passed={summary['passed_source_count']} "
+        f"failed={summary['failed_source_count']} interrupted={summary['interrupted_source_count']} "
+        f"not-started={summary['not_run_source_count']} reused={summary['authoritative_reuse_count']} "
+        f"(requalified-prior-task={prior}); estimated avoided rerun cost={estimate}; "
+        "not measured net savings."
+    )
 
 
 
@@ -762,6 +965,7 @@ def record_execution(
     batch["finished_at"] = int(time.time())
     batch["runner_duration_ms"] = runner_duration_ms
     batch["measurement_scope"] = "prepare-and-runner-segments"
+    complete_request_timing(verification, batch)
     return store_batch(verification, batch)
 
 

--- a/hooks/click_lifecycle.py
+++ b/hooks/click_lifecycle.py
@@ -90,6 +90,16 @@ def _write_state(
     click_state.write_json(click_state.state_path(event), payload)
 
 
+def record_control_event(event: dict[str, Any], code: str) -> None:
+    """Called within the host's state lock; failures cannot affect admission."""
+    try:
+        state = _read_contract_state(event)
+        if state and click_incremental.record_control_event(state, event, code):
+            _save_contract_state(event, state)
+    except Exception:
+        pass
+
+
 def _read_state(event: dict[str, Any]) -> dict[str, Any]:
     path = click_state.state_path(event)
     try:
@@ -111,9 +121,8 @@ def _write_contract_state(
     event: dict[str, Any], status: str, digest: str, contract: dict[str, Any]
 ) -> str:
     contract_id = f"ctr_{secrets.token_hex(16)}"
-    click_state.write_json(
-        click_state.contract_path(event),
-        {
+    previous = _read_contract_state(event)
+    current = {
             "state_schema_version": CONTRACT_STATE_SCHEMA_VERSION,
             "status": status,
             "contract_digest": digest,
@@ -121,6 +130,7 @@ def _write_contract_state(
             "staged_turn_id": str(event.get("turn_id", "")),
             "approved_turn_id": "",
             "runtime_mode": "guarded",
+            "presentation": click_incremental.contract_presentation(contract),
             "intent_digest": digest,
             "intent_turn_id": str(event.get("turn_id", "")),
             "follow_up_turns": [],
@@ -136,9 +146,52 @@ def _write_contract_state(
                 click_shadow_dashboard.fresh_state()
             ),
             "updated_at": int(time.time()),
-        },
-    )
+        }
+    if (
+        click_runtime_state.view(previous).guarded_approved
+        and _contract_is_completed(previous)
+    ):
+        _carry_completed_candidates(event, previous, current)
+    # Viewer history is deliberately separate from the fresh authority ledger.
+    presentations = previous.get("presentation_history", {})
+    presentations = dict(presentations) if isinstance(presentations, dict) else {}
+    if CONTRACT_ID_PATTERN.fullmatch(str(previous.get("contract_id", ""))):
+        presentations[previous["contract_id"]] = click_incremental.sanitize_presentation(previous.get("presentation"))
+    current["presentation_history"] = dict(list(presentations.items())[-8:])
+    current["verification"][click_incremental.CURRENT_BATCH_FIELD] = None
+    _save_contract_state(event, current)
     return contract_id
+
+
+def _carry_completed_candidates(
+    event: dict[str, Any], previous: dict[str, Any], current: dict[str, Any]
+) -> None:
+    verification = previous.get("verification", {})
+    revision = verification.get("mutation_revision", 0)
+    _, claim_error = click_claims.receipt_entries(previous, settle_through_revision=revision)
+    if claim_error:
+        return
+    sources = _evidence_sources(previous) or {}
+    origins: dict[str, dict[str, str]] = {}
+    for batch in click_incremental.batch_history(previous.get("verification")):
+        for source in batch["sources"]:
+            fact = sources.get(source["source_key"], {})
+            if (
+                source["status"] in {"passed", "reused"}
+                and batch["current_revision"] == revision
+                and source["check_digest"] == fact.get("verified_check_digest")
+            ):
+                origins[source["source_key"]] = {
+                    "batch_id": batch["batch_id"],
+                    "execution_status": source["status"],
+                }
+    click_evidence.carry_successor_evidence(
+        previous, current, origins=origins,
+        scope_digest=click_evidence.successor_scope_digest(
+            str(click_state.contract_path(event).resolve())
+        ),
+        expected_contract_schema_version=CONTRACT_STATE_SCHEMA_VERSION,
+    )
 
 
 def _fresh_evidence_state(
@@ -213,25 +266,7 @@ def _ensure_evidence_state(event: dict[str, Any]) -> tuple[dict[str, Any], bool]
         previous = state
         state = _fresh_evidence_state(event, history_complete=not recovered)
         if completed_evidence:
-            origins: dict[str, dict[str, str]] = {}
-            for batch in click_incremental.batch_history(
-                previous.get("verification")
-            ):
-                for source in batch["sources"]:
-                    if source["status"] in {"passed", "reused"}:
-                        origins[source["source_key"]] = {
-                            "batch_id": batch["batch_id"],
-                            "execution_status": source["status"],
-                        }
-            click_evidence.carry_successor_evidence(
-                previous,
-                state,
-                origins=origins,
-                scope_digest=click_evidence.successor_scope_digest(
-                    str(click_state.contract_path(event).resolve())
-                ),
-                expected_contract_schema_version=CONTRACT_STATE_SCHEMA_VERSION,
-            )
+            _carry_completed_candidates(event, previous, state)
         _save_contract_state(event, state)
         return state, recovered
     if _append_follow_up(event, state):
@@ -712,6 +747,7 @@ def pass_contract(event: dict[str, Any], contract_id: str) -> tuple[str, str]:
             "it explicitly, then stage and show the contract again.",
         )
     if contract_id != expected_id:
+        record_control_event(event, "contract-id-mismatch")
         return (
             "",
             "The contract_id differs from the proposal staged for user approval. "

--- a/hooks/click_receipt.py
+++ b/hooks/click_receipt.py
@@ -19,11 +19,13 @@ LEGACY_RECEIPT_VERSION = 1
 RECEIPT_VERSION = 2
 SHARD_RECEIPT_VERSION = 3
 SUCCESSOR_RECEIPT_VERSION = 4
+GUARDED_SUCCESSOR_RECEIPT_VERSION = 5
 SUPPORTED_RECEIPT_VERSIONS = {
     LEGACY_RECEIPT_VERSION,
     RECEIPT_VERSION,
     SHARD_RECEIPT_VERSION,
     SUCCESSOR_RECEIPT_VERSION,
+    GUARDED_SUCCESSOR_RECEIPT_VERSION,
 }
 ENVELOPE_VERSION = 1
 UNSIGNED_ASSURANCE = "unsigned-integrity-only"
@@ -117,6 +119,9 @@ SUCCESSOR_LINEAGE_FIELDS = LINEAGE_FIELDS | {
     "origin_evidence_session_id",
     "requalification_mode",
 }
+GUARDED_SUCCESSOR_LINEAGE_FIELDS = (
+    SUCCESSOR_LINEAGE_FIELDS - {"origin_evidence_session_id"}
+) | {"origin_contract_id"}
 COVERAGE_FIELDS = {
     "host_assurance",
     "host_coverage_digest",
@@ -348,7 +353,11 @@ def _normalize_lineage(
     value: Any, *, kind: str, revision: int, receipt_version: int
 ) -> tuple[dict[str, Any] | None, str]:
     successor = isinstance(value, dict) and value.get("mode") == "successor-reused"
-    fields = SUCCESSOR_LINEAGE_FIELDS if successor else LINEAGE_FIELDS
+    guarded = successor and "origin_contract_id" in value
+    fields = (
+        GUARDED_SUCCESSOR_LINEAGE_FIELDS if guarded
+        else SUCCESSOR_LINEAGE_FIELDS if successor else LINEAGE_FIELDS
+    )
     error = _exact_fields(value, fields, "evidence.lineage")
     if error:
         return None, error
@@ -370,16 +379,19 @@ def _normalize_lineage(
         return None, f"Completion receipt lineage mode is invalid for `{kind}` evidence."
     if mode == "successor-reused":
         origin_batch_id = value.get("origin_batch_id")
-        origin_session_id = value.get("origin_evidence_session_id")
+        identity_field = "origin_contract_id" if guarded else "origin_evidence_session_id"
+        origin_session_id = value.get(identity_field)
         requalification_mode = value.get("requalification_mode")
         if (
-            receipt_version != SUCCESSOR_RECEIPT_VERSION
+            receipt_version != (
+                GUARDED_SUCCESSOR_RECEIPT_VERSION if guarded else SUCCESSOR_RECEIPT_VERSION
+            )
             or kind != "argv"
             or not _is_digest(dependency_digest)
             or not isinstance(origin_batch_id, str)
             or re.fullmatch(r"[0-9a-f]{32}", origin_batch_id) is None
             or not isinstance(origin_session_id, str)
-            or re.fullmatch(r"evs_[0-9a-f]{32}", origin_session_id) is None
+            or re.fullmatch(r"ctr_[0-9a-f]{32}" if guarded else r"evs_[0-9a-f]{32}", origin_session_id) is None
             or requalification_mode not in {"exact", "dependency", "safe-change"}
         ):
             return None, "Successor-reused evidence lineage is invalid."
@@ -388,7 +400,7 @@ def _normalize_lineage(
             "from_revision": from_revision,
             "dependency_digest": dependency_digest,
             "origin_batch_id": origin_batch_id,
-            "origin_evidence_session_id": origin_session_id,
+            identity_field: origin_session_id,
             "requalification_mode": requalification_mode,
         }, ""
     if mode == "dependency-reused":
@@ -457,7 +469,7 @@ def _normalize_evidence(
 ) -> tuple[dict[str, Any] | None, str]:
     fields = (
         SHARDED_EVIDENCE_FIELDS
-        if receipt_version in {SHARD_RECEIPT_VERSION, SUCCESSOR_RECEIPT_VERSION}
+        if receipt_version in {SHARD_RECEIPT_VERSION, SUCCESSOR_RECEIPT_VERSION, GUARDED_SUCCESSOR_RECEIPT_VERSION}
         else EVIDENCE_FIELDS
     )
     error = _exact_fields(value, fields, "evidence source")
@@ -525,7 +537,7 @@ def _normalize_evidence(
         },
         "lineage": lineage,
     }
-    if receipt_version in {SHARD_RECEIPT_VERSION, SUCCESSOR_RECEIPT_VERSION}:
+    if receipt_version in {SHARD_RECEIPT_VERSION, SUCCESSOR_RECEIPT_VERSION, GUARDED_SUCCESSOR_RECEIPT_VERSION}:
         if kind != "argv" and value.get("shard") is not None:
             return None, "Only argv evidence may carry shard provenance."
         shard, error = _normalize_shard(value.get("shard"), source_key=source_key)
@@ -584,6 +596,7 @@ def validate_receipt(value: Any) -> tuple[dict[str, Any] | None, str]:
         RECEIPT_VERSION,
         SHARD_RECEIPT_VERSION,
         SUCCESSOR_RECEIPT_VERSION,
+        GUARDED_SUCCESSOR_RECEIPT_VERSION,
     }:
         authority, error = _normalize_authority(value.get("authority"))
         if error:
@@ -651,7 +664,7 @@ def validate_receipt(value: Any) -> tuple[dict[str, Any] | None, str]:
         seen.add(source_key)
         normalized_evidence.append(normalized)
     normalized_evidence.sort(key=lambda source: str(source["source_key"]))
-    if version in {SHARD_RECEIPT_VERSION, SUCCESSOR_RECEIPT_VERSION}:
+    if version in {SHARD_RECEIPT_VERSION, SUCCESSOR_RECEIPT_VERSION, GUARDED_SUCCESSOR_RECEIPT_VERSION}:
         sharded = [
             source for source in normalized_evidence if source.get("shard") is not None
         ]
@@ -686,6 +699,12 @@ def validate_receipt(value: Any) -> tuple[dict[str, Any] | None, str]:
         for source in normalized_evidence
     ):
         return None, "Receipt v4 requires successor-reused evidence lineage."
+    if version == GUARDED_SUCCESSOR_RECEIPT_VERSION and (
+        authority is None or authority["mode"] != "guarded"
+        or not any("origin_contract_id" in source["lineage"] for source in normalized_evidence)
+        or any(source["lineage"].get("origin_contract_id") == contract["id"] for source in normalized_evidence)
+    ):
+        return None, "Receipt v5 requires separately approved Guarded successor lineage."
 
     workspace = execution["workspace"]
     assert isinstance(workspace, dict)

--- a/hooks/click_receipt_runtime.py
+++ b/hooks/click_receipt_runtime.py
@@ -172,6 +172,7 @@ def _evidence_receipts(
                 return None, "The host coverage identity changed after argv evidence completed."
 
         if kind == "argv" and int(source.get("successor_reuse_count", 0)) > 0:
+            guarded_origin = source.get("last_successor_origin_contract_id", "")
             lineage = {
                 "mode": "successor-reused",
                 "from_revision": int(
@@ -185,8 +186,8 @@ def _evidence_receipts(
                 "origin_batch_id": str(
                     source.get("last_successor_origin_batch_id", "")
                 ),
-                "origin_evidence_session_id": str(
-                    source.get("last_successor_origin_evidence_session_id", "")
+                ("origin_contract_id" if guarded_origin else "origin_evidence_session_id"): str(
+                    guarded_origin or source.get("last_successor_origin_evidence_session_id", "")
                 ),
                 "requalification_mode": str(
                     source.get("last_successor_mode", "")
@@ -244,6 +245,7 @@ def _evidence_receipts(
         if receipt_version in {
             click_receipt.SHARD_RECEIPT_VERSION,
             click_receipt.SUCCESSOR_RECEIPT_VERSION,
+            click_receipt.GUARDED_SUCCESSOR_RECEIPT_VERSION,
         }:
             metadata = source.get("shard")
             receipt_source["shard"] = (
@@ -301,7 +303,9 @@ def build_envelope(
         for source in sources.values()
     )
     receipt_version = (
-        click_receipt.SUCCESSOR_RECEIPT_VERSION
+        click_receipt.GUARDED_SUCCESSOR_RECEIPT_VERSION
+        if has_successor and any(source.get("last_successor_origin_contract_id") for source in sources.values())
+        else click_receipt.SUCCESSOR_RECEIPT_VERSION
         if has_successor
         else click_receipt.SHARD_RECEIPT_VERSION
         if any(

--- a/hooks/click_shadow_dashboard.py
+++ b/hooks/click_shadow_dashboard.py
@@ -81,25 +81,26 @@ HTML = """<!doctype html>
   </header>
   <main id="main">
     <section class="hero" aria-labelledby="title">
-      <div><p class="eyebrow">검증 효율 · INCREMENTAL VERIFICATION</p><h1 id="title">무엇을 실행했고,<br>얼마나 기다렸나요?</h1><p id="taskline">현재 Click 상태를 불러오는 중…</p><p id="batchHeadline">실제 검증 기록을 기다리고 있습니다.</p></div>
-      <div class="notice"><strong id="observerTitle">Observer 확인 중</strong><span id="observerBody">Dashboard와 Observer는 서로 독립적으로 동작합니다.</span></div>
+      <div><p class="eyebrow">승인한 약속 · 확인된 결과</p><h1 id="title">약속한 범위 안에서,<br>유효한 검증을 이어서.</h1><p id="taskline">현재 Click 상태를 불러오는 중…</p><p id="batchHeadline">실제 검증 기록을 기다리고 있습니다.</p></div>
+      <div class="notice"><strong id="topComparison">비교 실측 없음</strong><span>과거 실행시간은 비용 회피 추정입니다. 실제 순절감률은 동등한 비교 실측이 있어야 계산합니다.</span></div>
     </section>
+    <section class="panel contract-panel"><div class="panel-title"><h2 id="contractName">현재 작업</h2><span id="approvalState" class="pill">승인 상태 확인 중</span></div><div id="contractPromises"></div><details><summary>약속 전체·포함·제외 범위와 유지 조건</summary><div id="allPromises"></div><div id="contractBoundary"></div><p class="muted">로컬 표시용 요약입니다. 전체 약속과 승인 대상은 제시된 계약 원문을 기준으로 합니다. 표시 정보와 viewer 이력은 실행 권한이 아닙니다.</p><code id="contractId"></code></details><p id="controlSummary" class="muted"></p></section>
     <section class="metrics" aria-label="실제 증분 검증 결과">
       <article><span>요청한 검증 묶음</span><strong id="currentChecks">—</strong><small>개별 테스트 케이스 수가 아닙니다</small></article>
       <article><span>실제 실행</span><strong id="executedChecks">—</strong><small id="executionDetail">실제 시작한 검증 묶음</small></article>
       <article><span>실제 재사용</span><strong id="reusedChecks">—</strong><small>권한 규칙을 통과해 적용된 결과</small></article>
-      <article><span>생략한 실행 비용 · 추정</span><strong id="estimatedAvoided">—</strong><small id="estimateCoverage">과거 실행시간 기반 · 실측 절약 아님</small></article>
+      <article><span>재실행 비용 회피 추정</span><strong id="estimatedAvoided">—</strong><small id="estimateCoverage">과거 실행시간 기반 · 실측 절약 아님</small></article>
     </section>
     <section class="metric-split" aria-label="실제 결과와 Shadow 텔레메트리">
-      <article class="panel compact"><p class="eyebrow">실측 · 이번 검증</p><h2>대기시간과 실행 구간</h2><div class="statline"><span>전체 검증 대기시간</span><strong id="requestWall">—</strong></div><div class="statline"><span>측정 가능한 처리 구간</span><strong id="processingDuration">—</strong></div><p class="muted" id="timeScope">호스트 전달·대기·최종 반환은 계측 범위 밖입니다.</p><div class="statline"><span>검사 실행 구간 (Observer 포함)</span><strong id="executedDuration">—</strong></div><div class="statline"><span>동일 상태 / 관찰 입력 / 안전 변경 재사용</span><strong id="reuseBreakdown">—</strong></div></article>
-      <article class="panel compact shadow-card"><p class="eyebrow">SHADOW TELEMETRY · 권한 없음</p><h2>잠재 재사용 관찰</h2><div class="statline"><span>후보 / 확인 / 모순</span><strong id="shadowBreakdown">—</strong></div><div class="statline"><span>잠재 시간 / 관찰기 처리 비용</span><strong id="shadowTiming">—</strong></div><p class="muted" id="tracingSlowdown">추적으로 인한 검사 지연은 별도 측정하지 않았습니다.</p></article>
+      <article class="panel compact"><p class="eyebrow">실측 · 이번 검증</p><h2>측정된 구간과 빠진 구간</h2><div class="statline"><span>Hook 진입 → 결과 기록 · 부분 실측</span><strong id="requestWall">—</strong></div><div class="statline"><span>측정 가능한 처리 구간</span><strong id="processingDuration">—</strong></div><p class="muted" id="timeScope">호스트 요청 전·최종 반환은 계측 범위 밖입니다.</p><div class="statline"><span>검사 실행 구간 (Observer 포함)</span><strong id="executedDuration">—</strong></div><div class="statline"><span>동일 상태 / 관찰 입력 / 안전 변경 재사용</span><strong id="reuseBreakdown">—</strong></div></article>
+      <article class="panel compact"><p class="eyebrow">재사용의 출처와 비교 조건</p><h2 id="comparisonStatus">비교 실측 없음</h2><p id="reuseOrigins"></p><p id="reuseRate" class="muted"></p><p id="zeroReuse" class="muted"></p><p class="muted">과거 성공의 실행시간 합은 추정치입니다. 동등한 비교 실측 없이 순절감률·토큰·요금·전체 개발시간으로 환산하지 않습니다.</p></article>
     </section>
     <section class="panel timeline"><div class="panel-title"><div><p class="eyebrow">변경별 타임라인</p><h2>최근 검증 배치</h2></div><button id="latestBatch" type="button">최신 배치</button></div><label for="batchSelect">상세 결과 선택</label> <select id="batchSelect"></select><p id="batchState" class="muted"></p><p id="historyMeta" class="muted"></p></section>
     <section class="workspace">
       <article class="panel checks"><div class="panel-title"><div><p class="eyebrow">검사 목록</p><h2>실행 또는 재사용 결과</h2></div><span id="sourceCount" class="count">0</span></div><div id="sources" class="source-list"></div></article>
-      <article class="panel map-panel"><div class="panel-title"><div><p class="eyebrow">EVIDENCE MAP · SHADOW 관찰 · 권한 없음</p><h2>선택한 검사의 관찰된 입력</h2></div><span id="mapMeta" class="muted"></span></div><div id="emptyMap" class="empty">검사를 선택하면 현재 입력과 이전 baseline의 관계를 보여줍니다.</div><svg id="map" role="img" aria-label="선택한 검사의 Evidence Map"></svg></article>
     </section>
-    <section class="panel explanation" aria-live="polite"><p class="eyebrow">판정 이유</p><h2 id="whyTitle">검사를 선택하세요</h2><p id="whyBody">왜 실행했거나 재사용했는지 사람말로 설명합니다.</p><div id="limits"></div></section>
+    <section class="panel explanation" aria-live="polite"><p class="eyebrow">판정 이유</p><h2 id="whyTitle">검사를 선택하세요</h2><p id="whyBody">왜 실행했거나 재사용했는지 사람말로 설명합니다.</p><p id="originName"></p><details><summary>원계약·검사·revision·판정 상세</summary><div id="limits"></div></details></section>
+    <details class="panel telemetry"><summary>Evidence Map · Shadow 관찰 상세 · 재사용 권한 없음</summary><p><strong id="observerTitle">Observer 확인 중</strong> · <span id="observerBody">Dashboard와 Observer는 독립적입니다.</span></p><article class="map-panel"><div class="panel-title"><h2>선택한 검사의 관찰된 입력</h2><span id="mapMeta" class="muted"></span></div><div id="emptyMap" class="empty">검사를 선택하면 현재 입력과 이전 baseline의 관계를 보여줍니다.</div><svg id="map" role="img" aria-label="선택한 검사의 Evidence Map"></svg></article><article class="compact shadow-card"><h2>잠재 재사용 관찰</h2><div class="statline"><span>후보 / 확인 / 모순</span><strong id="shadowBreakdown">—</strong></div><div class="statline"><span>잠재 시간 / 관찰기 처리 비용</span><strong id="shadowTiming">—</strong></div><p class="muted" id="tracingSlowdown">추적으로 인한 검사 지연은 별도 측정하지 않았습니다.</p></article></details>
     <section class="panel comparison"><p class="eyebrow">명시적으로 실행한 비교 측정 · 일상 추정치와 별개</p><h2>전체 재실행 기준 vs 증분 실행</h2><p id="comparisonInfo">아직 비교 측정이 없습니다. 아래 명령을 로컬에서 실행한 뒤 JSON을 선택하세요.</p><pre>python3 benchmarks/incremental_verification.py --iterations 3 --warmups 1 --output /tmp/click-comparison.json</pre><label>비교 JSON 선택 <input id="comparisonFile" type="file" accept="application/json,.json"></label><div id="comparisonChart"></div></section>
     <section class="panel exports"><h2>공유 리포트</h2><p class="muted">현재 선택한 배치와 가져온 비교 측정을 내보냅니다. 파일 경로·원시 명령·환경 값·토큰은 제외합니다. 검증은 실행하지 않습니다.</p><button type="button" id="exportJson">JSON 내보내기</button> <button type="button" id="exportHtml">독립형 HTML 내보내기</button><span id="exportStatus" role="status"></span></section>
   </main>
@@ -117,6 +118,10 @@ CSS += """.metric-split{display:grid;grid-template-columns:1fr 1fr;gap:12px;marg
 
 CSS += """.timeline,.comparison,.exports{margin:12px 0}#batchHeadline{font-size:20px;color:var(--text)}button,select,input{font:inherit}select{max-width:100%;background:#141c29;color:var(--text);padding:10px;border:1px solid var(--line);border-radius:9px}button:not(.source){background:#243650;color:var(--text);border:1px solid #456087;padding:10px 14px;border-radius:9px;cursor:pointer}button:focus-visible,input:focus-visible,select:focus-visible{outline:2px solid var(--blue);outline-offset:3px}.comparison pre{overflow:auto;background:#0c111a;padding:14px;border-radius:10px;font-size:12px}.comparison-row{border-top:1px solid var(--line);padding:18px 0}.comparison-row h3{font-size:14px}.comparison-bar{min-width:190px;border-radius:5px;margin:8px 0;padding:8px;font-size:12px;background:#204d76;white-space:nowrap}.comparison-bar.incremental{background:#513575}.comparison-row p{font-size:12px;color:var(--muted)}.comparison-row p.slower{color:var(--red)}.exports h2{margin-bottom:10px}.exports span{font-size:12px;margin-left:12px}.timeline label{font-size:12px}#timeScope{line-height:1.6}#batchState{line-height:1.6}#executionDetail{line-height:1.5}.metrics small{line-height:1.5}"""
 
+CSS += """.contract-panel{margin-bottom:16px}.contract-panel p{line-height:1.6}.contract-panel code{overflow-wrap:anywhere;color:var(--muted);font-size:11px}details summary{cursor:pointer;padding:10px 0;color:var(--blue)}details[open] summary{margin-bottom:12px}.workspace{grid-template-columns:1fr}.source-list{grid-template-columns:repeat(2,minmax(0,1fr));max-height:360px}.telemetry{margin-top:12px}.telemetry .map-panel{min-height:0}.contract-panel .pill{white-space:nowrap}#reuseRate,#zeroReuse,#controlSummary{line-height:1.6}@media(max-width:650px){.source-list{grid-template-columns:1fr}.contract-panel .panel-title{align-items:start;gap:12px;flex-direction:column}}"""
+
+CSS += """main{padding-top:24px}.hero{margin-bottom:16px;align-items:center}h1{font-size:clamp(28px,3.1vw,40px);line-height:1.1}#taskline{margin-top:8px}#batchHeadline{margin:8px 0 0;font-size:17px}.contract-panel{padding:16px 20px}.contract-panel .panel-title{margin-bottom:8px}#contractPromises{display:flex;gap:24px}#contractPromises p{flex:1;margin:4px 0;font-size:13px;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}#controlSummary{margin:6px 0 0}.metrics article{padding:16px}.notice{padding:12px;max-width:300px}.notice span{font-size:11px}@media(max-width:650px){#contractPromises{display:block}.hero{gap:14px}.notice{box-sizing:border-box}}"""
+
 JS = r"""(() => {
   'use strict';
   const $ = id => document.getElementById(id);
@@ -130,11 +135,12 @@ JS = r"""(() => {
   let activeBatch = null;
   let activeSummary = null;
   let comparison = null;
+  let lastSnapshotSignature = '';
   const statusText = {
     planned: '실행 예정', 'reuse-pending': '재사용 예정 · 미적용', running: '실행 중',
     passed: '통과', failed: '실패', interrupted: '중단 · 일부 결과 미확정',
     'not-run': '미실행', reused: '재사용 적용', unknown: '측정 정보 없음',
-    rejected: '실행 전 거부', incomplete: '미확정', evidence: 'Evidence', approved: 'Guarded', none: '활성 작업 없음'
+    rejected: '실행 전 거부', incomplete: '미확정', evidence: 'Evidence', staged: '승인 대기', approved: '승인됨', none: '활성 작업 없음'
   };
   const outcomeText = {
     'request-rejected': '요청이 거부되어 시작하지 않았습니다.',
@@ -146,6 +152,7 @@ JS = r"""(() => {
     'command-error': '실행 경계에서 오류가 발생했습니다. 같은 검사를 다시 실행하지 않았습니다.',
     'command-interrupted': '검사 실행이 중단되었습니다.',
     'outcome-unconfirmed': '종료 결과를 확인하지 못했습니다.'
+    , 'not-requested': '아직 요청되지 않은 검증입니다. 승인 후 기준 검증을 실행하세요.'
   };
 
   const executionLabels = {
@@ -158,9 +165,9 @@ JS = r"""(() => {
   };
   const reasonText = {
     'same-revision-receipt-current': '같은 revision의 검사 결과가 현재 작업트리와 정확히 일치해 재사용했습니다.',
-    'successor-evidence-current': '이전 Evidence 작업의 실제 통과 결과를 현재 명령·작업트리·환경·실행 파일·호스트 범위에 다시 결합해 재사용했습니다.',
-    'successor-evidence-dependencies-unchanged': '이전 Evidence 작업의 실제 통과 결과를 가져와, 현재 변경 뒤에도 관찰된 입력이 바뀌지 않았음을 다시 확인해 재사용했습니다.',
-    'successor-evidence-safe-change-covered': '이전 Evidence 작업의 실제 통과 결과를 가져와, 현재 커밋된 안전 변경 정책이 이번 변경을 허용하는지 다시 확인해 재사용했습니다.',
+    'successor-evidence-current': '이전 작업의 실제 통과 결과를 현재 명령·작업트리·환경·실행 파일·호스트 범위에 다시 결합해 재사용했습니다.',
+    'successor-evidence-dependencies-unchanged': '이전 작업의 실제 통과 결과를 가져와, 현재 변경 뒤에도 관찰된 입력이 바뀌지 않았음을 다시 확인해 재사용했습니다.',
+    'successor-evidence-safe-change-covered': '이전 작업의 실제 통과 결과를 가져와, 사전에 커밋된 안전 변경 정책이 이번 변경을 허용하는지 다시 확인해 재사용했습니다.',
     'successor-evidence-scope-mismatch': '이전 결과가 현재 호스트 세션과 작업 공간의 후속 작업 범위에 속하지 않아 실제 검사를 실행했습니다.',
     'successor-evidence-integrity-invalid': '이전 실행 사실의 무결성이나 출처를 확인할 수 없어 실제 검사를 실행했습니다.',
     'observed-dependencies-unchanged': '이 검사가 실제로 읽었던 입력이 바뀌지 않아 이전 통과 결과를 재사용했습니다.',
@@ -190,6 +197,7 @@ JS = r"""(() => {
   };
 
   function reasonFor(source) {
+    if (source.execution_reason_code === 'user-cancelled' && source.execution_status === 'not-run') return '실행 전에 취소되어 시작하지 않았습니다. 이전 계약의 승인이나 실행 권한은 이어받지 않습니다.';
     if (outcomeText[source.execution_reason_code]) return outcomeText[source.execution_reason_code];
     if (source.execution_status === 'unknown') return '실제 실행 기록이 없는 이전 데이터입니다. 계획을 실행 실적으로 표시하지 않습니다.';
     const planned = source.execution_status === 'planned' || source.execution_status === 'reuse-pending';
@@ -202,14 +210,16 @@ JS = r"""(() => {
     selected = source.id;
     const label = statusText[source.execution_status] || '측정 정보 없음';
     $('whyTitle').textContent = `${source.label} · ${label}`;
-    $('whyBody').textContent = reasonFor(source);
+    $('whyBody').textContent = `${reasonFor(source)} ${source.next_action || ''}`;
+    $('originName').textContent = source.reuse_origin ? `${source.origin_name || '이전 작업'} → 원본 검사 ${source.origin_check_label || source.label} → 현재 계약에서 재판정` : ['passed','failed','interrupted','reused'].includes(source.execution_status) ? '현재 계약 안에서 관측한 결과입니다.' : '아직 실행·재사용 결과가 없습니다.';
     const tags = [
       `현재 revision ${source.current_revision}`,
       source.previous_revision >= 0 ? `이전 성공 revision ${source.previous_revision}` : '이전 성공 없음',
       `계획 ${executionLabels[source.execution_decision]?.[0] || '없음'} · 실제 ${label}`,
       `실행 구간 ${fmt(source.duration_ms)}`,
       source.duration_baseline ? `과거 표본 ${source.duration_baseline.sample_count}개 · revision ${source.duration_baseline.revision} · ${fmt(source.duration_baseline.duration_ms)}` : '과거 시간 표본 없음',
-      source.reuse_origin ? `이전 Evidence 배치 ${source.reuse_origin.batch_id.slice(0,12)} · 출처 revision ${source.reuse_origin.origin_revision}` : '현재 작업 안의 근거',
+      source.reuse_origin ? `원본 ${source.reuse_origin.contract_id || source.reuse_origin.evidence_session_id} · 배치 ${source.reuse_origin.batch_id} · 출처 revision ${source.reuse_origin.origin_revision}` : '현재 작업 안의 근거',
+      `정확한 검사 결합 ${source.check_digest || source.duration_baseline?.check_digest || '정보 없음'}`,
       `판정 식별자 ${source.reason_code || '없음'}`,
       ...source.shadow_limitations.map(item => `Shadow: ${item}`)
     ];
@@ -351,7 +361,7 @@ JS = r"""(() => {
       safe_change_reuse_count: reused.filter(item => item.decision === 'reuse-safe-change').length,
       executed_duration_ms: sum(started.map(item => item.duration_ms)),
       request_wall_ms: batch.request_wall_ms,
-      measured_processing_ms: batch.measurement_scope === 'prepare-only' ? batch.prepare_duration_ms : sum([batch.prepare_duration_ms,batch.runner_duration_ms]),
+      measured_processing_ms: batch.runner_duration_ms === null ? batch.prepare_duration_ms : sum([batch.prepare_duration_ms,batch.runner_duration_ms]),
       estimated_avoided_ms: baselines.length || !reused.length ? sum(baselines.map(item => item.duration_ms)) : null,
       estimated_source_count: baselines.length, baseline_sample_count: baselines.length
     };
@@ -363,12 +373,15 @@ JS = r"""(() => {
     return {...data, sources: batch.sources.map(item => {
       const id = `source:${item.source_key.slice(0,16)}`;
       const source = current ? data.sources.find(source => source.id === id) : null;
+      const originBatch = item.reuse_origin ? data.batches.find(previous=>previous.task?.id === (item.reuse_origin.contract_id || item.reuse_origin.evidence_session_id)) : null;
       return {...(source || {input_count:0, changed_inputs:[], shadow_limitations:[], observer_status:'unavailable'}),
         id, label:item.label, status:item.status, execution_status:item.status,
         execution_decision:item.decision || 'not-planned', reason_code:item.reason_code,
         execution_reason_code:item.execution_reason_code, current_revision:item.current_revision,
         previous_revision:item.previous_revision, duration_ms:item.duration_ms, duration_baseline:item.duration_baseline,
-        authority_source:item.authority_source, reuse_origin:item.reuse_origin};
+        authority_source:item.authority_source, reuse_origin:item.reuse_origin, check_digest:item.check_digest,
+        origin_name:source?.origin_name || originBatch?.task?.name || '보관 범위 밖의 이전 작업',
+        origin_check_label:source?.origin_check_label || originBatch?.sources.find(previous=>previous.source_key===item.source_key)?.label || item.label};
     }), map: current ? data.map : {nodes:[],edges:[]}};
   }
 
@@ -378,10 +391,11 @@ JS = r"""(() => {
     activeBatch = batches.find(batch => batch.batch_id === (selectedBatch || data.history?.current_batch_id)) || null;
     const select = $('batchSelect');
     select.replaceChildren();
+    if (!activeBatch) {const placeholder=document.createElement('option');placeholder.value='';placeholder.textContent='현재 계약 · 검증 요청 기록 없음';placeholder.selected=true;select.append(placeholder);}
     [...batches].reverse().forEach(batch => {
       const option = document.createElement('option');
       option.value = batch.batch_id;
-      option.textContent = `${new Date(batch.timestamp*1000).toLocaleString()} · 변경 ${batch.current_revision} · ${statusText[batch.status]}`;
+      option.textContent = `${batch.task?.name || '이전 검증'} · ${new Date(batch.timestamp*1000).toLocaleString()} · 변경 ${batch.current_revision} · ${statusText[batch.status]}`;
       option.selected = batch.batch_id === activeBatch?.batch_id;
       select.append(option);
     });
@@ -445,6 +459,8 @@ JS = r"""(() => {
   }
 
   function renderComparison() {
+    $('comparisonStatus').textContent = comparison ? '별도 비교 실측 있음 · fixture 조건 한정' : '비교 실측 없음';
+    $('topComparison').textContent=$('comparisonStatus').textContent;
     const root = $('comparisonChart'); root.replaceChildren();
     if (!comparison) return;
     const c = comparison.conditions;
@@ -469,11 +485,14 @@ JS = r"""(() => {
 
   function shareReport() {
     if (!snapshot) throw Error('표시할 실행 기록이 없습니다.');
-    return {version:1,kind:'click-verification-efficiency-report',generated_at:snapshot.generated_at,
+    return {version:2,kind:'click-verification-efficiency-report',generated_at:snapshot.generated_at,
+      projection_version:snapshot.version ?? null,engine:snapshot.engine ?? null,accounting:snapshot.accounting ?? null,controls:snapshot.controls ?? null,
+      task:snapshot.task?{runtime_mode:snapshot.task.runtime_mode,contract_id:snapshot.task.contract_id,approval_bound:snapshot.task.approval_bound}:null,
       unit:'verification-group',summary:activeSummary,
       measurement_scope:activeBatch?.measurement_scope || 'unknown',
       batch:activeBatch ? {batch_id:activeBatch.batch_id,current_revision:activeBatch.current_revision,timestamp:activeBatch.timestamp,
         finished_at:activeBatch.finished_at,status:activeBatch.status,reason_code:activeBatch.reason_code,
+        task:activeBatch.task?{mode:activeBatch.task.mode,id:activeBatch.task.id}:null,
         sources:activeBatch.sources.map(item=>({label:item.label,source_key:item.source_key,check_digest:item.check_digest,
           decision:item.decision,status:item.status,started:item.started,completed:item.completed,reason_code:item.reason_code,
           execution_reason_code:item.execution_reason_code,authority_source:item.authority_source,
@@ -481,7 +500,7 @@ JS = r"""(() => {
           duration_baseline:item.duration_baseline,reuse_origin:item.reuse_origin,
           estimated_avoided_ms:item.status === 'reused' ? item.duration_baseline?.duration_ms ?? null : 0}))} : null,
       comparison,shadow:snapshot.summary.shadow,
-      notes:['전체 대기시간은 별도 측정값이 없으면 알 수 없음','준비와 runner 구간만 부분 계측 · 호스트 전달·대기·최종 저장·반환 제외',
+      notes:['전체 사용자 대기시간은 측정하지 않음','Hook 진입부터 결과 기록 또는 준비와 runner 개별 구간만 부분 계측 · 호스트 요청 전·최종 저장·반환 제외',
         '생략 비용은 실제 적용된 재사용의 이전 성공 실행 표본에 기반한 추정','Shadow는 실제 재사용·실측 절약 아님',
         '입력 파일 경로와 원시 명령·환경·토큰은 공유본에 포함하지 않음','비교 fixture 결과를 일반 저장소 성능으로 일반화할 수 없음']};
   }
@@ -497,8 +516,8 @@ JS = r"""(() => {
     const s=report.summary;
     add('h1','Click · 검증 효율 리포트');
     add('p',`${count(s.total_source_count)}개 검증 묶음 중 ${count(s.executed_source_count)}개 실제 실행 · ${count(s.authoritative_reuse_count)}개 재사용 · ${count(s.not_run_source_count)}개 미실행`);
-    add('p',`전체 대기시간: ${fmt(s.request_wall_ms)} / 부분 처리 구간: ${fmt(s.measured_processing_ms)} / 검사 실행 구간: ${fmt(s.executed_duration_ms)}`);
-    add('p',`생략한 실행 비용 추정: ${fmt(s.estimated_avoided_ms)} · 표본이 있는 ${count(s.estimated_source_count)} / 재사용 ${count(s.authoritative_reuse_count)}개 묶음`);
+    add('p',`Hook 진입 → 결과 기록 부분 실측: ${fmt(s.request_wall_ms)} / 부분 처리 구간: ${fmt(s.measured_processing_ms)} / 검사 실행 구간: ${fmt(s.executed_duration_ms)}`);
+    add('p',`재실행 비용 회피 추정: ${fmt(s.estimated_avoided_ms)} · 표본이 있는 ${count(s.estimated_source_count)} / 재사용 ${count(s.authoritative_reuse_count)}개 묶음`);
     add('h2','검증 묶음별 실제 결과');const table=add('table','');
     const heading=add('tr','',table);['이름','계획','실제 결과','시간 / 과거 표본','이유'].forEach(text=>add('th',text,heading));
     report.batch?.sources.forEach(item=>{const tr=add('tr','',table);const origin=item.reuse_origin?` · 이전 배치 ${item.reuse_origin.batch_id.slice(0,12)}에서 재판정`:'';[item.label,executionLabels[item.decision]?.[0]||'없음',statusText[item.status],item.status==='reused'?fmt(item.duration_baseline?.duration_ms)+' (과거 표본)':fmt(item.duration_ms),(outcomeText[item.execution_reason_code]||reasonText[item.reason_code]||'정보 없음')+origin].forEach(text=>add('td',text,tr));});
@@ -536,17 +555,40 @@ JS = r"""(() => {
     const incremental = activeBatch ? summarize(activeBatch) : data.summary.incremental;
     activeSummary = incremental;
     const shadow = data.summary.shadow;
-    $('batchHeadline').textContent = `${count(incremental.total_source_count)}개 검증 묶음 중 ${count(incremental.executed_source_count)}개 실행 · ${count(incremental.authoritative_reuse_count)}개 재사용`;
+    $('contractName').textContent = data.task.name || '현재 작업';
+    $('approvalState').textContent = data.task.approval_bound ? '별도 승인됨 · Guarded' : data.task.runtime_mode === 'evidence' ? '호스트 권한 · Click 승인 없음' : data.task.status === 'staged' ? '승인 대기 · Guarded' : data.task.status === 'none' ? '활성 계약 없음 · 이력 전용' : '승인 정보 없음';
+    $('contractId').textContent = data.task.contract_id || '승인 계약 ID 없음';
+    const paragraphs = values => values.map(text => {const p=document.createElement('p');p.textContent=text;return p;});
+    $('contractPromises').replaceChildren(...paragraphs(data.task.promises?.length ? data.task.promises.slice(0,2) : ['표시 가능한 약속 요약이 없습니다. 기존 승인 계약 또는 사용자 요청을 확인하세요.']));
+    $('allPromises').replaceChildren(...paragraphs(data.task.promises || []));
+    $('contractBoundary').replaceChildren(...paragraphs([
+      `포함: ${(data.task.in_scope || []).join(' · ') || '원문 확인'}`,
+      `제외: ${(data.task.out_of_scope || []).join(' · ') || '원문 확인'}`,
+      `유지 조건: ${(data.task.must_hold || []).join(' · ') || '원문 확인'}`,
+    ]));
+    const controls=data.controls || [];
+    $('controlSummary').textContent = `이 계약의 관측 통제: 차단 ${controls.filter(item=>item.effect==='blocked').length}건 · 비차단 안내 ${controls.filter(item=>item.effect==='advisory').length}건. 의미적 범위 준수나 숨은 추론을 판정한 수치가 아닙니다.`;
+    if (data.task.status==='none') $('controlSummary').textContent='활성 계약이 없습니다. 보관된 viewer 이력은 승인이나 실행 권한을 전달하지 않습니다.';
+    const reusedItems=(activeBatch?.sources || []).filter(item=>item.status==='reused');
+    const prior=reusedItems.filter(item=>item.reuse_origin).length;
+    $('reuseOrigins').textContent=`선택한 기록: 현재 작업 안의 재사용 ${reusedItems.length-prior} · 이전 작업에서 재판정 ${prior}`;
+    const a=data.accounting;
+    $('reuseRate').textContent=a ? `보관된 검증 그룹 요청 기준: ${a.reuse_numerator} / ${a.request_denominator} · ${a.reuse_rate===null?'비율 미측정':(100*a.reuse_rate).toFixed(1)+'%'} · ${a.from_timestamp?new Date(a.from_timestamp*1000).toLocaleString():'시작 기록 없음'} ~ ${a.through_timestamp?new Date(a.through_timestamp*1000).toLocaleString():'종료 기록 없음'}. 실제 재시도는 별도 요청이며 중복 수신·화면 갱신은 추가 집계하지 않습니다.` : '집계 정보 없음';
+    $('zeroReuse').textContent=reusedItems.length ? `재사용 중 과거 시간 표본 미측정 ${reusedItems.filter(item=>!item.duration_baseline).length}개` : [...new Set(view.sources.map(source=>source.next_action || reasonFor(source)))].slice(0,3).join(' ');
+    $('comparisonStatus').textContent=comparison ? '별도 비교 실측 있음 · fixture 조건 한정' : '비교 실측 없음';
+    $('topComparison').textContent=$('comparisonStatus').textContent;
+    $('batchHeadline').textContent = incremental.total_source_count === null ? '이번 계약의 검증 요청 기록이 아직 없습니다.' : `${count(incremental.total_source_count)}개 검증 묶음 중 ${count(incremental.executed_source_count)}개 실행 · ${count(incremental.authoritative_reuse_count)}개 재사용`;
     $('currentChecks').textContent = count(incremental.total_source_count);
     $('executedChecks').textContent = count(incremental.executed_source_count);
     $('reusedChecks').textContent = count(incremental.authoritative_reuse_count);
     $('executionDetail').textContent = `통과 ${count(incremental.passed_source_count)} · 실패 ${count(incremental.failed_source_count)} · 중단 ${count(incremental.interrupted_source_count)} · 미실행 ${count(incremental.not_run_source_count)} · 대기/미확정 ${count(incremental.pending_source_count)}`;
     $('requestWall').textContent = fmt(incremental.request_wall_ms);
     $('processingDuration').textContent = fmt(incremental.measured_processing_ms);
-    $('timeScope').textContent = activeBatch?.measurement_scope === 'prepare-only' ? '부분 계측: 준비·재사용 판정만 포함. 호스트 대기·전달·최종 저장·반환은 제외합니다.' : '부분 계측: 준비 + runner의 로컬 경과시간 합계. 서로 다른 프로세스의 시계 원점을 빼지 않습니다. 호스트 대기·전달·최종 저장·반환은 제외합니다.';
+    $('timeScope').textContent = activeBatch?.measurement_scope === 'hook-entry-to-result-recording' ? '부분 실측: 같은 호스트의 단조 시계로 Hook 진입부터 결과 기록 직전까지 측정했습니다. Hook 이전 요청 대기·최종 저장·호스트 반환은 제외합니다.' : activeBatch?.measurement_scope === 'prepare-only' ? '부분 계측: 준비·재사용 판정만 포함. 호스트 대기·전달·최종 저장·반환은 제외합니다.' : '부분 계측: 준비 + runner의 개별 경과시간 합계. 호스트 대기·전달·최종 저장·반환은 제외합니다.';
+    if (!activeBatch) $('timeScope').textContent='이 계약의 요청-결과 시간은 아직 측정되지 않았습니다.';
     $('estimateCoverage').textContent = `이전 시간 표본이 있는 ${count(incremental.estimated_source_count)} / 재사용 ${count(incremental.authoritative_reuse_count)}개 묶음 · 실측 절약 아님`;
     $('estimatedAvoided').textContent = fmt(incremental.estimated_avoided_ms);
-    $('reuseBreakdown').textContent = `${incremental.exact_reuse_count} / ${incremental.dependency_reuse_count} / ${incremental.safe_change_reuse_count}`;
+    $('reuseBreakdown').textContent = `${count(incremental.exact_reuse_count)} / ${count(incremental.dependency_reuse_count)} / ${count(incremental.safe_change_reuse_count)}`;
     $('executedDuration').textContent = fmt(incremental.executed_duration_ms);
     $('shadowBreakdown').textContent = `${shadow.candidate_count} / ${shadow.confirmed_candidate_count} / ${shadow.contradiction_count}`;
     $('shadowTiming').textContent = `${fmt(shadow.potential_ms)} / ${fmt(shadow.observer_overhead_ms)}`;
@@ -571,7 +613,10 @@ JS = r"""(() => {
         cache: 'no-store'
       });
       if (!response.ok) throw new Error(String(response.status));
-      render(await response.json());
+      const data=await response.json();
+      const signature=JSON.stringify({...data,generated_at:null});
+      if (signature!==lastSnapshotSignature) {lastSnapshotSignature=signature;render(data);}
+      else { $('connection').textContent='연결됨';document.querySelector('.live').classList.add('ok'); }
     } catch (_) {
       $('connection').textContent = '연결 끊김';
       document.querySelector('.live').classList.remove('ok');

--- a/hooks/click_verification.py
+++ b/hooks/click_verification.py
@@ -1011,7 +1011,13 @@ def _successor_binding_reason(
     executable_digest: str,
     host_coverage: dict[str, Any],
 ) -> str:
-    """Validate a prior Evidence fact without pretending it is this lifecycle."""
+    """Validate prior facts against the current lifecycle's bindings."""
+    if (
+        previous.get("dependency_patterns", []) != current.get("dependency_patterns", [])
+        or previous.get("dependency_declaration_digest", "")
+        != current.get("dependency_declaration_digest", "")
+    ):
+        return "contract-binding-changed"
     if previous.get("verified_check_digest") != group_digest:
         return "check-binding-changed"
     if previous.get("verified_root") != git_root:
@@ -1058,6 +1064,8 @@ def _requalify_successor_baseline(
 ) -> None:
     """Create a new-lifecycle baseline only after explicit binding checks."""
     current_shard = current.get("shard")
+    current_patterns = list(current.get("dependency_patterns", []))
+    current_declaration = current.get("dependency_declaration_digest", "")
     preserved = json.loads(json.dumps(previous))
     current.clear()
     current.update(preserved)
@@ -1066,6 +1074,8 @@ def _requalify_successor_baseline(
     else:
         current["shard"] = current_shard
     current.update(
+        dependency_patterns=current_patterns,
+        dependency_declaration_digest=current_declaration,
         status="passed" if exact_tree else "stale",
         verified_revision=revision if exact_tree else max(0, revision - 1),
         attempts=0,
@@ -1095,6 +1105,7 @@ def _requalify_successor_baseline(
         last_successor_reused_at=0,
         last_successor_origin_batch_id="",
         last_successor_origin_evidence_session_id="",
+        last_successor_origin_contract_id="",
         last_successor_candidate_digest="",
         last_successor_origin_revision=-1,
         last_successor_mode="",
@@ -1109,9 +1120,8 @@ def _mark_successor_reuse(
     ) + 1
     source["last_successor_reused_at"] = int(time.time()) or 1
     source["last_successor_origin_batch_id"] = metadata["batch_id"]
-    source["last_successor_origin_evidence_session_id"] = metadata[
-        "evidence_session_id"
-    ]
+    source["last_successor_origin_evidence_session_id"] = metadata.get("evidence_session_id", "")
+    source["last_successor_origin_contract_id"] = metadata.get("contract_id", "")
     source["last_successor_candidate_digest"] = metadata["candidate_digest"]
     source["last_successor_origin_revision"] = metadata["origin_revision"]
     source["last_successor_mode"] = mode
@@ -1889,6 +1899,7 @@ def _prepare_verification(
     # A preparation hook and its runner are different processes. Measure their
     # local elapsed segments, not a subtraction of cross-process clock origins.
     started = time.perf_counter_ns()
+    request_started = time.monotonic_ns()
     trace: dict[str, Any] = {}
     result = _prepare_verification_impl(
         event, raw, runner_script=runner_script, render_command=render_command,
@@ -1910,21 +1921,35 @@ def _prepare_verification(
             if isinstance(tool_id, str) and tool_id else secrets.token_hex(16)
         )
         previous_id = verification.get(click_incremental.CURRENT_BATCH_FIELD)
+        previous_clock = verification.get("incremental_request_clock")
         previous_batch = click_incremental.current_batch(verification)
         batch = click_incremental.new_batch(
             trace.get("plan"), batch_id=request_id,
             revision=int(verification.get("mutation_revision", 0)), prepared_ms=elapsed,
             requested=trace.get("requested"), labels=trace.get("labels"),
             reuse_origins=trace.get("reuse_origins"),
+            task={
+                "mode": state.get("runtime_mode"),
+                "id": state.get("contract_id") if state.get("runtime_mode") == "guarded" else state.get("evidence_session_id"),
+                "name": click_incremental.sanitize_presentation(state.get("presentation"))["name"],
+            },
         )
         if click_incremental.store_batch(verification, batch):
+            click_incremental.start_request_clock(verification, request_id, started_ns=request_started)
             if result[1]:
+                click_incremental.record_control_event(state, event, "verification-request-rejected")
                 click_incremental.reject_batch(verification)
                 if previous_batch and previous_batch["status"] in {"planned", "running"}:
                     verification[click_incremental.CURRENT_BATCH_FIELD] = previous_id
+                    if previous_clock is not None:
+                        verification["incremental_request_clock"] = previous_clock
             elif trace.get("all_reused"):
                 click_incremental.finish_reuse(verification)
+            if result[2]:
+                click_incremental.record_control_event(state, event, "verification-guidance")
             _save_contract_state(event, state)
+            if trace.get("all_reused"):
+                result = (result[0], result[1], "\n".join(filter(None, (result[2], click_incremental.host_summary(verification)))))
     except Exception:
         # Measurements cannot admit/reject a command or grant reuse authority.
         pass
@@ -2140,11 +2165,15 @@ def _prepare_verification_impl(
             source["reserved_check_digest"] = group_digests[source_key]
 
     successor_candidates: dict[str, tuple[dict[str, Any], dict[str, Any]]] = {}
-    if runtime.evidence:
+    if runtime.evidence or runtime.guarded_approved:
         scope_digest = click_evidence.successor_scope_digest(
             str(click_state.contract_path(event).resolve())
         )
         for source_key in requested_keys:
+            # A current-lifecycle execution (especially a failure) supersedes a
+            # prior candidate. Never resurrect A over B's observed result.
+            if sources[source_key].get("attempts", 0) or sources[source_key].get("verified_contract_digest"):
+                continue
             candidate = click_evidence.successor_candidate(
                 state,
                 source_key,
@@ -2636,10 +2665,13 @@ def _prepare_verification_impl(
     if measurement is not None:
         measurement["plan"] = incremental_plan
         measurement["labels"] = {
+            **click_incremental.sanitize_presentation(state.get("presentation"))["evidence_labels"],
+            **{
             key: str(source["shard"]["shard_id"])
             for key, source in sources.items()
             if isinstance(source, dict)
             and click_evidence_shards.source_metadata_is_valid(source.get("shard"))
+            },
         }
         measurement["reuse_origins"] = {
             key: successor_origins[key]
@@ -3044,6 +3076,7 @@ def _record_verification_result(
                 source_ran = source_results.get(source_key, {}).get("started") is True
             was_current = _evidence_is_current(source, previous_revision)
             if check_positions and source_ran:
+                click_evidence.clear_successor_receipt(source)
                 source["status"] = "failed"
                 source["attempts"] = int(source.get("attempts", 0)) + 1
                 source["unchanged_failure_retries"] = 1
@@ -3083,6 +3116,7 @@ def _record_verification_result(
             if source_results is not None:
                 source_ran = source_results.get(source_key, {}).get("started") is True
             if source_ran:
+                click_evidence.clear_successor_receipt(source)
                 source["attempts"] = int(source.get("attempts", 0)) + 1
             if all(position < succeeded_count for position in check_positions):
                 source["status"] = "passed"
@@ -3948,6 +3982,13 @@ def _run_verification(
     if not recorded:
         sys.stderr.write("Click could not record the verification result safely.\n")
         return exit_code or 2
+    try:
+        result_state = json.loads(state_path.read_text(encoding="utf-8"))
+        message = click_incremental.host_summary(result_state.get("verification"))
+        if message:
+            print(message, flush=True)
+    except (OSError, ValueError, TypeError):
+        pass  # A display failure cannot change the observed verification result.
     return exit_code
 
 

--- a/skills/click/SKILL.md
+++ b/skills/click/SKILL.md
@@ -56,6 +56,8 @@ Only in a later turn whose user response explicitly approves the shown proposal,
 
 ## Execute the approved boundary once
 
+A completed Guarded contract may supply successful verification candidates to a new contract in the same host session and workspace. The new contract still requires its own later-turn approval and exact declared checks. Never treat retained facts as inherited execution authority or completion. Requalification and receipt v5 follow the capability protocol; dependency declarations, viewer history and timing cannot authorize reuse by themselves.
+
 Before implementation, read the [anti-loop policy](references/anti-loop-policy.md) and [structured capability protocol](references/capability-protocol.md). Prefer focused follow-up after broad repository context; this is non-blocking strategy guidance, not contract authority. Implement continuously without a replacement plan or contract. Use their canonical inspect, mutate, managed-service, and verify forms rather than duplicating command details here.
 
 Collect each assigned source once after the last mutation that can invalidate it. Reuse successful evidence, keep Browser or hosted work out of a shadow verification suite, and stop verification when each condition has current evidence. Treat repeat, retry, and timing notices as non-authoritative guidance, not permission failures; active runner conflicts, Browser receipt binding, and verification-time repository mutation remain hard. Stop any managed service before declaring completion. A failed or stale source may be repaired or replaced under the documented retry rules; it is not a reason to accumulate another proof path.

--- a/skills/click/references/capability-protocol.md
+++ b/skills/click/references/capability-protocol.md
@@ -152,6 +152,15 @@ complete shard provenance required by v3. Merely retaining a successor
 candidate never selects v4 and never creates reuse authority. Offline
 verification accepts and validates v4 while retaining legacy v1-v3 support.
 
+An actually applied successor from a completed Guarded contract selects v5
+and records `origin_contract_id` instead of the v4 Evidence session identity.
+The new contract's separate staging and approval remain current authority;
+earlier approval, claims, tokens and unfinished work never transfer. Candidates
+must requalify against current exact declared checks, dependency declaration,
+workspace, environment, executable, known Hook coverage and existing change
+rules. Incomplete or uncertain bindings run the check. v5 retains complete v3
+shard provenance where present; offline validation still accepts v1–v4.
+
 If a host omits the working directory selected by a nested execution tool,
 export may recover it only from the sole canonical Git root shared by every
 current argv evidence source. A stale, missing, non-canonical, or conflicting

--- a/skills/click/references/modes.md
+++ b/skills/click/references/modes.md
@@ -40,6 +40,8 @@ Show the exact Hook-generated easy contract once as the default approval body, w
 
 After every declared evidence source is current for the final mutation revision and no managed service remains active, a later change may stage a fresh contract. A contract with no argv source needs no ceremonial local batch. Missing, running, failed, or stale evidence—and an active managed service—still block replacement.
 
+That completed contract may retain successful verification candidates for the next Guarded contract, never approval, execution claims, tokens or completion. The successor must be separately approved and request its own declared checks before current-binding requalification. Changing a dependency declaration does not inherit its predecessor's authority. See the capability protocol for v5 lineage and conservative rerun rules.
+
 ## Off
 
 Ordinary work is fail-open while no Guarded contract is active. Apply Guarded when the user selects `@Click` or invokes `$click`; run `click-gate arm` and use the compact-contract workflow. Once staged or approved but incomplete, that contract blocks ordinary mutations across later turns. On approval or resume, pass the same emitted `contract_id`; do not resend the JSON. Ephemeral state may age out, but staged and approved-incomplete contracts are never removed by cleanup.

--- a/skills/click/references/shadow-intelligence-v1.md
+++ b/skills/click/references/shadow-intelligence-v1.md
@@ -91,6 +91,19 @@ Click lifecycle.
 
 ## Evidence Map and ROI projection
 
+Projection v4 first shows the current contract's bounded display summary,
+approval state, requested/executed/reused/failed/unstarted verification groups,
+and the distinction between an avoided-rerun-cost estimate and a separately
+measured comparison. Evidence Map and Shadow remain collapsed details.
+The local display copy is not authority and is not guaranteed secret detection;
+shared JSON/HTML omit contract prose, raw argv, input paths and environment
+values. Engine version and unsigned source-file digest identify the snapshot,
+not publisher authenticity. Observed approval/id denials and advisory guidance
+are distinct telemetry, not semantic scope judgments. Group reuse rates expose
+their retained-history numerator, denominator and time window; missing timing
+stays null. Hook-entry-to-result-recording is partial request timing, excluding
+host queueing and final return. See the capability protocol for reuse authority.
+
 The dashboard receives a separate, strict, bounded projection instead of the
 raw Click state. Its first summary is the authoritative incremental plan:
 total sources, sources actually executed, exact/dependency/safe-change reuse,

--- a/tests/test_click_dashboard_projection.py
+++ b/tests/test_click_dashboard_projection.py
@@ -29,6 +29,39 @@ BACKEND = "a" * 64
 
 
 class ClickDashboardProjectionTests(unittest.TestCase):
+    def test_display_copy_rejects_paths_secrets_and_html_without_authority(self) -> None:
+        state = {"status": "staged", "runtime_mode": "guarded", "presentation": {
+            "name": "password abc", "promises": ["/home/private/repo", "<script>alert(1)</script>"],
+            "evidence_labels": {KEY_RUN: "secret token"},
+        }}
+        projection = click_dashboard_projection.dashboard_projection(state)
+        rendered = json.dumps(projection)
+        for forbidden in ("password abc", "/home/private", "<script>", "secret token"):
+            self.assertNotIn(forbidden, rendered)
+        self.assertFalse(projection["task"]["approval_bound"])
+        self.assertTrue(click_dashboard_projection.projection_is_valid(projection))
+
+    def test_first_guarded_contract_shows_promise_approval_and_unstarted_sources(self) -> None:
+        state = {
+            "runtime_mode": "guarded", "status": "staged", "contract_id": "ctr_" + "a" * 32,
+            "staged_turn_id": "one", "approved_turn_id": "",
+            "presentation": {"name": "새 계약 검증", "promises": ["관련 검증을 통과한다"],
+                             "in_scope": ["검증 경로"], "out_of_scope": ["배포"], "must_hold": ["별도 승인 유지"],
+                             "evidence_labels": {KEY_RUN: "핵심 동작"}},
+            "verification": {"mutation_revision": 0},
+            "evidence_state": {"sources": {KEY_RUN: {"kind": "argv", "status": "ready"}}},
+        }
+        projection = click_dashboard_projection.dashboard_projection(state)
+        self.assertEqual(projection["task"]["name"], "새 계약 검증")
+        self.assertEqual(projection["task"]["promises"], ["관련 검증을 통과한다"])
+        self.assertFalse(projection["task"]["approval_bound"])
+        self.assertEqual(projection["sources"][0]["execution_status"], "not-run")
+        self.assertIn("검증", projection["sources"][0]["next_action"])
+        self.assertIsNone(projection["accounting"]["reuse_rate"])
+        self.assertTrue(click_dashboard_projection.projection_is_valid(projection))
+        state.update(status="approved", approved_turn_id="two")
+        self.assertTrue(click_dashboard_projection.dashboard_projection(state)["task"]["approval_bound"])
+
     def setUp(self) -> None:
         temporary = tempfile.TemporaryDirectory()
         self.addCleanup(temporary.cleanup)

--- a/tests/test_click_efficiency.py
+++ b/tests/test_click_efficiency.py
@@ -68,6 +68,7 @@ const batch=JSON.parse(JSON.stringify(input.batch));batch.sources[0].label='</td
 batch.sources[0].reuse_origin={kind:'successor-evidence',batch_id:'a'.repeat(32),evidence_session_id:'evs_'+'b'.repeat(32),candidate_digest:'c'.repeat(64),origin_revision:7};
 api.setState(snapshot,batch,input.summary,safe);
 const report=api.shareReport();assert(!JSON.stringify(report).includes('<example-private-value>'));
+assert.equal(report.task,null);assert.equal(report.engine,null);assert.equal(report.accounting,null);assert.equal(report.controls,null);
 assert.equal(report.summary.authoritative_reuse_count,input.summary.authoritative_reuse_count);
 assert.equal(report.batch.sources[0].reuse_origin.origin_revision,7);
 const html=api.standaloneReport(report);assert(!html.includes('<script>'));assert(html.includes('&lt;script&gt;'));

--- a/tests/test_click_gate_lifecycle.py
+++ b/tests/test_click_gate_lifecycle.py
@@ -1063,7 +1063,7 @@ class ClickGateLifecycleTests(ClickGateTestCase):
             (self.workspace / "generated.txt").read_text(encoding="utf-8"), "ok"
         )
 
-    def test_state_records_a_digest_not_contract_plaintext(self) -> None:
+    def test_state_retains_bounded_display_but_not_full_contract_or_read_content(self) -> None:
         self.approve_contract()
         (self.workspace / "private-marker.txt").write_text(
             "private marker\n", encoding="utf-8"
@@ -1081,7 +1081,13 @@ class ClickGateLifecycleTests(ClickGateTestCase):
         self.assertIn('"scale":"focused"', state_text)
         self.assertIn('"unit_limit":4', state_text)
         self.assertNotIn("inventory write path", state_text)
-        self.assertNotIn("threshold crossing", state_text)
+        # The result-first local viewer deliberately retains a bounded display
+        # copy. It is not the canonical contract and never grants authority.
+        state = json.loads(next((self.plugin_data / "gate-state").glob("session-contract-*.json")).read_text())
+        self.assertIn("threshold crossing", json.dumps(state["presentation"]))
+        self.assertEqual(set(state["presentation"]), {
+            "name", "promises", "in_scope", "out_of_scope", "must_hold", "evidence_labels"
+        })
         self.assertNotIn("existing notification mechanism", state_text)
         self.assertNotIn("재고가 임계값", state_text)
         self.assertNotIn('"E1"', state_text)

--- a/tests/test_click_gate_verification.py
+++ b/tests/test_click_gate_verification.py
@@ -26,6 +26,132 @@ from click_gate_test_support import (
 
 
 class ClickGateVerificationTests(ClickGateTestCase):
+    def test_guarded_successor_requires_new_approval_and_exports_contract_origin(self) -> None:
+        (self.workspace / ".gitignore").write_text("__pycache__/\n", encoding="utf-8")
+        self.initialize_git(".gitignore", "verification_fixture.py")
+        self.set_default("guarded", "turn-0")
+        self.approve_contract()
+        command = self.verification_argv()
+        first = self.verify_gate([command], "turn-2")
+        self.assertEqual(self.run_rewritten(first).returncode, 0)
+        state_path = next((self.plugin_data / "gate-state").glob("session-contract-*.json"))
+        previous = json.loads(state_path.read_text(encoding="utf-8"))
+
+        replacement = self.contract()
+        replacement["outcome"] = "verify the separately approved follow-up"
+        self.arm_gate("turn-3")
+        staged = self.stage_gate(replacement, "turn-3")
+        self.assertEqual(staged["hookSpecificOutput"]["permissionDecision"], "allow")
+        current = json.loads(state_path.read_text(encoding="utf-8"))
+        self.assertNotEqual(current["contract_id"], previous["contract_id"])
+        self.assertEqual(current["approved_turn_id"], "")
+        self.assertEqual(current["verification"]["status"], "ready")
+        self.assertNotIn("runner_token", current["verification"])
+        self.assertEqual(next(iter(current["evidence_state"]["sources"].values()))["status"], "ready")
+        self.assertTrue(current.get("successor_evidence"))
+        denied = self.verify_gate([command], "turn-3")
+        self.assertEqual(denied["hookSpecificOutput"]["permissionDecision"], "deny")
+        self.arm_gate("turn-4")
+        self.pass_gate(current["contract_id"], "turn-4")
+        reused = self.verify_gate([command], "turn-4")
+        self.assertNotIn("run-verification", split_runner_command(reused["hookSpecificOutput"]["updatedInput"]["command"]))
+        exported = self.run_rewritten(self.pre_tool("Bash", "click-gate receipt export", "turn-4", submit_prompt=False))
+        self.assertEqual(exported.returncode, 0, exported.stderr)
+        body = json.loads(exported.stdout)["receipt"]
+        self.assertEqual(body["version"], 5)
+        self.assertEqual(body["contract"]["id"], current["contract_id"])
+        self.assertEqual(body["contract"]["approved_turn_id"], "turn-4")
+        self.assertEqual(body["evidence"][0]["lineage"]["origin_contract_id"], previous["contract_id"])
+        self.assertEqual(body["evidence"][0]["lineage"]["requalification_mode"], "exact")
+
+    def test_guarded_successor_partial_code_reuse_new_check_and_relevant_rerun(self) -> None:
+        (self.workspace / ".gitignore").write_text("__pycache__/\n", encoding="utf-8")
+        beta = self.workspace / "beta.py"
+        beta.write_text("import unittest\nVALUE = 1\nclass Beta(unittest.TestCase):\n    def test_value(self): self.assertGreater(VALUE, 0)\n", encoding="utf-8")
+        command = self.verification_argv()
+        beta_command = [sys.executable, "-m", "unittest", "beta"]
+        policy = self.workspace / ".click" / "evidence-reuse.json"
+        policy.parent.mkdir()
+        policy.write_text(json.dumps({"version": 1, "entries": [{"checks": [command], "reuse_if_only_changed": ["beta.py"]}]}), encoding="utf-8")
+        self.initialize_git(".gitignore", "verification_fixture.py", "beta.py", ".click/evidence-reuse.json")
+        self.set_default("guarded", "turn-0")
+        contract = self.contract()
+        contract["verification"]["evidence"].append({"id": "E2", "kind": "argv", "description": "beta code behavior"})
+        contract["verification"]["done_when"].append({"condition": "beta passes", "primary_evidence": "E2"})
+        self.arm_gate("turn-1")
+        self.stage_gate(contract, "turn-1")
+        self.arm_gate("turn-2")
+        self.pass_gate(turn_id="turn-2")
+        first = self.verify_gate([command, beta_command], "turn-2", evidence_ids=["E1", "E2"])
+        self.assertEqual(self.run_rewritten(first).returncode, 0)
+        origin_id = self.active_contract_id()
+        contract["outcome"] = "check the next beta code change and a new validation"
+        contract["verification"]["evidence"].extend([
+            {"id": "E3", "kind": "argv", "description": "new validation"},
+            {"id": "E-hold", "kind": "manual", "description": "finish after relevant-input scenario"},
+        ])
+        contract["verification"]["done_when"].extend([
+            {"condition": "new validation passes", "primary_evidence": "E3"},
+            {"condition": "relevant input scenario checked", "primary_evidence": "E-hold"},
+        ])
+        self.arm_gate("turn-3")
+        self.stage_gate(contract, "turn-3")
+        self.arm_gate("turn-4")
+        self.pass_gate(turn_id="turn-4")
+        self.assertIsNone(self.pre_tool("apply_patch", "*** Begin Patch\n*** End Patch", "turn-4"))
+        beta.write_text(beta.read_text(encoding="utf-8").replace("VALUE = 1", "VALUE = 2"), encoding="utf-8")
+        self.tool_hook("post-tool", "apply_patch", {"patch": "beta code"}, turn_id="turn-4", tool_use_id="tool-1")
+        request = self.verify_gate([command, beta_command, [*command, "-v"]], "turn-4", evidence_ids=["E1", "E2", "E3"])
+        result = self.run_rewritten(request)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        state_path = next((self.plugin_data / "gate-state").glob("session-contract-*.json"))
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        batch = CLICK_VERIFICATION.click_incremental.current_batch(state["verification"])
+        by_key = {source["source_key"]: source for source in batch["sources"]}
+        alpha = by_key[CLICK_EVIDENCE.evidence_key("E1")]
+        self.assertEqual(alpha["status"], "reused")
+        self.assertEqual(alpha["decision"], "reuse-safe-change")
+        self.assertEqual(alpha["reuse_origin"]["contract_id"], origin_id)
+        for source_id in ("E2", "E3"):
+            self.assertEqual(by_key[CLICK_EVIDENCE.evidence_key(source_id)]["status"], "passed")
+        unknown = self.verify_gate([command], "turn-4", evidence_ids=["E_UNAPPROVED"])
+        self.assertEqual(unknown["hookSpecificOutput"]["permissionDecision"], "deny")
+
+        self.assertIsNone(self.pre_tool("apply_patch", "*** Begin Patch\n*** End Patch", "turn-4"))
+        fixture = self.workspace / "verification_fixture.py"
+        fixture.write_text(fixture.read_text(encoding="utf-8") + "\n# related code changed\n", encoding="utf-8")
+        self.tool_hook("post-tool", "apply_patch", {"patch": "related code"}, turn_id="turn-4", tool_use_id="tool-1")
+        rerun = self.verify_gate([command], "turn-4")
+        self.assertIn("run-verification", split_runner_command(rerun["hookSpecificOutput"]["updatedInput"]["command"]))
+        self.assertEqual(self.run_rewritten(rerun).returncode, 0)
+        source = json.loads(state_path.read_text(encoding="utf-8"))["evidence_state"]["sources"][CLICK_EVIDENCE.evidence_key("E1")]
+        self.assertEqual(source["successor_reuse_count"], 0)
+        self.assertEqual(source["last_successor_origin_contract_id"], "")
+
+    def test_guarded_successor_does_not_inherit_a_dependency_declaration(self) -> None:
+        (self.workspace / ".gitignore").write_text("__pycache__/\n", encoding="utf-8")
+        self.initialize_git(".gitignore", "verification_fixture.py")
+        self.set_default("guarded", "turn-0")
+        contract = self.contract()
+        contract["verification"]["evidence"][0]["dependencies"] = ["verification_fixture.py"]
+        self.arm_gate("turn-1")
+        self.stage_gate(contract, "turn-1")
+        self.arm_gate("turn-2")
+        self.pass_gate(turn_id="turn-2")
+        command = self.verification_argv()
+        self.assertEqual(self.run_rewritten(self.verify_gate([command], "turn-2")).returncode, 0)
+        self.arm_gate("turn-3")
+        self.stage_gate(self.contract(), "turn-3")
+        self.arm_gate("turn-4")
+        self.pass_gate(turn_id="turn-4")
+        rerun = self.verify_gate([command], "turn-4")
+        self.assertIn("run-verification", split_runner_command(rerun["hookSpecificOutput"]["updatedInput"]["command"]))
+        self.assertEqual(self.run_rewritten(rerun).returncode, 0)
+        state_path = next((self.plugin_data / "gate-state").glob("session-contract-*.json"))
+        source = json.loads(state_path.read_text(encoding="utf-8"))["evidence_state"]["sources"][CLICK_EVIDENCE.evidence_key("E1")]
+        self.assertEqual(source["dependency_patterns"], [])
+        self.assertEqual(source["successor_reuse_count"], 0)
+
     def install_complete_dependency_observation(
         self,
         command: list[str],

--- a/tests/test_click_incremental.py
+++ b/tests/test_click_incremental.py
@@ -4,9 +4,81 @@ import json
 import unittest
 
 from hooks import click_incremental
+from click_gate_test_support import ClickGateTestCase
 
 
 class ClickIncrementalPlanTests(unittest.TestCase):
+    def test_cancellation_retains_finished_failure_and_never_counts_unstarted_as_run(self) -> None:
+        plan = click_incremental.build_plan([
+            self.item("a", "run", "observed-input-changed", "runner"),
+            self.item("b", "run", "no-passing-evidence", "runner"),
+        ], current_revision=12)
+        verification = {}
+        click_incremental.store_batch(verification, click_incremental.new_batch(plan, batch_id="a" * 32, revision=12, prepared_ms=None))
+        click_incremental.mark_started(verification, "a" * 64)
+        click_incremental.mark_completed(verification, "a" * 64, status="failed", reason="command-failed", duration_ms=None)
+        click_incremental.interrupt_batch(verification)
+        before = click_incremental.history_accounting(verification)
+        self.assertEqual(before["executed_source_count"], 1)
+        self.assertEqual(before["failed_source_count"], 1)
+        self.assertEqual(before["not_run_source_count"], 1)
+        self.assertEqual(before["reuse_rate"], 0)
+        click_incremental.interrupt_batch(verification)
+        self.assertEqual(click_incremental.history_accounting(verification), before)
+        self.assertIsNone(click_incremental.batch_summary(click_incremental.current_batch(verification))["executed_duration_ms"])
+        self.assertIsNone(click_incremental.history_accounting({})["reuse_rate"])
+
+    def test_control_events_deduplicate_observations_without_storing_reason_prose(self) -> None:
+        state = {"status": "staged", "approved_turn_id": "", "verification": {"status": "ready"}}
+        event = {"session_id": "fixture", "turn_id": "one", "tool_use_id": "tool-one", "tool_input": {"command": "sensitive secret-token /home/private"}}
+        self.assertTrue(click_incremental.record_control_event(state, event, "contract-id-mismatch"))
+        self.assertFalse(click_incremental.record_control_event(state, event, "contract-lifecycle-rejected"))
+        self.assertTrue(click_incremental.record_control_event(state, event, "verification-guidance"))
+        values = click_incremental.control_events(state)
+        self.assertEqual([value["effect"] for value in values], ["blocked", "advisory"])
+        self.assertNotIn("secret-token", json.dumps(values))
+        self.assertNotIn("/home/private", json.dumps(values))
+        self.assertEqual(state["approved_turn_id"], "")
+        self.assertEqual(state["verification"], {"status": "ready"})
+
+    def test_retained_group_rate_exposes_denominator_window_and_missing_duration(self) -> None:
+        plan = click_incremental.build_plan([
+            self.item("a", "run", "observed-input-changed", "runner"),
+            self.item("b", "reuse-exact", "same-revision-receipt-current", "exact-receipt"),
+        ], current_revision=12)
+        plan["decisions"][1]["duration_baseline"] = None
+        verification = {}
+        click_incremental.store_batch(verification, click_incremental.new_batch(plan, batch_id="a" * 32, revision=12, prepared_ms=1))
+        click_incremental.record_execution(verification, {"a" * 64: 4}, source_results={"a" * 64: {
+            "status": "failed", "started": True, "completed": True, "reason_code": "command-failed",
+        }}, reused_keys={"b" * 64}, exit_code=1, runner_duration_ms=7)
+        report = click_incremental.history_accounting(verification)
+        self.assertEqual(report["reuse_numerator"], 1)
+        self.assertEqual(report["request_denominator"], 2)
+        self.assertEqual(report["reuse_rate"], 0.5)
+        self.assertEqual(report["missing_baseline_duration_count"], 1)
+        self.assertEqual(report["failed_source_count"], 1)
+        self.assertEqual(report["unit"], "verification-group-request")
+        self.assertEqual(report["window"], "retained-history")
+        self.assertIsNotNone(report["from_timestamp"])
+        verification[click_incremental.HISTORY_FIELD] *= 2
+        self.assertEqual(click_incremental.history_accounting(verification), report)
+
+    def test_request_timing_is_partial_and_unknown_clock_stays_null(self) -> None:
+        plan = click_incremental.build_plan([
+            self.item("a", "reuse-exact", "same-revision-receipt-current", "exact-receipt"),
+        ], current_revision=12)
+        verification = {}
+        batch = click_incremental.new_batch(plan, batch_id="a" * 32, revision=12, prepared_ms=1)
+        click_incremental.start_request_clock(verification, batch["batch_id"], started_ns=1_000_000, clock_id="fixture-clock")
+        click_incremental.complete_request_timing(verification, batch, ended_ns=6_000_000, clock_id="fixture-clock")
+        self.assertEqual(batch["request_wall_ms"], 5)
+        self.assertEqual(batch["measurement_scope"], "hook-entry-to-result-recording")
+        self.assertTrue(click_incremental.batch_is_valid(batch))
+        missing = click_incremental.new_batch(plan, batch_id="b" * 32, revision=12, prepared_ms=None)
+        click_incremental.complete_request_timing(verification, missing, ended_ns=6_000_000, clock_id="other-clock")
+        self.assertIsNone(missing["request_wall_ms"])
+
     def item(
         self,
         suffix: str,
@@ -230,6 +302,25 @@ class ClickIncrementalPlanTests(unittest.TestCase):
                 authority_source="exact-receipt",
                 estimated_avoided_ms=1,
             )
+
+
+class ClickObservedControlTests(ClickGateTestCase):
+    hook_in_process = True
+
+    def test_real_hook_records_approval_and_id_denials_without_granting_authority(self) -> None:
+        self.set_default("guarded", "turn-0")
+        self.arm_gate("turn-1")
+        self.stage_gate(turn_id="turn-1")
+        denied = self.pre_tool("apply_patch", "*** Begin Patch\n*** End Patch", "turn-1")
+        self.assertEqual(denied["hookSpecificOutput"]["permissionDecision"], "deny")
+        self.arm_gate("turn-2")
+        mismatch = self.pass_gate("ctr_" + "0" * 32, "turn-2")
+        self.assertEqual(mismatch["hookSpecificOutput"]["permissionDecision"], "deny")
+        state_path = next((self.plugin_data / "gate-state").glob("session-contract-*.json"))
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        self.assertEqual(state["status"], "staged")
+        self.assertEqual(state["approved_turn_id"], "")
+        self.assertEqual({item["code"] for item in click_incremental.control_events(state)}, {"approval-required", "contract-id-mismatch"})
 
 
 if __name__ == "__main__":

--- a/tests/test_click_receipt.py
+++ b/tests/test_click_receipt.py
@@ -243,6 +243,34 @@ class ClickReceiptTests(unittest.TestCase):
         self.assertIsNone(rejected)
         self.assertIn("Successor-reused", error)
 
+    def test_v5_requires_guarded_separate_contract_and_preserves_shard_integrity(self) -> None:
+        receipt = _valid_sharded_receipt()
+        receipt["version"] = 5
+        receipt["evidence"][0]["lineage"] = {
+            "mode": "successor-reused", "from_revision": 9,
+            "dependency_digest": _digest("e"), "origin_batch_id": "a" * 32,
+            "origin_contract_id": "ctr_" + "b" * 32,
+            "requalification_mode": "dependency",
+        }
+        normalized, error = click_receipt.validate_receipt(receipt)
+        self.assertEqual(error, "")
+        self.assertIsNotNone(normalized)
+        for case in ("downgrade", "self-origin", "evidence-authority", "missing-shard", "mixed-identity"):
+            with self.subTest(case=case):
+                bad = copy.deepcopy(receipt)
+                if case == "downgrade":
+                    bad["version"] = 4
+                elif case == "self-origin":
+                    bad["evidence"][0]["lineage"]["origin_contract_id"] = bad["contract"]["id"]
+                elif case == "evidence-authority":
+                    bad["contract"] = None
+                    bad["authority"].update(mode="evidence", approval_bound=False, execution_authority="host")
+                elif case == "missing-shard":
+                    bad["evidence"].pop()
+                else:
+                    bad["evidence"][0]["lineage"]["origin_evidence_session_id"] = "evs_" + "c" * 32
+                self.assertIsNone(click_receipt.validate_receipt(bad)[0])
+
     def test_unknown_sensitive_or_self_referential_fields_fail_closed(self) -> None:
         for path, field in (
             ((), "runner_token"),

--- a/tests/test_click_shadow_dashboard.py
+++ b/tests/test_click_shadow_dashboard.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import shutil
+import subprocess
 from pathlib import Path
 import threading
 import time
@@ -22,6 +24,40 @@ from click_gate_test_support import (
 
 
 class ClickShadowDashboardTests(ClickGateTestCase):
+    def test_dashboard_javascript_parses_and_keeps_contract_prose_out_of_share_report(self) -> None:
+        node = shutil.which("node")
+        if node is None:
+            self.skipTest("Node syntax check unavailable; browser verification remains separate")
+        result = subprocess.run([node, "--check"], input=CLICK_SHADOW_DASHBOARD.JS, text=True, capture_output=True)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        share = CLICK_SHADOW_DASHBOARD.JS.split("function shareReport()", 1)[1].split("function standaloneReport", 1)[0]
+        self.assertNotIn("snapshot.task.promises", share)
+        self.assertNotIn("snapshot.task.name", share)
+        self.assertIn("projection_version", share)
+        self.assertIn("reuse_origin", share)
+
+    def test_guarded_contract_transition_keeps_viewer_history_without_authority(self) -> None:
+        self.set_default("guarded", "turn-0")
+        self.approve_contract()
+        first_id = self.active_contract_id()
+        self.assertEqual(self.run_rewritten(self.verify_gate([self.verification_argv()])).returncode, 0)
+        self.arm_gate("turn-3")
+        contract = self.contract()
+        contract["outcome"] = "다음 계약의 검증"
+        staged = self.stage_gate(contract, "turn-3")
+        self.assertEqual(staged["hookSpecificOutput"]["permissionDecision"], "allow")
+        state_path = next((self.plugin_data / "gate-state").glob("session-contract-*.json"))
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        projection = CLICK_SHADOW_DASHBOARD.click_dashboard_projection.dashboard_projection(state)
+        self.assertFalse(projection["task"]["approval_bound"])
+        self.assertEqual(projection["task"]["name"], "다음 계약의 검증")
+        self.assertNotEqual(projection["task"]["contract_id"], first_id)
+        self.assertIsNone(projection["history"]["current_batch_id"])
+        self.assertEqual(projection["batches"][-1]["task"]["id"], first_id)
+        self.assertEqual(projection["sources"][0]["execution_status"], "not-run")
+        self.assertEqual(state["verification"]["status"], "ready")
+        self.assertEqual(state["approved_turn_id"], "")
+
     def test_control_parser_accepts_only_explicit_dashboard_actions(self) -> None:
         for action in ("start", "stop", "status"):
             self.assertEqual(
@@ -225,7 +261,10 @@ class ClickShadowDashboardTests(ClickGateTestCase):
         with urllib.request.urlopen(base + "/", timeout=2) as response:
             html = response.read().decode()
             self.assertEqual(response.status, 200)
-            self.assertIn("얼마나 기다렸나요?", html)
+            self.assertIn("약속한 범위 안에서", html)
+            self.assertIn('id="approvalState"', html)
+            self.assertIn('id="contractPromises"', html)
+            self.assertIn('<details class="panel telemetry">', html)
             self.assertIn("실제 재사용", html)
             self.assertIn("독립형 HTML 내보내기", html)
             self.assertIn("default-src 'none'", response.headers["Content-Security-Policy"])
@@ -249,7 +288,10 @@ class ClickShadowDashboardTests(ClickGateTestCase):
             self.assertEqual(payload["summary"]["shadow"]["candidate_count"], 0)
             self.assertNotIn("actual_saved_ms", body)
             self.assertNotIn(str(self.workspace), body)
-            self.assertNotIn("contract_id", body)
+            self.assertEqual(payload["task"]["contract_id"], self.active_contract_id())
+            self.assertNotIn("runner_token", body)
+            self.assertNotIn(access_token, body)
+            self.assertNotIn("raw_argv", body)
 
         wrong_host = urllib.request.Request(
             base + "/", headers={"Host": "attacker.invalid"}

--- a/tests/test_click_shadow_dashboard.py
+++ b/tests/test_click_shadow_dashboard.py
@@ -28,7 +28,13 @@ class ClickShadowDashboardTests(ClickGateTestCase):
         node = shutil.which("node")
         if node is None:
             self.skipTest("Node syntax check unavailable; browser verification remains separate")
-        result = subprocess.run([node, "--check"], input=CLICK_SHADOW_DASHBOARD.JS, text=True, capture_output=True)
+        result = subprocess.run(
+            [node, "--check"],
+            input=CLICK_SHADOW_DASHBOARD.JS,
+            text=True,
+            encoding="utf-8",
+            capture_output=True,
+        )
         self.assertEqual(result.returncode, 0, result.stderr)
         share = CLICK_SHADOW_DASHBOARD.JS.split("function shareReport()", 1)[1].split("function standaloneReport", 1)[0]
         self.assertNotIn("snapshot.task.promises", share)

--- a/tests/test_click_shadow_dashboard.py
+++ b/tests/test_click_shadow_dashboard.py
@@ -238,9 +238,11 @@ class ClickShadowDashboardTests(ClickGateTestCase):
             "PLUGIN_DATA": str(self.plugin_data),
             "CLICK_CONFIG_HOME": str(self.plugin_data),
         }
+        environment_ready = threading.Event()
 
         def serve() -> None:
             with mock.patch.dict(os.environ, environment):
+                environment_ready.set()
                 results.append(
                     CLICK_SHADOW_DASHBOARD.run_server(
                         [str(state_path), instance_id, access_token]
@@ -249,6 +251,7 @@ class ClickShadowDashboardTests(ClickGateTestCase):
 
         thread = threading.Thread(target=serve, daemon=True)
         thread.start()
+        self.assertTrue(environment_ready.wait(timeout=2))
         port = 0
         for _ in range(500):
             with CLICK_STATE.state_lock():

--- a/tests/test_incremental_benchmark.py
+++ b/tests/test_incremental_benchmark.py
@@ -10,6 +10,7 @@ import tempfile
 from unittest import mock
 
 from benchmarks.incremental_verification import Fixture, _fixture_runner_argv, comparison_delta, distribution, main
+from benchmarks import incremental_verification as benchmark
 from hooks import click_incremental
 
 
@@ -18,6 +19,42 @@ BENCHMARK = ROOT / "benchmarks" / "incremental_verification.py"
 
 
 class IncrementalVerificationBenchmarkTests(unittest.TestCase):
+    def test_guarded_workflow_compares_three_configs_and_audits_real_successor_reuse(self):
+        result = benchmark.run_guarded_workflow_benchmark(iterations=1, warmups=0, workload_rounds=20)
+        self.assertEqual(result["kind"], "click-guarded-workflow-benchmark")
+        sample = result["samples"][0]
+        self.assertEqual(set(sample["arms"]), {"baseline", "click-default", "explicit-reuse"})
+        digests = [arm["final_input_digest"] for arm in sample["arms"].values()]
+        self.assertEqual(len(set(digests)), 1)
+        for arm in sample["arms"].values():
+            self.assertTrue(all(step["audit_matches"] for step in arm["steps"]))
+            steps = {step["scenario"]: step for step in arm["steps"]}
+            self.assertEqual(steps["failure"]["validation"]["status"], "failed")
+            self.assertEqual(steps["retry"]["validation"]["status"], "passed")
+            self.assertEqual(steps["unchanged"]["audit"]["status"], "passed")
+        explicit = sample["arms"]["explicit-reuse"]
+        steps = {step["scenario"]: step for step in explicit["steps"]}
+        partial = steps["unrelated-code"]["validation"]
+        self.assertEqual((partial["executed_source_count"], partial["reused_source_count"]), (1, 1))
+        reused = next(item for item in partial["batch"]["sources"] if item["status"] == "reused")
+        self.assertEqual(reused["reuse_origin"]["kind"], "successor-contract")
+        self.assertNotEqual(steps["first-run"]["contract_id"], steps["unrelated-code"]["contract_id"])
+        self.assertEqual(steps["related-code"]["validation"]["executed_source_count"], 1)
+        self.assertEqual(steps["environment"]["validation"]["executed_source_count"], 2)
+        failed = next(item for item in steps["failure"]["validation"]["batch"]["sources"] if item["status"] == "failed")
+        self.assertIsNone(failed["reuse_origin"])
+        self.assertEqual(explicit["successor_receipt"]["receipt"]["version"], 5)
+        self.assertTrue(all(item["preapproval_denied"] and item["wrong_id_denied"] and item["separate_turns"] for item in explicit["controls"]))
+        default_steps = sample["arms"]["click-default"]["steps"]
+        self.assertEqual(default_steps[1]["validation"]["reused_source_count"], 0)
+        self.assertNotIn("runner_token", json.dumps(result))
+        report = benchmark.workflow_report_html(result)
+        self.assertIn("<html lang=\"ko\">", report)
+        self.assertIn("음수", report)
+        self.assertNotIn("<script", report)
+        self.assertNotIn("PLUGIN_DATA", report)
+        self.assertNotIn("raw_argv", report)
+
     def test_windows_fixture_runner_keeps_the_preflight_interpreter_and_capability(self) -> None:
         argv = ["py", "-3", str(BENCHMARK), "--encoded-runner", "transport-fixture"]
         with mock.patch("benchmarks.incremental_verification._split", return_value=argv):

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -46,7 +46,7 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
             (ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
         )
         self.assertEqual(manifest["name"], "click")
-        self.assertEqual(manifest["version"], "0.81.1")
+        self.assertEqual(manifest["version"], "0.82.0")
         self.assertEqual(manifest["license"], "MIT")
         combined_copy = " ".join(
             (
@@ -72,10 +72,10 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
         self.assertEqual(marketplace["name"], "click")
         self.assertEqual(marketplace["plugins"][0]["name"], "click")
         self.assertEqual(
-            marketplace["plugins"][0]["source"]["ref"], "v0.81.1"
+            marketplace["plugins"][0]["source"]["ref"], "v0.82.0"
         )
 
-    def test_readmes_lead_with_incremental_verification_positioning(self) -> None:
+    def test_readmes_preserve_modes_references_and_reproducible_evidence_boundaries(self) -> None:
         for name, readme in _readmes().items():
             with self.subTest(readme=name):
                 opening = "\n".join(readme.splitlines()[:45]).lower()
@@ -84,8 +84,9 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
                 self.assertIn("evidence", readme)
                 self.assertIn("guarded", readme.lower())
                 self.assertIn("off", readme.lower())
-                self.assertLessEqual(len(readme.splitlines()), 240)
-                self.assertLessEqual(len(readme), 16_000)
+                # Marketing wording/line counts are not protocol guarantees.
+                # Preserve actionable references, mode distinctions, and avoid
+                # leaking internal approval/runner transport into introductions.
                 for link in TECHNICAL_LINKS:
                     self.assertIn(link, readme)
                 for internal_copy in (
@@ -99,14 +100,6 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
                     self.assertNotIn(internal_copy, readme)
         english = _readmes()["README.md"]
         self.assertIn(
-            "Incremental verification for coding agents.", english
-        )
-        self.assertIn(
-            "Click keeps passing checks reusable until the code they depend on "
-            "actually changes.",
-            english,
-        )
-        self.assertIn(
             "Click does not prove that the code is correct or that the selected "
             "tests are sufficient.",
             english,
@@ -114,6 +107,9 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
         for readme in _readmes().values():
             self.assertIn("click-gate observer off", readme)
             self.assertIn("benchmarks/incremental_verification.py", readme)
+            self.assertIn("--guarded-workflow", readme)
+            self.assertIn("--html-output", readme)
+            self.assertIn("v5", readme)
 
     def test_readmes_document_qualitative_profiles_and_exact_receipts(self) -> None:
         for readme in _readmes().values():
@@ -353,13 +349,14 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
 
     def test_release_documents_identify_current_and_preserve_release_history(self) -> None:
         for readme in _readmes().values():
-            self.assertIn("v0.81.1", readme)
+            self.assertIn("v0.82.0", readme)
             self.assertIn("codex plugin marketplace upgrade click", readme)
             self.assertIn("codex plugin add click@click", readme)
             self.assertIn("RELEASE_NOTES.md", readme)
 
         notes = (ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8")
         for marker in (
+            "## v0.82.0",
             "## v0.81.1",
             "## v0.81.0",
             "## v0.80.0",


### PR DESCRIPTION
## Summary

- requalify completed Guarded contract results as candidates under a separately approved successor contract
- add receipt v5 cross-contract lineage while preserving v1-v4 and Evidence Shards compatibility
- make verification outcomes, timing, provenance, and sanitized dashboard exports result-first and explicit
- add a real three-configuration Guarded workflow benchmark, including full-suite audits and visible negative results
- keep Codex and generated Antigravity distributions, documentation, and regression coverage in parity

## Verification

- `python3 scripts/validate_distribution.py`
- `python3 -m compileall -q hooks evals scripts benchmarks tests`
- `git diff --check`
- `python3 -m unittest discover -s tests -q`
  - 676 tests discovered across committed Evidence Shards
  - 671 passed, 5 platform-conditional skips

## Measurement boundary

The bundled short benchmark fixture can be slower with Click because management overhead exceeds avoided execution cost. Its same-state full-suite audits matched in the recorded run, but this is not a universal safety proof or a claim of net development-time savings.
