### PR TITLE
Let the ETW smoke test report event loss instead of failing on it

### DIFF
--- a/tests/test_click_observer_windows.py
+++ b/tests/test_click_observer_windows.py
@@ -751,6 +751,17 @@ class WindowsNativeSmokeTests(unittest.TestCase):
             self.assertEqual(result.record["backend"]["name"], "windows-etw")
             self.assertIn(result.record["status"], {"complete", "partial"})
             self.assertGreaterEqual(result.record["child_process_count"], 1)
+            lost = set(result.record["ineligibility_reasons"]) & {
+                "unresolved-event", "process-tree-incomplete", "event-loss"
+            }
+            if lost:
+                # The backend itself reports that it lost events on this host.
+                # The record must say so honestly and grant nothing; it cannot
+                # then be asked for an input it told us it did not see. A skip
+                # keeps the loss visible in the run summary.
+                self.assertEqual(result.record["status"], "partial", result.record)
+                self.assertFalse(result.record["reuse_authorized"], result.record)
+                self.skipTest(f"ETW lost events on this host: {sorted(lost)}")
             self.assertTrue(
                 any(
                     item["path"].lower() == "input.txt"


### PR DESCRIPTION
## Summary

`deterministic-partitions (windows-latest, 1)` failed on #110 in `test_native_etw_observes_child_input_without_workspace_artifacts`. The record it printed:

```
status: partial · ineligibility_reasons: [observation-partial, process-tree-incomplete, shadow-mode, unresolved-event]
unresolved_event_count: 2 · process_tree_complete: false · inputs: []
```

ETW lost the child's events on the runner, said so, and granted nothing — and the test then failed because the input it had just reported losing was not in `inputs`. The same job passed on #113's Windows run; this is the ETW-completeness flake family that #114 addressed for the authoritative observer, unrelated to #110's Linux change.

## Change (test only)

When the backend reports loss (`unresolved-event`, `process-tree-incomplete`, `event-loss`), the test asserts the record is honest — `status == "partial"`, `reuse_authorized == False` — and **skips** with the loss in the reason, so a runner that keeps losing events stays visible in the summary instead of failing the job or passing silently. A complete capture is still required to show `input.txt`.

## Tests
`tests.test_click_observer_windows` (skips off Windows) and `tests.test_repository_policy` — green locally; the change is exercised by the Windows partition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)