### PR TITLE
Check for reported ETW loss before requiring a child process

### DIFF
--- a/tests/test_click_observer_windows.py
+++ b/tests/test_click_observer_windows.py
@@ -750,18 +750,19 @@ class WindowsNativeSmokeTests(unittest.TestCase):
             self.assertEqual(fallback_calls, [], result.record)
             self.assertEqual(result.record["backend"]["name"], "windows-etw")
             self.assertIn(result.record["status"], {"complete", "partial"})
-            self.assertGreaterEqual(result.record["child_process_count"], 1)
             lost = set(result.record["ineligibility_reasons"]) & {
                 "unresolved-event", "process-tree-incomplete", "event-loss"
             }
             if lost:
-                # The backend itself reports that it lost events on this host.
-                # The record must say so honestly and grant nothing; it cannot
-                # then be asked for an input it told us it did not see. A skip
-                # keeps the loss visible in the run summary.
+                # The backend itself reports that it lost events on this host —
+                # sometimes the whole child. The record must say so honestly
+                # and grant nothing; it cannot then be asked for a process or
+                # an input it told us it did not see. A skip keeps the loss
+                # visible in the run summary.
                 self.assertEqual(result.record["status"], "partial", result.record)
                 self.assertFalse(result.record["reuse_authorized"], result.record)
                 self.skipTest(f"ETW lost events on this host: {sorted(lost)}")
+            self.assertGreaterEqual(result.record["child_process_count"], 1, result.record)
             self.assertTrue(
                 any(
                     item["path"].lower() == "input.txt"


### PR DESCRIPTION
## Summary

`deterministic-partitions (windows-latest, 3)` failed on #115 in `test_native_etw_observes_child_input_without_workspace_artifacts`:

```
self.assertGreaterEqual(result.record["child_process_count"], 1)
AssertionError: 0 not greater than or equal to 1
```

#117 made this test skip visibly when the ETW backend reports that it lost events — but the child-count assertion runs *before* that check, so a capture in which ETW lost the whole child still failed on the count.

## Change (test only)
The loss check moves ahead of the child-count assertion. A record that reports nothing lost must still show the child process and its input; the count assertion now carries the record for diagnosis.

## Tests
`tests.test_click_observer_windows` (skips off Windows) and `tests.test_repository_policy` — green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)