### PR TITLE
Release v0.94.1 documentation patch

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -9,7 +9,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/grapefruit0205/click.git",
-        "ref": "v0.94.0"
+        "ref": "v0.94.1"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "click",
-  "version": "0.94.0",
+  "version": "0.94.1",
   "description": "Incremental verification for coding agents: propose complete test shards, rerun affected checks, and reuse authoritative passing evidence with optional Guarded approval boundaries.",
   "author": {
     "name": "Junseok Pak",

--- a/README.ko.md
+++ b/README.ko.md
@@ -76,14 +76,14 @@ codex plugin add click@click
 
 Codex를 재시작하고 새 작업을 시작해 설치된 Hook과 스킬을 다시 불러옵니다. CLI의 `/hooks`에서 검토 대기 중인 Click Hook을 확인한 뒤 사용하세요. 자세한 내용은 [Hook 문제 확인](#hook-문제-확인)을 참고하세요.
 
-현재 릴리스는 **v0.94.0**입니다. 업데이트 명령은 다음과 같습니다.
+현재 릴리스는 **v0.94.1**입니다. 업데이트 명령은 다음과 같습니다.
 
 ```sh
 codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-업데이트 후에도 재시작하고 새 작업을 사용합니다. v0.94.0은 고정된 Vitest 5와 Jest 30 프로필에 제한된 자동 inventory와 정확한 파일 샤딩을 추가하고, Node·npm·Go·콘텐츠 검증까지 정확한 런타임 및 입력 결합을 확장합니다. 상주 Hook worker는 반복되는 Python 시작 비용을 줄입니다. 대시보드는 실행, 자동 샤딩, 같은 상태의 정확 재사용, 저장소 소유자 정책 재사용, 권위 있는 관찰을 한국어·영어·중국어 간체로 구분합니다. 지원하지 않거나 불명확한 탐색은 원래 parent 명령을 실행하며, 자동 샤딩 `init/status/refresh`와 권한 있는 샤드 재사용은 필수 회귀 기준으로 유지합니다. 검증 결과와 측정 한계는 [릴리스 노트](RELEASE_NOTES.md)와 [다국어 확장 기록](docs/history/multilang-expansion/FINAL_REPORT.md)에 있습니다.
+업데이트 후에도 재시작하고 새 작업을 사용합니다. v0.94.1은 유지 중인 아키텍처 문서와 canonical 프롬프트를 완료된 구현 이력에서 분리하며, v0.94.0의 런타임 동작을 그대로 유지합니다. 자동 샤딩 `init/status/refresh`, 권한 있는 샤드 재사용, 보수적인 parent fallback은 필수 회귀 기준입니다. 검증 결과와 측정 한계는 [릴리스 노트](RELEASE_NOTES.md), [문서 안내](docs/README.md), [다국어 확장 기록](docs/history/multilang-expansion/FINAL_REPORT.md)에 있습니다.
 
 설치와 재사용 준비 상태는 서로 다릅니다.
 

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ codex plugin add click@click
 
 Restart Codex and start a new task so the installed Hooks and skill reload. Review pending Click Hooks in the CLI's `/hooks` view before relying on them; see [Hook troubleshooting](#hook-troubleshooting).
 
-Current release: **v0.94.0**. To update:
+Current release: **v0.94.1**. To update:
 
 ```sh
 codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-Restart and use a fresh task after updating. v0.94.0 adds bounded automatic inventory and exact-file sharding for pinned Vitest 5 and Jest 30 profiles, extends exact runtime and input binding to Node, npm, Go, and content validation, and uses a resident Hook worker to reduce repeated Python startup. The dashboard now separates execution, automatic sharding, exact reuse, owner-policy reuse, and authoritative observation in Korean, English, and Simplified Chinese. Unsupported or ambiguous discovery still runs the parent command; automatic sharding `init/status/refresh` and authorized shard reuse remain required regressions. See [release notes](RELEASE_NOTES.md) and the [multilingual expansion record](docs/history/multilang-expansion/FINAL_REPORT.md) for validation, measurements, and their limits.
+Restart and use a fresh task after updating. v0.94.1 separates maintained architecture and canonical prompts from completed implementation history, while preserving the v0.94.0 runtime behavior. Automatic sharding `init/status/refresh`, authorized shard reuse, and conservative parent fallback remain required regressions. See [release notes](RELEASE_NOTES.md), the [documentation map](docs/README.md), and the [multilingual expansion record](docs/history/multilang-expansion/FINAL_REPORT.md) for validation, measurements, and their limits.
 
 ## Start with everyday work
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,14 +29,14 @@ codex plugin add click@click
 
 重启 Codex 并新建任务，让已安装的 Hook 和技能重新加载。在依赖 Hook 之前，先通过 CLI 的 `/hooks` 页面审阅待确认的 Click Hook；详见 [Hook 故障排查](#hook-故障排查)。
 
-当前版本：**v0.94.0**。更新命令：
+当前版本：**v0.94.1**。更新命令：
 
 ```sh
 codex plugin marketplace upgrade click
 codex plugin add click@click
 ```
 
-更新后请重启，并使用新任务。v0.94.0 为固定版本的 Vitest 5 和 Jest 30 配置增加了有界自动 inventory 与精确文件分片，将精确运行时和输入绑定扩展到 Node、npm、Go 与内容验证，并通过常驻 Hook worker 减少重复的 Python 启动开销。仪表板以韩语、英语和简体中文分别显示执行、自动分片、同状态精确复用、仓库所有者策略复用和权威观察。遇到不支持或不明确的发现过程时仍执行原始 parent 命令；自动分片 `init/status/refresh` 与经授权的分片复用仍是必须满足的回归标准。验证结果与测量限制见[版本说明](RELEASE_NOTES.md)和[多语言扩展记录](docs/history/multilang-expansion/FINAL_REPORT.md)。
+更新后请重启，并使用新任务。v0.94.1 将持续维护的架构文档和规范提示词与已完成的实现历史分开，同时保留 v0.94.0 的运行时行为。自动分片 `init/status/refresh`、经授权的分片复用和保守的 parent fallback 仍是必须满足的回归标准。验证结果与测量限制见[版本说明](RELEASE_NOTES.md)、[文档索引](docs/README.md)和[多语言扩展记录](docs/history/multilang-expansion/FINAL_REPORT.md)。
 
 ## 从日常工作开始
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,20 @@
 # Release notes
 
+## v0.94.1 — 2026-09-09
+
+- Maintained architecture documents, canonical prompts, completed phase packages,
+  and historical evidence now have explicit entry points under `docs/README.md`,
+  `docs/architecture/`, and `docs/history/`. Historical records keep their original
+  contents and literal paths where those paths are part of the evidence.
+- The canonical Click skill reference and generated Antigravity package now point
+  to the reorganized multilingual expansion record. Relative Markdown links and
+  generated distribution parity were validated after the move.
+- Runtime behavior is unchanged. Automatic sharding `init/status/refresh`,
+  complete-inventory enforcement, authorized shard reuse, and conservative parent
+  fallback remain required regressions. The focused local suites passed 87 tests
+  with 2 platform-only skips, and pull request #99 passed the Linux, macOS, and
+  Windows matrix after one transient Windows native-observation job was rerun.
+
 ## v0.94.0 — 2026-09-08
 
 - Automatic inventory and exact-file sharding now cover bounded, pinned Vitest

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -46,7 +46,7 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
             (ROOT / ".codex-plugin" / "plugin.json").read_text(encoding="utf-8")
         )
         self.assertEqual(manifest["name"], "click")
-        self.assertEqual(manifest["version"], "0.94.0")
+        self.assertEqual(manifest["version"], "0.94.1")
         self.assertEqual(manifest["license"], "MIT")
         combined_copy = " ".join(
             (
@@ -72,7 +72,7 @@ class RepositoryPolicyTests(core.RepositoryPolicyTests):
         self.assertEqual(marketplace["name"], "click")
         self.assertEqual(marketplace["plugins"][0]["name"], "click")
         self.assertEqual(
-            marketplace["plugins"][0]["source"]["ref"], "v0.94.0"
+            marketplace["plugins"][0]["source"]["ref"], "v0.94.1"
         )
 
     def test_readmes_preserve_modes_references_and_reproducible_evidence_boundaries(self) -> None:


### PR DESCRIPTION
The documentation reorganization merged in #99 changed the canonical Click skill reference and generated Antigravity package, while the published plugin metadata still reported v0.94.0.

This patch release updates the plugin and marketplace metadata to v0.94.1, refreshes the Korean, English, and Simplified Chinese release guidance, and records the new canonical documentation map. Runtime behavior remains unchanged, including automatic sharding `init/status/refresh`, authorized shard reuse, and conservative parent fallback.

Validation:
- 87 focused sharding, reuse, and fallback tests passed; 2 platform-only tests skipped
- distribution validation passed
- Codex plugin and Click skill validation passed
- relative Markdown links and `git diff --check` passed
- #99 passed the Linux, macOS, and Windows CI matrix after rerunning one transient Windows native-observation failure
