### PR TITLE
Do not record the interpreter's optional self-read as a conditional input

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -40,6 +40,13 @@ This candidate remains unreleased. See `docs/architecture/automatic-observation.
   Node Worker is now detected explicitly — the isolate announces itself to the
   collector — so a Worker run is denied a receipt by its count rather than by
   where its own probe happened to land.
+- The conditional JS projection no longer records whether the executed
+  interpreter read its own binary. V8 re-opens the Node executable for its
+  builtin remap depending on where ASLR placed it, so the same check produced
+  `["execute"]` in one run and `["execute", "read"]` in the next and the
+  receipt was refused for an input difference that no application read made.
+  The binary's identity stays bound by the receipt's runtime digest and by the
+  row's content digest.
 - A receipt's environment fingerprint normalizes the search path: repeated
   entries and Click's own command directory are dropped. A host that offers
   Click's commands by adding the plugin's directory to the search path of the

--- a/dist/antigravity/hooks/click_conditional_observer.py
+++ b/dist/antigravity/hooks/click_conditional_observer.py
@@ -133,6 +133,14 @@ ordinary inputs. No application read is removed because it is later written.
         # Pseudo-files and devices consumed by application code are dynamic.
         if path.parts[1:2] in [("proc",), ("sys",), ("dev",)]:
             return None
+        if "execute" in row["operations"] and "read" in row["operations"]:
+            # V8 re-opens its own binary for the builtin remap depending on
+            # where ASLR placed it, so the executed interpreter is read in one
+            # run and not the next. The binary's identity is already bound by
+            # the receipt's runtime digest and by this row's content digest;
+            # whether the engine happened to read its own image is not an
+            # input the check consumed.
+            row = {**row, "operations": sorted(op for op in row["operations"] if op != "read")}
         external.append(row)
     return {"inputs": list(parsed.inputs), "external": external}
 

--- a/dist/claude/hooks/click_conditional_observer.py
+++ b/dist/claude/hooks/click_conditional_observer.py
@@ -133,6 +133,14 @@ ordinary inputs. No application read is removed because it is later written.
         # Pseudo-files and devices consumed by application code are dynamic.
         if path.parts[1:2] in [("proc",), ("sys",), ("dev",)]:
             return None
+        if "execute" in row["operations"] and "read" in row["operations"]:
+            # V8 re-opens its own binary for the builtin remap depending on
+            # where ASLR placed it, so the executed interpreter is read in one
+            # run and not the next. The binary's identity is already bound by
+            # the receipt's runtime digest and by this row's content digest;
+            # whether the engine happened to read its own image is not an
+            # input the check consumed.
+            row = {**row, "operations": sorted(op for op in row["operations"] if op != "read")}
         external.append(row)
     return {"inputs": list(parsed.inputs), "external": external}
 

--- a/hooks/click_conditional_observer.py
+++ b/hooks/click_conditional_observer.py
@@ -133,6 +133,14 @@ ordinary inputs. No application read is removed because it is later written.
         # Pseudo-files and devices consumed by application code are dynamic.
         if path.parts[1:2] in [("proc",), ("sys",), ("dev",)]:
             return None
+        if "execute" in row["operations"] and "read" in row["operations"]:
+            # V8 re-opens its own binary for the builtin remap depending on
+            # where ASLR placed it, so the executed interpreter is read in one
+            # run and not the next. The binary's identity is already bound by
+            # the receipt's runtime digest and by this row's content digest;
+            # whether the engine happened to read its own image is not an
+            # input the check consumed.
+            row = {**row, "operations": sorted(op for op in row["operations"] if op != "read")}
         external.append(row)
     return {"inputs": list(parsed.inputs), "external": external}
 

--- a/tests/test_click_conditional_observation.py
+++ b/tests/test_click_conditional_observation.py
@@ -128,6 +128,22 @@ class ConditionalSnapshotTests(unittest.TestCase):
                                                      node_path='/usr/bin/node', backend_path='/usr/bin/strace'),
                          'record not eligible')
 
+    @unittest.skipUnless(sys.platform == 'linux', 'the projection reads a Linux strace capture')
+    def test_the_interpreters_optional_self_read_does_not_change_its_external_row(self):
+        directory = self.root / 'observer'
+        node = shutil.which('node') or '/usr/bin/node'
+        base = f'100 execve("{node}", ["node"], 0x1) = 0\n100 access("{directory}/ready-100", F_OK) = 0\n'
+        tail = '\n100 exit_group(0) = ?\n100 +++ exited with 0 +++\n'
+        # V8 sometimes re-opens the executed binary for its builtin remap; the
+        # two runs must project the same row for it.
+        without = conditional.project_capture((base + tail.lstrip('\n')).encode(), project=self.root, cwd=self.root, directory=directory)
+        with_read = conditional.project_capture((base + f'100 openat(AT_FDCWD, "{node}", O_RDONLY|O_CLOEXEC) = 3<{node}>' + tail).encode(),
+                                                project=self.root, cwd=self.root, directory=directory)
+        self.assertIsNotNone(without); self.assertIsNotNone(with_read)
+        rows = lambda projection: [r for r in projection['external'] if r['path'] == node]
+        self.assertEqual(rows(without), rows(with_read))
+        self.assertEqual(rows(with_read)[0]['operations'], ['execute'])
+
     def test_projection_keeps_application_proc_read_and_unknown_calls_ineligible(self):
         directory = self.root / 'observer'
         base = f'100 execve("/usr/bin/node", ["node"], 0x1) = 0\n100 access("{directory}/ready-100", F_OK) = 0\n'


### PR DESCRIPTION
## Summary

With #115 merged (probes excluded, Workers counted explicitly), one refusal mode remained on CI runners, and the refusal reason #115 added to the runner output named it exactly on #110 and #112:

```
inputs differed between the learning and binding runs:
  /opt/hostedtoolcache/node/22.23.2/x64/bin/node operations changed
learning: {"path": ".../bin/node", "kind": "file", "operations": ["execute"]}
binding:  {"path": ".../bin/node", "kind": "file", "operations": ["execute", "read"]}
```

(and the reverse order on the other PR.) V8 re-opens its own executable for the builtin remap depending on where ASLR placed it, so whether the interpreter *read* its own image varies between two runs of the same check on the same host. `issue()` correctly refuses a receipt when the two projections differ — and here they differed by a fact that no application read produced.

## Change
In `project_capture`, an executed external binary's optional `read` is dropped from its row's operations; both runs then describe the interpreter as `["execute"]`. Its identity remains bound twice over — by the receipt's `runtime.node_digest` and by the row's own content digest — so nothing about what the check consumed is lost. Project rows are untouched.

## Tests
- New `test_the_interpreters_optional_self_read_does_not_change_its_external_row` (Linux): two synthetic traces, one with and one without the self-open, project the same external row for the interpreter, with operations `["execute"]`.
- `ConditionalSnapshotTests`, `RealConditionalTests`, `ConditionalHookTests`, `test_repository_policy` — green; distributions rebuilt and validated.

This is the last refusal mode observed today; the refusal reason stays in the runner output so any further one will name itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)