### PR TITLE
Index the host runtime before forking shard workers

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -119,6 +119,10 @@ This candidate remains unreleased. See `docs/architecture/automatic-observation.
   reporting, bounded failure collection, Node framework observation and Shadow
   mode keep the sequential path. The result line shows the summed duration
   alongside the parallel wall clock when children overlapped.
+- The runner indexes the host runtime once before forking its shard workers,
+  so every child inherits the shared index instead of walking the runtime roots
+  itself. Three 3-second shards: workers admitted their targets at 0.75 s
+  instead of 1.76 s; wall 6.4 s → 5.1 s.
 - A receipt's environment fingerprint normalizes the search path: repeated
   entries and Click's own command directory are dropped. A host that offers
   Click's commands by adding the plugin's directory to the search path of the

--- a/dist/antigravity/hooks/click_verification_runner.py
+++ b/dist/antigravity/hooks/click_verification_runner.py
@@ -550,6 +550,21 @@ def _run_verification_impl(
         and not shadow_enabled
     ):
         parallel_blocks = _parallel_blocks(checks, parallel_groups, grouped_checks)
+    if parallel_blocks and authoritative_enabled and isinstance(authoritative_runtime, dict):
+        # Forked workers inherit this process's memory: index the host runtime
+        # once here so every child starts from the shared index instead of
+        # walking the runtime roots itself.
+        try:
+            (click_observation_inputs,) = click_import_bootstrap.load_siblings(
+                __package__, "click_observation_inputs"
+            )
+            click_observation_inputs.shared_runtime_index(
+                shadow_workspace,
+                str(authoritative_runtime["artifact_id"]),
+                profile=str(authoritative_runtime["profile"]),
+            )
+        except Exception:  # noqa: BLE001 - each worker's snapshot reports the real reason
+            pass
     # Shard children run in forked workers: the observer's snapshot work is
     # CPU-bound Python, so threads would only serialize it on the GIL. Each
     # worker returns its _CheckExecution over a pipe; the loop below consumes

--- a/dist/claude/hooks/click_verification_runner.py
+++ b/dist/claude/hooks/click_verification_runner.py
@@ -550,6 +550,21 @@ def _run_verification_impl(
         and not shadow_enabled
     ):
         parallel_blocks = _parallel_blocks(checks, parallel_groups, grouped_checks)
+    if parallel_blocks and authoritative_enabled and isinstance(authoritative_runtime, dict):
+        # Forked workers inherit this process's memory: index the host runtime
+        # once here so every child starts from the shared index instead of
+        # walking the runtime roots itself.
+        try:
+            (click_observation_inputs,) = click_import_bootstrap.load_siblings(
+                __package__, "click_observation_inputs"
+            )
+            click_observation_inputs.shared_runtime_index(
+                shadow_workspace,
+                str(authoritative_runtime["artifact_id"]),
+                profile=str(authoritative_runtime["profile"]),
+            )
+        except Exception:  # noqa: BLE001 - each worker's snapshot reports the real reason
+            pass
     # Shard children run in forked workers: the observer's snapshot work is
     # CPU-bound Python, so threads would only serialize it on the GIL. Each
     # worker returns its _CheckExecution over a pipe; the loop below consumes

--- a/hooks/click_verification_runner.py
+++ b/hooks/click_verification_runner.py
@@ -550,6 +550,21 @@ def _run_verification_impl(
         and not shadow_enabled
     ):
         parallel_blocks = _parallel_blocks(checks, parallel_groups, grouped_checks)
+    if parallel_blocks and authoritative_enabled and isinstance(authoritative_runtime, dict):
+        # Forked workers inherit this process's memory: index the host runtime
+        # once here so every child starts from the shared index instead of
+        # walking the runtime roots itself.
+        try:
+            (click_observation_inputs,) = click_import_bootstrap.load_siblings(
+                __package__, "click_observation_inputs"
+            )
+            click_observation_inputs.shared_runtime_index(
+                shadow_workspace,
+                str(authoritative_runtime["artifact_id"]),
+                profile=str(authoritative_runtime["profile"]),
+            )
+        except Exception:  # noqa: BLE001 - each worker's snapshot reports the real reason
+            pass
     # Shard children run in forked workers: the observer's snapshot work is
     # CPU-bound Python, so threads would only serialize it on the GIL. Each
     # worker returns its _CheckExecution over a pipe; the loop below consumes


### PR DESCRIPTION
## Summary

Follow-up to #128 (forked shard workers) and #130 (shared runtime index): the runner now builds the shared host-runtime index in the parent, before it forks. The workers inherit it through the fork instead of each walking the runtime roots themselves.

## Measurement

Three 3-second shards, three workers, same machine back to back:

| | targets admitted at | runner wall |
|---|---|---|
| before | +1.76 s | 6.44 s |
| after | +0.75 s | **5.14 s** |

## Notes

Guarded by the same conditions as the parallel path (Linux, actionable reporting, authoritative observer available). A failure to build the index here is ignored, and each worker's own snapshot then reports the real reason exactly as before.

## Tests

`tests/test_click_parallel_shards.py`, `tests/test_click_shared_runtime_index.py`, `tests/test_click_automatic_shards.py`, gate verification, repository policy and distribution validation run fail-closed on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)