### PR TITLE
Show both projections when a conditional receipt is refused

### DIFF
--- a/tests/test_click_conditional_observation.py
+++ b/tests/test_click_conditional_observation.py
@@ -204,7 +204,14 @@ class RealConditionalTests(unittest.TestCase):
                 self.assertEqual(output['process'].stdout.data.count(b'RAN-ONCE'),1)
                 self.assertTrue(framework.record_valid(execution.record),execution.record)
                 self.assertTrue(conditional.eligible_record(execution.record),(self.projection_diagnostics, execution.record))
-                self.assertEqual(execution.envelope is None,learning,execution.record)
+                # A refused receipt means the two runs' projections differed or
+                # issue() declined for another reason; show both sides, so a
+                # host-only refusal can be read from the failure alone.
+                self.assertEqual(execution.envelope is None,learning,{
+                    'diagnostics': self.projection_diagnostics,
+                    'learning_capture': previous.get('conditional_capture') if isinstance(previous, dict) else None,
+                    'binding_capture': execution.record.get('conditional_capture'),
+                    'record': {key: execution.record.get(key) for key in ('capture','runtime','workers')}})
                 previous=execution.record
             envelope=execution.envelope
             observation=conditional.verify(envelope,secret=runner_token,expected_binding=context)


### PR DESCRIPTION
## Summary

`framework-observation (3.12.14, 9.1.1)` failed once on #110 in `RealConditionalTests.test_real_execution_attestation_and_per_input_invalidation`:

```
self.assertEqual(execution.envelope is None, learning, execution.record)
AssertionError: True != False
```

The binding record was eligible (the preceding assertion passed) yet `issue()` refused the receipt — which happens when the learning and binding projections differ, or when a snapshot cannot be taken. The failure printed only the binding record, so the differing rows could not be read. Locally the test passes 8 of 8 and the same job passed on `main` and #112; the refusal is host-specific and needs the missing half to be diagnosed.

## Change (test only)
The assertion message now carries the learning capture, the binding capture, the projection diagnostics and the runtime record. No behavior changes; the next refusal on a runner will name the rows that differed.

## Tests
`tests.test_click_conditional_observation.RealConditionalTests` and `tests.test_repository_policy` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)