### PR TITLE
Bind one search-path identity for the Hook and the runner

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,6 +30,14 @@ This candidate remains unreleased. See `docs/architecture/automatic-observation.
   dashboard show the output the host did not read again as an estimate (bytes
   and an approximate token count at four bytes per token). It is a disclosed
   estimate of avoided reading, never a time or cost claim.
+- A receipt's environment fingerprint normalizes the search path: repeated
+  entries and Click's own command directory are dropped. A host that offers
+  Click's commands by adding the plugin's directory to the search path of the
+  tool call that runs a verification, but not to the Hook process that decides
+  reuse, made every receipt's environment digest differ from the one recomputed
+  at the next request, so on Claude Code every check reran with
+  `environment-binding-changed` and no reuse was ever possible. Execution still
+  receives the host's real search path; only the receipt subset is normalized.
 - Observed-input identity is content-based: type and permission bits, file
   content, directory membership, metadata-only size and symlink text. Inode
   numbers, link counts, ownership and timestamps no longer invalidate a native

--- a/dist/antigravity/hooks/click_verification_bindings.py
+++ b/dist/antigravity/hooks/click_verification_bindings.py
@@ -215,6 +215,51 @@ def verification_environment(*, cwd: Path) -> dict[str, str]:
     return environment
 
 
+SEARCH_PATH_KEYS = frozenset({"PATH"})
+
+
+def _own_command_directories() -> set[str]:
+    """Directories a host adds to the search path to offer Click's commands."""
+    directories: set[str] = set()
+    # Plain path text, so a host whose separator rules are emulated in a test
+    # cannot make locating Click's own directory raise.
+    candidates = [os.path.dirname(os.path.dirname(os.path.abspath(__file__)))]
+    configured = os.environ.get("CLAUDE_PLUGIN_ROOT", "").strip()
+    if configured:
+        candidates.append(configured)
+    for root in candidates:
+        try:
+            directories.add(os.path.normcase(os.path.join(root, "bin")))
+        except (OSError, RuntimeError, ValueError, TypeError):
+            continue
+    return directories
+
+
+def normalized_search_path(value: str) -> str:
+    """Drop repeated entries and Click's own command directory.
+
+    A host can offer Click's commands by adding the plugin's own directory to
+    the search path of the tool call that runs a verification, while the Hook
+    process that decides reuse never sees it, and either side can repeat an
+    entry. Neither difference changes which executable a check resolves to --
+    a repeat can never win over its first occurrence, and Click's own
+    directory holds only Click's commands -- and the executables a check
+    actually resolves are fingerprinted separately by content. Normalizing
+    here keeps one environment identity for one environment, instead of one
+    per process that computes it.
+    """
+    own = _own_command_directories()
+    entries: list[str] = []
+    seen: set[str] = set()
+    for entry in str(value).split(os.pathsep):
+        key = os.path.normcase(entry)
+        if key in own or key in seen:
+            continue
+        seen.add(key)
+        entries.append(entry)
+    return os.pathsep.join(entries)
+
+
 def environment_fingerprint(environment: dict[str, str], *, cwd: Path | None = None) -> dict[str, str]:
     """Return the subset of an execution environment that binds a receipt."""
     exact: set[str] = set()
@@ -227,7 +272,11 @@ def environment_fingerprint(environment: dict[str, str], *, cwd: Path | None = N
     except (OSError, RuntimeError, ValueError, NotImplementedError):
         exact, prefixes = set(), set()
     return {
-        str(key): str(value)
+        str(key): (
+            normalized_search_path(str(value))
+            if verification_environment_key(str(key)) in SEARCH_PATH_KEYS
+            else str(value)
+        )
         for key, value in environment.items()
         if environment_key_is_fingerprinted(str(key), exact=exact, prefixes=prefixes)
     }

--- a/dist/claude/hooks/click_verification_bindings.py
+++ b/dist/claude/hooks/click_verification_bindings.py
@@ -215,6 +215,51 @@ def verification_environment(*, cwd: Path) -> dict[str, str]:
     return environment
 
 
+SEARCH_PATH_KEYS = frozenset({"PATH"})
+
+
+def _own_command_directories() -> set[str]:
+    """Directories a host adds to the search path to offer Click's commands."""
+    directories: set[str] = set()
+    # Plain path text, so a host whose separator rules are emulated in a test
+    # cannot make locating Click's own directory raise.
+    candidates = [os.path.dirname(os.path.dirname(os.path.abspath(__file__)))]
+    configured = os.environ.get("CLAUDE_PLUGIN_ROOT", "").strip()
+    if configured:
+        candidates.append(configured)
+    for root in candidates:
+        try:
+            directories.add(os.path.normcase(os.path.join(root, "bin")))
+        except (OSError, RuntimeError, ValueError, TypeError):
+            continue
+    return directories
+
+
+def normalized_search_path(value: str) -> str:
+    """Drop repeated entries and Click's own command directory.
+
+    A host can offer Click's commands by adding the plugin's own directory to
+    the search path of the tool call that runs a verification, while the Hook
+    process that decides reuse never sees it, and either side can repeat an
+    entry. Neither difference changes which executable a check resolves to --
+    a repeat can never win over its first occurrence, and Click's own
+    directory holds only Click's commands -- and the executables a check
+    actually resolves are fingerprinted separately by content. Normalizing
+    here keeps one environment identity for one environment, instead of one
+    per process that computes it.
+    """
+    own = _own_command_directories()
+    entries: list[str] = []
+    seen: set[str] = set()
+    for entry in str(value).split(os.pathsep):
+        key = os.path.normcase(entry)
+        if key in own or key in seen:
+            continue
+        seen.add(key)
+        entries.append(entry)
+    return os.pathsep.join(entries)
+
+
 def environment_fingerprint(environment: dict[str, str], *, cwd: Path | None = None) -> dict[str, str]:
     """Return the subset of an execution environment that binds a receipt."""
     exact: set[str] = set()
@@ -227,7 +272,11 @@ def environment_fingerprint(environment: dict[str, str], *, cwd: Path | None = N
     except (OSError, RuntimeError, ValueError, NotImplementedError):
         exact, prefixes = set(), set()
     return {
-        str(key): str(value)
+        str(key): (
+            normalized_search_path(str(value))
+            if verification_environment_key(str(key)) in SEARCH_PATH_KEYS
+            else str(value)
+        )
         for key, value in environment.items()
         if environment_key_is_fingerprinted(str(key), exact=exact, prefixes=prefixes)
     }

--- a/hooks/click_verification_bindings.py
+++ b/hooks/click_verification_bindings.py
@@ -215,6 +215,51 @@ def verification_environment(*, cwd: Path) -> dict[str, str]:
     return environment
 
 
+SEARCH_PATH_KEYS = frozenset({"PATH"})
+
+
+def _own_command_directories() -> set[str]:
+    """Directories a host adds to the search path to offer Click's commands."""
+    directories: set[str] = set()
+    # Plain path text, so a host whose separator rules are emulated in a test
+    # cannot make locating Click's own directory raise.
+    candidates = [os.path.dirname(os.path.dirname(os.path.abspath(__file__)))]
+    configured = os.environ.get("CLAUDE_PLUGIN_ROOT", "").strip()
+    if configured:
+        candidates.append(configured)
+    for root in candidates:
+        try:
+            directories.add(os.path.normcase(os.path.join(root, "bin")))
+        except (OSError, RuntimeError, ValueError, TypeError):
+            continue
+    return directories
+
+
+def normalized_search_path(value: str) -> str:
+    """Drop repeated entries and Click's own command directory.
+
+    A host can offer Click's commands by adding the plugin's own directory to
+    the search path of the tool call that runs a verification, while the Hook
+    process that decides reuse never sees it, and either side can repeat an
+    entry. Neither difference changes which executable a check resolves to --
+    a repeat can never win over its first occurrence, and Click's own
+    directory holds only Click's commands -- and the executables a check
+    actually resolves are fingerprinted separately by content. Normalizing
+    here keeps one environment identity for one environment, instead of one
+    per process that computes it.
+    """
+    own = _own_command_directories()
+    entries: list[str] = []
+    seen: set[str] = set()
+    for entry in str(value).split(os.pathsep):
+        key = os.path.normcase(entry)
+        if key in own or key in seen:
+            continue
+        seen.add(key)
+        entries.append(entry)
+    return os.pathsep.join(entries)
+
+
 def environment_fingerprint(environment: dict[str, str], *, cwd: Path | None = None) -> dict[str, str]:
     """Return the subset of an execution environment that binds a receipt."""
     exact: set[str] = set()
@@ -227,7 +272,11 @@ def environment_fingerprint(environment: dict[str, str], *, cwd: Path | None = N
     except (OSError, RuntimeError, ValueError, NotImplementedError):
         exact, prefixes = set(), set()
     return {
-        str(key): str(value)
+        str(key): (
+            normalized_search_path(str(value))
+            if verification_environment_key(str(key)) in SEARCH_PATH_KEYS
+            else str(value)
+        )
         for key, value in environment.items()
         if environment_key_is_fingerprinted(str(key), exact=exact, prefixes=prefixes)
     }

--- a/tests/test_click_verification_bindings.py
+++ b/tests/test_click_verification_bindings.py
@@ -127,6 +127,37 @@ class VerificationBindingStageTests(unittest.TestCase):
             self.assertEqual(first, second)
             self.assertEqual(digest.call_count, 2 * per_stage)
 
+    def test_the_search_path_binds_the_same_identity_in_hook_and_runner(self):
+        own = sorted(bindings._own_command_directories())[0]
+        plugin_bin = str(Path(own))
+        entries = ["/usr/local/bin", "/usr/bin", "/home/user/.local/bin"]
+        # The Hook process sees a repeated entry; the tool call that runs the
+        # verification sees Click's own command directory appended instead.
+        hook = os.pathsep.join([*entries, "/usr/bin"])
+        runner = os.pathsep.join([*entries, plugin_bin])
+        self.assertNotEqual(hook, runner)
+        self.assertEqual(
+            bindings.normalized_search_path(hook), bindings.normalized_search_path(runner)
+        )
+        self.assertEqual(bindings.normalized_search_path(hook), os.pathsep.join(entries))
+        # Order and every distinct directory are preserved: a repeat can never
+        # win over its first occurrence, so dropping it changes no resolution.
+        self.assertEqual(
+            bindings.normalized_search_path(os.pathsep.join(["/b", "/a", "/b"])),
+            os.pathsep.join(["/b", "/a"]),
+        )
+        # Only the search path is normalized; other values stay verbatim.
+        fingerprint = bindings.environment_fingerprint(
+            {"PATH": hook, "TZ": "UTC" + os.pathsep + "UTC"}
+        )
+        self.assertEqual(fingerprint["PATH"], os.pathsep.join(entries))
+        self.assertEqual(fingerprint["TZ"], "UTC" + os.pathsep + "UTC")
+        # A real directory difference still changes the identity.
+        self.assertNotEqual(
+            bindings.normalized_search_path(hook),
+            bindings.normalized_search_path(os.pathsep.join([*entries, "/opt/tools/bin"])),
+        )
+
     def test_environment_fingerprint_is_an_allowlist_with_owner_extension(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory).resolve()


### PR DESCRIPTION
## Summary

**On Claude Code, Click never reused anything.** Found while running the real-token A/B: every decision in every session came back `environment-binding-changed`, and `[Click 결과]` said `실제 재사용 없음` every time. The minimal reproduction is two identical `click-gate verify` calls with nothing changed in between — the second one still reran.

Cause: the search path is part of a receipt's environment fingerprint, and the two processes that compute it do not see the same one.

```
runner (the tool call that runs the verification), 18 entries:
  …:/snap/bin:/…/skills-plugin/…/bin:/…/dist/claude/bin
Hook (the process that decides reuse), 17 entries:
  …:/snap/bin:/snap/bin:/…/skills-plugin/…/bin
```

The host adds the plugin's own `bin` to the search path of the tool call so Click's commands resolve, and does not add it to the Hook subprocess; the two also repeat different entries. So the digest the runner stored with the receipt could never equal the digest the Hook recomputed at the next request. #108's allowlist removed session-variable noise but not this asymmetry, because `PATH` is legitimately fingerprinted.

## Fix

`environment_fingerprint` normalizes the search path value, and only there — execution still receives the host's real `PATH`:

- **Repeated entries are dropped.** A repeat can never win over its first occurrence, so removing it changes no resolution.
- **Click's own command directory is dropped.** It holds only Click's commands, it is present exactly when the host chose to offer them, and the executables a check actually resolves are fingerprinted separately by content.

Measured on this host: 17 and 18 entries normalize onto the same 12.

| | before | after |
|---|---|---|
| two identical verifications, nothing changed | `run · environment-binding-changed` | **`reuse-exact · same-revision-receipt-current`** |

Verified in a live Claude Code session against the built plugin, not only in the harness.

## Why this matters

Every earlier measurement of Click on this host was measuring a runtime that could not reuse. The reuse-rate work in #108 and the performance work in #112 were real but invisible here; this is the change that lets any of it show.

## Tests
- New `test_the_search_path_binds_the_same_identity_in_hook_and_runner` (`test_click_verification_bindings`): the Hook's repeated entry and the runner's appended plugin directory normalize to the same value, order and every distinct directory are preserved, a real new directory still changes the identity, and no other variable is normalized.
- `_own_command_directories` uses path text rather than `pathlib`, so the existing Windows-emulating test (`test_windows_environment_binding_is_case_insensitive`, which patches `os.name`) cannot raise on a POSIX host.
- Ran in a clean environment: `test_click_verification_bindings`, `test_click_gate_verification`, `test_click_verification_freshness`, `test_click_authoritative_reuse`, `test_click_automatic_observation`, `test_repository_policy`, `test_click_verification_economics` — 235 + 141 tests, green — plus `build_antigravity_distribution.py`, `build_claude_distribution.py`, `validate_distribution.py`, `check_doc_links.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)