### PR TITLE
Make conditional JS observation deterministic across identical executions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,17 @@ trigger remains unconfirmed. The preceding stabilization was merged in PR #103
 after its 43 checks passed; that historical run does not validate later changes.
 This candidate remains unreleased. See `docs/architecture/automatic-observation.md`.
 
+- Conditional JS learning no longer depends on two runtime-internal reads that
+  vary between identical executions: glibc's one-time
+  `/proc/sys/vm/overcommit_memory` allocator probe (any thread, any time) and
+  V8 re-opening the running Node image to relocate embedded builtins
+  (address-space dependent). Either made a projection ineligible or changed the
+  external input set between the learning and binding executions, so a child
+  intermittently lost its receipt and re-ran. Both were reproduced locally
+  under CPU contention. Application proc reads, metadata calls and image reads
+  stay dynamic. The Inspector controller now exits on its own after reporting;
+  the runner releases the endpoint FIFO instead of waiting five seconds and
+  terminating it, which also shortens every observed execution.
 - Preparation status now explains bounded failure reasons, recovery actions and
   recent per-check rerun/conditional-reuse decisions in all three dashboard
   languages. Mode selection and status never claim reuse authorization.

--- a/dist/antigravity/hooks/click_conditional_observer.py
+++ b/dist/antigravity/hooks/click_conditional_observer.py
@@ -20,6 +20,7 @@ MAX_INPUTS = 4096
 MAX_BYTES = 512 * 1024 * 1024
 DIGEST = re.compile(r"^[0-9a-f]{64}$")
 OPERATIONS = {"enumerate", "execute", "metadata", "read"}
+ALLOCATOR_POLICY_PROBE = "/proc/sys/vm/overcommit_memory"
 
 
 def digest(value):
@@ -42,12 +43,14 @@ def source_digest():
             "click_observer_process_tree.py")]])
 
 
-def project_capture(raw, *, project, cwd, directory, truncated=False):
+def project_capture(raw, *, project, cwd, directory, runtime=None, truncated=False):
     """Conditional projection; retain ordinary external files as bound inputs.
 
-Only the fixed Node bootstrap's proc/cgroup probes and ancestor metadata are
-outside this confidence scope. The same probes after the acknowledgement are
-ordinary inputs. No application read is removed because it is later written.
+Only the fixed Node bootstrap's proc/cgroup probes, ancestor metadata, the C
+library's one-time allocator policy probe and the engine's re-mapping of the
+already bound runtime image are outside this confidence scope. The same
+bootstrap probes after the acknowledgement are ordinary inputs. No application
+read is removed because it is later written.
     """
     if __package__:
         from . import click_observer_linux as linux, click_observer_process_tree as processes
@@ -58,6 +61,7 @@ ordinary inputs. No application read is removed because it is later written.
         return None
     root = Path(project).resolve()
     ready = str(Path(directory) / f"ready-{next(iter(tree.process_ids))}")
+    image = str(runtime) if runtime else None
     pipe = str(Path(directory) / "endpoints.pipe")
     started, lines = False, []
     for line in tree.trace.decode("utf-8", errors="strict").splitlines():
@@ -70,6 +74,25 @@ ordinary inputs. No application read is removed because it is later written.
         path, _, _ = linux._decoded_path(arguments)
         if (path == "/dev/null" and call in linux._OPEN_CALLS and "O_RDONLY" in arguments
                 and stat.S_ISCHR(os.stat("/dev/null").st_mode) and os.stat("/dev/null").st_rdev == os.makedev(1, 3)):
+            continue
+        # glibc reads the kernel overcommit policy once per process, from
+        # whichever thread first trims a non-main malloc heap, to choose
+        # between unmapping and advising freed pages. The byte only tunes
+        # memory release, and the probe's position relative to the
+        # acknowledgement is arbitrary, so an observed input set must not
+        # depend on it. A check opening the same sysctl read-only is
+        # indistinguishable and shares this exception; metadata calls on
+        # it and every other application proc read stay dynamic.
+        if (path == ALLOCATOR_POLICY_PROBE and call in {"open", "openat"}
+                and arguments.endswith('", O_RDONLY|O_CLOEXEC')):
+            continue
+        # V8 may map the running Node image again to relocate its embedded
+        # builtins, depending on where address-space randomization placed the
+        # code range. Execution and the receipt's runtime digest already bind
+        # that image, so this plain read-only open adds no input and must
+        # not vary the observed set between two executions.
+        if (image and call in {"open", "openat"} and arguments.endswith('", O_RDONLY')
+                and image in {path, linux._fd_path(result)}):
             continue
         if path == ready and call in {"access", "stat", "newfstatat"}:
             if linux._return_integer(result) == 0:

--- a/dist/antigravity/hooks/click_framework_observer.py
+++ b/dist/antigravity/hooks/click_framework_observer.py
@@ -135,7 +135,8 @@ def run_command(argv, *, runtime_inputs: bool = True, previous=None,
         tree = processes.inspect(raw, **options)
         if collector and collector.location:
             projection = conditional.project_capture(raw, project=project, cwd=kwargs["workspace"],
-                                                     directory=collector.location.name, **options)
+                                                     directory=collector.location.name,
+                                                     runtime=collector.runtime_path, **options)
     collector = node_observer.Collector(argv, dict(kwargs["environment"]), Path(kwargs["workspace"])) if runtime_inputs else None
     before = None
     external_before = None

--- a/dist/antigravity/hooks/click_node_observer.py
+++ b/dist/antigravity/hooks/click_node_observer.py
@@ -233,19 +233,29 @@ class Collector:
     def close(self):
         if self.child is not None:
             try:
-                try:
-                    self.child.stdin.close()
-                except OSError:
-                    pass
+                self.child.stdin.close()
+            except OSError:
+                pass
+        # The controller reads the FIFO through a blocking pool thread, and
+        # its exit joins that pool. Unlink first so a late target cannot
+        # block opening a reader-less FIFO, then release the last writer so
+        # the pending read returns EOF instead of outliving a 5s wait.
+        if self.location is not None:
+            try:
+                (Path(self.location.name) / "endpoints.pipe").unlink()
+            except OSError:
+                pass
+        if self.descriptor is not None:
+            os.close(self.descriptor)
+            self.descriptor = None
+        if self.child is not None:
+            try:
                 if self.child.poll() is None:
                     self.child.wait(timeout=5)
             except (OSError, subprocess.TimeoutExpired):
                 click_process.terminate_process_group(self.child, grace_seconds=0.2)
             self.child.stdout.close()
             self.child = None
-        if self.descriptor is not None:
-            os.close(self.descriptor)
-            self.descriptor = None
         if self.location is not None:
             self.location.cleanup()
             self.location = None

--- a/dist/claude/hooks/click_conditional_observer.py
+++ b/dist/claude/hooks/click_conditional_observer.py
@@ -20,6 +20,7 @@ MAX_INPUTS = 4096
 MAX_BYTES = 512 * 1024 * 1024
 DIGEST = re.compile(r"^[0-9a-f]{64}$")
 OPERATIONS = {"enumerate", "execute", "metadata", "read"}
+ALLOCATOR_POLICY_PROBE = "/proc/sys/vm/overcommit_memory"
 
 
 def digest(value):
@@ -42,12 +43,14 @@ def source_digest():
             "click_observer_process_tree.py")]])
 
 
-def project_capture(raw, *, project, cwd, directory, truncated=False):
+def project_capture(raw, *, project, cwd, directory, runtime=None, truncated=False):
     """Conditional projection; retain ordinary external files as bound inputs.
 
-Only the fixed Node bootstrap's proc/cgroup probes and ancestor metadata are
-outside this confidence scope. The same probes after the acknowledgement are
-ordinary inputs. No application read is removed because it is later written.
+Only the fixed Node bootstrap's proc/cgroup probes, ancestor metadata, the C
+library's one-time allocator policy probe and the engine's re-mapping of the
+already bound runtime image are outside this confidence scope. The same
+bootstrap probes after the acknowledgement are ordinary inputs. No application
+read is removed because it is later written.
     """
     if __package__:
         from . import click_observer_linux as linux, click_observer_process_tree as processes
@@ -58,6 +61,7 @@ ordinary inputs. No application read is removed because it is later written.
         return None
     root = Path(project).resolve()
     ready = str(Path(directory) / f"ready-{next(iter(tree.process_ids))}")
+    image = str(runtime) if runtime else None
     pipe = str(Path(directory) / "endpoints.pipe")
     started, lines = False, []
     for line in tree.trace.decode("utf-8", errors="strict").splitlines():
@@ -70,6 +74,25 @@ ordinary inputs. No application read is removed because it is later written.
         path, _, _ = linux._decoded_path(arguments)
         if (path == "/dev/null" and call in linux._OPEN_CALLS and "O_RDONLY" in arguments
                 and stat.S_ISCHR(os.stat("/dev/null").st_mode) and os.stat("/dev/null").st_rdev == os.makedev(1, 3)):
+            continue
+        # glibc reads the kernel overcommit policy once per process, from
+        # whichever thread first trims a non-main malloc heap, to choose
+        # between unmapping and advising freed pages. The byte only tunes
+        # memory release, and the probe's position relative to the
+        # acknowledgement is arbitrary, so an observed input set must not
+        # depend on it. A check opening the same sysctl read-only is
+        # indistinguishable and shares this exception; metadata calls on
+        # it and every other application proc read stay dynamic.
+        if (path == ALLOCATOR_POLICY_PROBE and call in {"open", "openat"}
+                and arguments.endswith('", O_RDONLY|O_CLOEXEC')):
+            continue
+        # V8 may map the running Node image again to relocate its embedded
+        # builtins, depending on where address-space randomization placed the
+        # code range. Execution and the receipt's runtime digest already bind
+        # that image, so this plain read-only open adds no input and must
+        # not vary the observed set between two executions.
+        if (image and call in {"open", "openat"} and arguments.endswith('", O_RDONLY')
+                and image in {path, linux._fd_path(result)}):
             continue
         if path == ready and call in {"access", "stat", "newfstatat"}:
             if linux._return_integer(result) == 0:

--- a/dist/claude/hooks/click_framework_observer.py
+++ b/dist/claude/hooks/click_framework_observer.py
@@ -135,7 +135,8 @@ def run_command(argv, *, runtime_inputs: bool = True, previous=None,
         tree = processes.inspect(raw, **options)
         if collector and collector.location:
             projection = conditional.project_capture(raw, project=project, cwd=kwargs["workspace"],
-                                                     directory=collector.location.name, **options)
+                                                     directory=collector.location.name,
+                                                     runtime=collector.runtime_path, **options)
     collector = node_observer.Collector(argv, dict(kwargs["environment"]), Path(kwargs["workspace"])) if runtime_inputs else None
     before = None
     external_before = None

--- a/dist/claude/hooks/click_node_observer.py
+++ b/dist/claude/hooks/click_node_observer.py
@@ -233,19 +233,29 @@ class Collector:
     def close(self):
         if self.child is not None:
             try:
-                try:
-                    self.child.stdin.close()
-                except OSError:
-                    pass
+                self.child.stdin.close()
+            except OSError:
+                pass
+        # The controller reads the FIFO through a blocking pool thread, and
+        # its exit joins that pool. Unlink first so a late target cannot
+        # block opening a reader-less FIFO, then release the last writer so
+        # the pending read returns EOF instead of outliving a 5s wait.
+        if self.location is not None:
+            try:
+                (Path(self.location.name) / "endpoints.pipe").unlink()
+            except OSError:
+                pass
+        if self.descriptor is not None:
+            os.close(self.descriptor)
+            self.descriptor = None
+        if self.child is not None:
+            try:
                 if self.child.poll() is None:
                     self.child.wait(timeout=5)
             except (OSError, subprocess.TimeoutExpired):
                 click_process.terminate_process_group(self.child, grace_seconds=0.2)
             self.child.stdout.close()
             self.child = None
-        if self.descriptor is not None:
-            os.close(self.descriptor)
-            self.descriptor = None
         if self.location is not None:
             self.location.cleanup()
             self.location = None

--- a/docs/architecture/node-runtime-observation.md
+++ b/docs/architecture/node-runtime-observation.md
@@ -67,6 +67,16 @@ JSON, under these explicit assumptions:
 - The runner's stdout/stderr transport and the normal `/dev/null` device are
   runtime facilities. Stdin, arbitrary descriptors and application proc/device
   reads are not granted the same exception.
+- Two runtime-internal reads vary between otherwise identical executions and
+  are excluded so that the learning and binding executions observe the same
+  set: the C library reads `/proc/sys/vm/overcommit_memory` once per process,
+  from whichever thread first trims a non-main malloc heap, and V8 may open
+  the running Node image read-only to relocate its embedded builtins,
+  depending on address-space randomization. The policy byte only tunes memory
+  release; the image is already bound by execution and by the receipt's
+  runtime digest. A check that opens that sysctl read-only itself is
+  indistinguishable and shares the exception; metadata calls on it, every
+  other proc read and an application read of the image stay ordinary inputs.
 - Unobserved native, asynchronous, scheduling or environment-introspection inputs
   may still affect results. Conditional confidence accepts this residual risk;
   it is not a proof of JavaScript semantics or of every possible input.
@@ -94,7 +104,10 @@ An external Node controller connects through loopback V8 Inspector endpoints.
 A bounded ESM preload publishes each Node process's endpoint through a private
 FIFO before the entry point runs. The controller acknowledges completed setup;
 without acknowledgement the preload stops waiting after five seconds and lets
-the original entry point continue. Existing `NODE_OPTIONS`, preloads and
+the original entry point continue. After the result is reported the runner
+unlinks the FIFO and releases its own writer, so the controller's pending FIFO
+read ends and the controller exits on its own instead of being terminated
+after a bounded wait. Existing `NODE_OPTIONS`, preloads and
 debuggers are preserved by declining preparation. Node can print its own
 temporary debugger endpoint and attachment messages on stderr; those are
 ordinary captured process output, not persisted runtime-record fields.

--- a/hooks/click_conditional_observer.py
+++ b/hooks/click_conditional_observer.py
@@ -20,6 +20,7 @@ MAX_INPUTS = 4096
 MAX_BYTES = 512 * 1024 * 1024
 DIGEST = re.compile(r"^[0-9a-f]{64}$")
 OPERATIONS = {"enumerate", "execute", "metadata", "read"}
+ALLOCATOR_POLICY_PROBE = "/proc/sys/vm/overcommit_memory"
 
 
 def digest(value):
@@ -42,12 +43,14 @@ def source_digest():
             "click_observer_process_tree.py")]])
 
 
-def project_capture(raw, *, project, cwd, directory, truncated=False):
+def project_capture(raw, *, project, cwd, directory, runtime=None, truncated=False):
     """Conditional projection; retain ordinary external files as bound inputs.
 
-Only the fixed Node bootstrap's proc/cgroup probes and ancestor metadata are
-outside this confidence scope. The same probes after the acknowledgement are
-ordinary inputs. No application read is removed because it is later written.
+Only the fixed Node bootstrap's proc/cgroup probes, ancestor metadata, the C
+library's one-time allocator policy probe and the engine's re-mapping of the
+already bound runtime image are outside this confidence scope. The same
+bootstrap probes after the acknowledgement are ordinary inputs. No application
+read is removed because it is later written.
     """
     if __package__:
         from . import click_observer_linux as linux, click_observer_process_tree as processes
@@ -58,6 +61,7 @@ ordinary inputs. No application read is removed because it is later written.
         return None
     root = Path(project).resolve()
     ready = str(Path(directory) / f"ready-{next(iter(tree.process_ids))}")
+    image = str(runtime) if runtime else None
     pipe = str(Path(directory) / "endpoints.pipe")
     started, lines = False, []
     for line in tree.trace.decode("utf-8", errors="strict").splitlines():
@@ -70,6 +74,25 @@ ordinary inputs. No application read is removed because it is later written.
         path, _, _ = linux._decoded_path(arguments)
         if (path == "/dev/null" and call in linux._OPEN_CALLS and "O_RDONLY" in arguments
                 and stat.S_ISCHR(os.stat("/dev/null").st_mode) and os.stat("/dev/null").st_rdev == os.makedev(1, 3)):
+            continue
+        # glibc reads the kernel overcommit policy once per process, from
+        # whichever thread first trims a non-main malloc heap, to choose
+        # between unmapping and advising freed pages. The byte only tunes
+        # memory release, and the probe's position relative to the
+        # acknowledgement is arbitrary, so an observed input set must not
+        # depend on it. A check opening the same sysctl read-only is
+        # indistinguishable and shares this exception; metadata calls on
+        # it and every other application proc read stay dynamic.
+        if (path == ALLOCATOR_POLICY_PROBE and call in {"open", "openat"}
+                and arguments.endswith('", O_RDONLY|O_CLOEXEC')):
+            continue
+        # V8 may map the running Node image again to relocate its embedded
+        # builtins, depending on where address-space randomization placed the
+        # code range. Execution and the receipt's runtime digest already bind
+        # that image, so this plain read-only open adds no input and must
+        # not vary the observed set between two executions.
+        if (image and call in {"open", "openat"} and arguments.endswith('", O_RDONLY')
+                and image in {path, linux._fd_path(result)}):
             continue
         if path == ready and call in {"access", "stat", "newfstatat"}:
             if linux._return_integer(result) == 0:

--- a/hooks/click_framework_observer.py
+++ b/hooks/click_framework_observer.py
@@ -135,7 +135,8 @@ def run_command(argv, *, runtime_inputs: bool = True, previous=None,
         tree = processes.inspect(raw, **options)
         if collector and collector.location:
             projection = conditional.project_capture(raw, project=project, cwd=kwargs["workspace"],
-                                                     directory=collector.location.name, **options)
+                                                     directory=collector.location.name,
+                                                     runtime=collector.runtime_path, **options)
     collector = node_observer.Collector(argv, dict(kwargs["environment"]), Path(kwargs["workspace"])) if runtime_inputs else None
     before = None
     external_before = None

--- a/hooks/click_node_observer.py
+++ b/hooks/click_node_observer.py
@@ -233,19 +233,29 @@ class Collector:
     def close(self):
         if self.child is not None:
             try:
-                try:
-                    self.child.stdin.close()
-                except OSError:
-                    pass
+                self.child.stdin.close()
+            except OSError:
+                pass
+        # The controller reads the FIFO through a blocking pool thread, and
+        # its exit joins that pool. Unlink first so a late target cannot
+        # block opening a reader-less FIFO, then release the last writer so
+        # the pending read returns EOF instead of outliving a 5s wait.
+        if self.location is not None:
+            try:
+                (Path(self.location.name) / "endpoints.pipe").unlink()
+            except OSError:
+                pass
+        if self.descriptor is not None:
+            os.close(self.descriptor)
+            self.descriptor = None
+        if self.child is not None:
+            try:
                 if self.child.poll() is None:
                     self.child.wait(timeout=5)
             except (OSError, subprocess.TimeoutExpired):
                 click_process.terminate_process_group(self.child, grace_seconds=0.2)
             self.child.stdout.close()
             self.child = None
-        if self.descriptor is not None:
-            os.close(self.descriptor)
-            self.descriptor = None
         if self.location is not None:
             self.location.cleanup()
             self.location = None

--- a/tests/test_click_conditional_observation.py
+++ b/tests/test_click_conditional_observation.py
@@ -87,6 +87,50 @@ class ConditionalSnapshotTests(unittest.TestCase):
             raw=(base+line+'\n100 exit_group(0) = ?\n100 +++ exited with 0 +++\n').encode()
             self.assertIsNone(conditional.project_capture(raw, project=self.root, cwd=self.root, directory=directory))
 
+    @unittest.skipUnless(sys.platform == 'linux', 'Linux strace projection')
+    def test_projection_excludes_the_allocator_policy_probe_from_any_thread_at_any_time(self):
+        # glibc reads this sysctl once, from whichever thread first trims a
+        # non-main heap; the observed input set must not depend on that timing.
+        root, directory = self.root.resolve(), self.root / 'observer'
+        probe = f'101 openat(AT_FDCWD<{root}>, "{conditional.ALLOCATOR_POLICY_PROBE}", O_RDONLY|O_CLOEXEC) = 28<{conditional.ALLOCATOR_POLICY_PROBE}>'
+        def project(before=(), after=()):
+            lines = ['100 execve("/usr/bin/node", ["node"], 0x1) = 0',
+                     '100 clone3({flags=CLONE_VM|CLONE_FILES|CLONE_THREAD, exit_signal=0}, 88) = 101',
+                     *before, f'100 access("{directory}/ready-100", F_OK) = 0', *after,
+                     f'100 openat(AT_FDCWD<{root}>, "input.txt", O_RDONLY|O_CLOEXEC) = 29<{root}/input.txt>',
+                     '101 exit(0) = ?', '100 exit_group(0) = ?', '100 +++ exited with 0 +++']
+            return conditional.project_capture(('\n'.join(lines) + '\n').encode(), project=self.root, cwd=self.root, directory=directory)
+        expected = project()
+        self.assertEqual(expected['inputs'], [{'path': 'input.txt', 'kind': 'file', 'operations': ['read']}])
+        self.assertEqual(project(before=[probe]), expected)
+        self.assertEqual(project(after=[probe]), expected)
+        self.assertEqual(project(after=[probe.replace('101 ', '100 ', 1)]), expected)
+        # Metadata or a differently shaped open of the same sysctl is an
+        # application introspection input and keeps the projection dynamic.
+        self.assertIsNone(project(after=[f'100 statx(AT_FDCWD<{root}>, "{conditional.ALLOCATOR_POLICY_PROBE}", AT_STATX_SYNC_AS_STAT, STATX_ALL, {{stx_mode=S_IFREG|0644}}) = 0']))
+        self.assertIsNone(project(after=[probe.replace('O_RDONLY|O_CLOEXEC', 'O_RDONLY')]))
+
+    @unittest.skipUnless(sys.platform == 'linux', 'Linux strace projection')
+    def test_projection_does_not_vary_with_the_engine_remapping_its_own_image(self):
+        # Whether V8 maps the running Node image again depends on address-space
+        # randomization; the image is bound by execution and the runtime digest.
+        root, directory = self.root.resolve(), self.root / 'observer'
+        runtime = Path('/opt/click-fixture/node/bin/node')
+        remap = f'100 openat(AT_FDCWD<{root}>, "{runtime}", O_RDONLY) = 20<{runtime}>'
+        def project(extra=(), **kwargs):
+            lines = [f'100 execve("{runtime}", ["node"], 0x1) = 0', *extra,
+                     f'100 access("{directory}/ready-100", F_OK) = 0',
+                     f'100 openat(AT_FDCWD<{root}>, "input.txt", O_RDONLY|O_CLOEXEC) = 29<{root}/input.txt>',
+                     '100 exit_group(0) = ?', '100 +++ exited with 0 +++']
+            return conditional.project_capture(('\n'.join(lines) + '\n').encode(), project=self.root, cwd=self.root, directory=directory, **kwargs)
+        expected = project(runtime=runtime)
+        self.assertEqual(expected['external'], [{'path': str(runtime), 'kind': 'file', 'operations': ['execute']}])
+        self.assertEqual(project([remap], runtime=runtime), expected)
+        # Without the runtime identity, and for an application read of the
+        # image, the read stays an ordinary operation on that external input.
+        for value in (project([remap]), project([remap.replace('O_RDONLY', 'O_RDONLY|O_CLOEXEC')], runtime=runtime)):
+            self.assertEqual(value['external'], [{'path': str(runtime), 'kind': 'file', 'operations': ['execute', 'read']}])
+
 
 @unittest.skipUnless(sys.platform == 'linux' and shutil.which('node') and shutil.which('strace'), 'Linux Node and strace required')
 class RealConditionalTests(unittest.TestCase):

--- a/tests/test_click_node_observer.py
+++ b/tests/test_click_node_observer.py
@@ -73,6 +73,9 @@ class RealNodeObservationTests(unittest.TestCase):
         self.assertFalse(self.record["reuse_authorized"])
         self.assertIn("engine-input-coverage-incomplete", self.record["reasons"])
         self.assertIsNotNone(controller.poll(), "observer process was stranded")
+        # The controller exits by itself once its FIFO writer is released;
+        # a terminated controller would report a signal exit instead.
+        self.assertEqual(controller.returncode, 0, "observer process did not exit after reporting")
         self.assertFalse(Path(directory).exists(), "transient observer directory was retained")
         self.assertNotIn("ws://", json.dumps(self.record))
         self.assertEqual(self.record["installed"], self.record["contexts"], self.record)


### PR DESCRIPTION
## Problem

`tests/test_click_conditional_observation.py::ConditionalHookTests` was flaky in CI:

- main run 34449083031 (`framework-observation (3.12.3, 9.1.1)`): `test_worker_input_runs_and_recovers_after_unsupported_code_is_removed` — `eligible_record(...)` False at `recover-learning`.
- PR #105 run 34550648512 (`deterministic-partitions (ubuntu-latest, 1)`): `test_default_hook_learns_then_reuses_and_reruns_changed_child` — BETA had `conditional_capture: null` at `learn-2`; `test_worker_input_runs_and_recovers_after_unsupported_code_is_removed` — ALPHA re-ran at `recover-reuse`.

All three are the same failure: `conditional.project_capture` intermittently produced a different result for two identical executions, so the learning → binding transition (which requires two executions observing the *same* input set) did not issue a receipt and the child re-ran. The `capture.status: "partial"` / `unresolved_event_count: 1` in the failing records is a red herring — it is the steady state for every observed run (the `ready-<pid>` handshake file flips from `missing` to `file`, which the shadow parser counts as a conflict; the conditional projection skips those lines).

## Root causes (both reproduced locally under CPU contention)

1. **glibc allocator probe.** `malloc`'s `check_may_shrink_heap()` opens `/proc/sys/vm/overcommit_memory` once per process, from whichever thread first trims a non-main arena heap — here the Inspector IO thread, at an arbitrary point relative to the handshake. The path was not in the bootstrap-probe allowlist, so whenever it appeared the projection was rejected as an application proc read (`return None` at the pseudo-file check) → `conditional_capture: null` → not eligible → no receipt.
2. **V8 self-remap.** With `--short-builtin-calls` (default), V8 re-opens the running Node image read-only (`OS::RemapPages`) to relocate embedded builtins into the code range — but only when address-space randomization places the code range out of pc-relative reach of the embedded blob. Verified: `--no-short-builtin-calls` removes the open in 12/12 runs. This toggled the Node binary's external row between `['execute']` and `['execute','read']` between consecutive runs, so `issue()` saw `external_after != external_before` and refused the receipt.

Binding either as an input would not help: `issue()` requires the learning and binding executions to observe the same set, and both reads are per-process nondeterministic. Both are runtime facilities: the overcommit byte only tunes memory release, and the Node image is already bound by `execute` and by the receipt's `runtime.node_digest`.

## Changes

- `hooks/click_conditional_observer.py`: `project_capture` skips glibc's exact probe shape (`open`/`openat` of `/proc/sys/vm/overcommit_memory` with `O_RDONLY|O_CLOEXEC`) from any thread at any time, and V8's plain `O_RDONLY` self-open of the observed runtime image (new optional `runtime=` argument). Metadata calls on the sysctl, every other application proc read and application reads of the image stay dynamic (covered by tests).
- `hooks/click_framework_observer.py`: passes `collector.runtime_path` to the projection.
- `hooks/click_node_observer.py`: `Collector.close()` now unlinks the endpoint FIFO and releases the runner's writer *before* waiting for the controller. The controller reads the FIFO through a blocking libuv threadpool `read()`, and `process.exit(0)` joins that pool, so previously every observed execution hit the 5 s `wait(timeout=5)` and SIGKILLed the controller. `finish()` drops from ~5.3 s to ~0.08 s per execution (measured), which shortens each `ConditionalHookTests` run by roughly a minute and removes a termination path from the steady state.
- Tests: synthetic-trace unit tests for both projection rules (including the negative cases), and `RealNodeObservationTests.execute` now asserts the controller exited on its own (`returncode == 0`; the old path ends in a signal exit).
- Docs: `docs/architecture/node-runtime-observation.md` assumptions list and collection lifecycle; `RELEASE_NOTES.md` unreleased bullet. The existing "historical trigger remains unconfirmed" note is about the authoritative-path opposite-child decision and is unrelated; left as is.
- Rebased onto #105; `dist/antigravity` and `dist/claude` rebuilt with both build scripts, byte-identical to `hooks/`; `scripts/validate_distribution.py` passes (Codex, Antigravity and Claude Code plugins).

## Verification

Environment mirrors CI: Ubuntu 24.04, strace 6.8, glibc 2.39, Node 22.23.2 (same `NODE_DIGEST`), Jest 30 / Vitest 5 fixtures via `npm ci`, pytest 9.1.1 in a venv, `hooks.click_observer_runtime prepare`.

- Reproduction harness (drives `framework.run_command` like the Hook, chained `previous`, pinned to 2 CPUs shared with 6 busy loops): **before** — projection rejected at iteration 19/40 (`/proc/sys/vm/overcommit_memory`), receipt refused at 33–34/80 (Node image `read` toggled); **after** — 0/120 failures, every iteration after the first issued a receipt.
- Also measured the tracee-exit → strace FIFO-EOF gap (the `-D` flush race): ≤0.4 ms idle, ≤0.1 ms under 6× oversubscription, so the `reader.join(timeout=1)` is not a realistic hazard and was left alone.
- `python3 -B -m unittest tests.test_click_conditional_observation` × 12 pinned to 2 CPUs shared with 6 busy loops (plus another session's unrelated test run on the machine): 12/12 PASS, 14 tests each, 91–122 s per run (the unstressed baseline before the fix was 109 s, so the removed 5 s controller stalls roughly cancel the contention).
- CI `framework-observation` module set (`test_click_automatic_observation test_click_framework_observation test_click_framework_candidates test_click_node_observer`): 70 tests, OK, none skipped, with pytest 9.1.1 and real native preparation.
- `scripts/validate_distribution.py`, `scripts/check_doc_links.py`, `tests.test_repository_policy`, `tests.test_distribution_validation`, `git diff --check`, `compileall`: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
