### PR TITLE
Keep receipts valid when the host offers other plugins' commands

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,17 @@
 # Release notes
 
+## Unreleased v1.1 candidate
+
+- Receipts survive other installed plugins on Claude Code. The host appends
+  every installed plugin's `bin` directory to the tool call's search path, and
+  the environment fingerprint dropped only Click's own, so with any second
+  plugin installed the Hook and runner fingerprints differed on every request
+  (`Verification runner environment changed after preparation`) and no receipt
+  was ever reused. Every `plugins/cache/<marketplace>/<plugin>/<version>/bin`
+  entry is now treated as host-owned wherever Click itself is loaded from; the
+  executables a check resolves stay fingerprinted by content. Found while
+  recording `docs/history/agent-ab-2026-09-12/`.
+
 ## v1.0.0 — 2026-09-12 — automatic Evidence observation
 
 v1.0.0 publishes the automatic Evidence observation work that `main` carried

--- a/dist/antigravity/hooks/click_verification_bindings.py
+++ b/dist/antigravity/hooks/click_verification_bindings.py
@@ -219,16 +219,20 @@ def verification_environment(*, cwd: Path) -> dict[str, str]:
 SEARCH_PATH_KEYS = frozenset({"PATH"})
 
 
+def _own_roots() -> list[str]:
+    # Plain path text, so a host whose separator rules are emulated in a test
+    # cannot make locating Click's own directory raise.
+    roots = [os.path.dirname(os.path.dirname(os.path.abspath(__file__)))]
+    configured = os.environ.get("CLAUDE_PLUGIN_ROOT", "").strip()
+    if configured:
+        roots.append(configured)
+    return roots
+
+
 def _own_command_directories() -> set[str]:
     """Directories a host adds to the search path to offer Click's commands."""
     directories: set[str] = set()
-    # Plain path text, so a host whose separator rules are emulated in a test
-    # cannot make locating Click's own directory raise.
-    candidates = [os.path.dirname(os.path.dirname(os.path.abspath(__file__)))]
-    configured = os.environ.get("CLAUDE_PLUGIN_ROOT", "").strip()
-    if configured:
-        candidates.append(configured)
-    for root in candidates:
+    for root in _own_roots():
         try:
             directories.add(os.path.normcase(os.path.join(root, "bin")))
         except (OSError, RuntimeError, ValueError, TypeError):
@@ -236,25 +240,40 @@ def _own_command_directories() -> set[str]:
     return directories
 
 
-def normalized_search_path(value: str) -> str:
-    """Drop repeated entries and Click's own command directory.
+def _is_plugin_command_directory(key: str) -> bool:
+    """Whether a search-path entry is a host-offered plugin command directory.
 
-    A host can offer Click's commands by adding the plugin's own directory to
-    the search path of the tool call that runs a verification, while the Hook
-    process that decides reuse never sees it, and either side can repeat an
-    entry. Neither difference changes which executable a check resolves to --
-    a repeat can never win over its first occurrence, and Click's own
-    directory holds only Click's commands -- and the executables a check
-    actually resolves are fingerprinted separately by content. Normalizing
-    here keeps one environment identity for one environment, instead of one
-    per process that computes it.
+    Claude Code and Codex install plugins under `.../plugins/cache/<marketplace>/
+    <plugin>/<version>` and the host appends each installed plugin's `bin` to
+    the search path of the tool call, not only Click's. The shape of the entry
+    identifies it wherever Click itself is loaded from, including a development
+    checkout passed with `--plugin-dir`.
+    """
+    parts = [part for part in key.split(os.sep) if part]
+    return (len(parts) >= 6 and parts[-1] == "bin"
+            and parts[-5] == "cache" and parts[-6] == "plugins")
+
+
+def normalized_search_path(value: str) -> str:
+    """Drop repeated entries and host-offered plugin command directories.
+
+    A host can offer plugin commands by adding each installed plugin's own
+    directory to the search path of the tool call that runs a verification,
+    while the Hook process that decides reuse never sees them, and either side
+    can repeat an entry. Neither difference changes which executable a check
+    resolves to -- a repeat can never win over its first occurrence, a plugin
+    directory holds only that plugin's commands -- and the executables a check
+    actually resolves are fingerprinted separately by content, so a plugin
+    that did shadow one would still change the receipt. Normalizing here keeps
+    one environment identity for one environment, instead of one per process
+    that computes it.
     """
     own = _own_command_directories()
     entries: list[str] = []
     seen: set[str] = set()
     for entry in str(value).split(os.pathsep):
         key = os.path.normcase(entry)
-        if key in own or key in seen:
+        if key in own or key in seen or _is_plugin_command_directory(key):
             continue
         seen.add(key)
         entries.append(entry)

--- a/dist/claude/hooks/click_verification_bindings.py
+++ b/dist/claude/hooks/click_verification_bindings.py
@@ -219,16 +219,20 @@ def verification_environment(*, cwd: Path) -> dict[str, str]:
 SEARCH_PATH_KEYS = frozenset({"PATH"})
 
 
+def _own_roots() -> list[str]:
+    # Plain path text, so a host whose separator rules are emulated in a test
+    # cannot make locating Click's own directory raise.
+    roots = [os.path.dirname(os.path.dirname(os.path.abspath(__file__)))]
+    configured = os.environ.get("CLAUDE_PLUGIN_ROOT", "").strip()
+    if configured:
+        roots.append(configured)
+    return roots
+
+
 def _own_command_directories() -> set[str]:
     """Directories a host adds to the search path to offer Click's commands."""
     directories: set[str] = set()
-    # Plain path text, so a host whose separator rules are emulated in a test
-    # cannot make locating Click's own directory raise.
-    candidates = [os.path.dirname(os.path.dirname(os.path.abspath(__file__)))]
-    configured = os.environ.get("CLAUDE_PLUGIN_ROOT", "").strip()
-    if configured:
-        candidates.append(configured)
-    for root in candidates:
+    for root in _own_roots():
         try:
             directories.add(os.path.normcase(os.path.join(root, "bin")))
         except (OSError, RuntimeError, ValueError, TypeError):
@@ -236,25 +240,40 @@ def _own_command_directories() -> set[str]:
     return directories
 
 
-def normalized_search_path(value: str) -> str:
-    """Drop repeated entries and Click's own command directory.
+def _is_plugin_command_directory(key: str) -> bool:
+    """Whether a search-path entry is a host-offered plugin command directory.
 
-    A host can offer Click's commands by adding the plugin's own directory to
-    the search path of the tool call that runs a verification, while the Hook
-    process that decides reuse never sees it, and either side can repeat an
-    entry. Neither difference changes which executable a check resolves to --
-    a repeat can never win over its first occurrence, and Click's own
-    directory holds only Click's commands -- and the executables a check
-    actually resolves are fingerprinted separately by content. Normalizing
-    here keeps one environment identity for one environment, instead of one
-    per process that computes it.
+    Claude Code and Codex install plugins under `.../plugins/cache/<marketplace>/
+    <plugin>/<version>` and the host appends each installed plugin's `bin` to
+    the search path of the tool call, not only Click's. The shape of the entry
+    identifies it wherever Click itself is loaded from, including a development
+    checkout passed with `--plugin-dir`.
+    """
+    parts = [part for part in key.split(os.sep) if part]
+    return (len(parts) >= 6 and parts[-1] == "bin"
+            and parts[-5] == "cache" and parts[-6] == "plugins")
+
+
+def normalized_search_path(value: str) -> str:
+    """Drop repeated entries and host-offered plugin command directories.
+
+    A host can offer plugin commands by adding each installed plugin's own
+    directory to the search path of the tool call that runs a verification,
+    while the Hook process that decides reuse never sees them, and either side
+    can repeat an entry. Neither difference changes which executable a check
+    resolves to -- a repeat can never win over its first occurrence, a plugin
+    directory holds only that plugin's commands -- and the executables a check
+    actually resolves are fingerprinted separately by content, so a plugin
+    that did shadow one would still change the receipt. Normalizing here keeps
+    one environment identity for one environment, instead of one per process
+    that computes it.
     """
     own = _own_command_directories()
     entries: list[str] = []
     seen: set[str] = set()
     for entry in str(value).split(os.pathsep):
         key = os.path.normcase(entry)
-        if key in own or key in seen:
+        if key in own or key in seen or _is_plugin_command_directory(key):
             continue
         seen.add(key)
         entries.append(entry)

--- a/hooks/click_verification_bindings.py
+++ b/hooks/click_verification_bindings.py
@@ -219,16 +219,20 @@ def verification_environment(*, cwd: Path) -> dict[str, str]:
 SEARCH_PATH_KEYS = frozenset({"PATH"})
 
 
+def _own_roots() -> list[str]:
+    # Plain path text, so a host whose separator rules are emulated in a test
+    # cannot make locating Click's own directory raise.
+    roots = [os.path.dirname(os.path.dirname(os.path.abspath(__file__)))]
+    configured = os.environ.get("CLAUDE_PLUGIN_ROOT", "").strip()
+    if configured:
+        roots.append(configured)
+    return roots
+
+
 def _own_command_directories() -> set[str]:
     """Directories a host adds to the search path to offer Click's commands."""
     directories: set[str] = set()
-    # Plain path text, so a host whose separator rules are emulated in a test
-    # cannot make locating Click's own directory raise.
-    candidates = [os.path.dirname(os.path.dirname(os.path.abspath(__file__)))]
-    configured = os.environ.get("CLAUDE_PLUGIN_ROOT", "").strip()
-    if configured:
-        candidates.append(configured)
-    for root in candidates:
+    for root in _own_roots():
         try:
             directories.add(os.path.normcase(os.path.join(root, "bin")))
         except (OSError, RuntimeError, ValueError, TypeError):
@@ -236,25 +240,40 @@ def _own_command_directories() -> set[str]:
     return directories
 
 
-def normalized_search_path(value: str) -> str:
-    """Drop repeated entries and Click's own command directory.
+def _is_plugin_command_directory(key: str) -> bool:
+    """Whether a search-path entry is a host-offered plugin command directory.
 
-    A host can offer Click's commands by adding the plugin's own directory to
-    the search path of the tool call that runs a verification, while the Hook
-    process that decides reuse never sees it, and either side can repeat an
-    entry. Neither difference changes which executable a check resolves to --
-    a repeat can never win over its first occurrence, and Click's own
-    directory holds only Click's commands -- and the executables a check
-    actually resolves are fingerprinted separately by content. Normalizing
-    here keeps one environment identity for one environment, instead of one
-    per process that computes it.
+    Claude Code and Codex install plugins under `.../plugins/cache/<marketplace>/
+    <plugin>/<version>` and the host appends each installed plugin's `bin` to
+    the search path of the tool call, not only Click's. The shape of the entry
+    identifies it wherever Click itself is loaded from, including a development
+    checkout passed with `--plugin-dir`.
+    """
+    parts = [part for part in key.split(os.sep) if part]
+    return (len(parts) >= 6 and parts[-1] == "bin"
+            and parts[-5] == "cache" and parts[-6] == "plugins")
+
+
+def normalized_search_path(value: str) -> str:
+    """Drop repeated entries and host-offered plugin command directories.
+
+    A host can offer plugin commands by adding each installed plugin's own
+    directory to the search path of the tool call that runs a verification,
+    while the Hook process that decides reuse never sees them, and either side
+    can repeat an entry. Neither difference changes which executable a check
+    resolves to -- a repeat can never win over its first occurrence, a plugin
+    directory holds only that plugin's commands -- and the executables a check
+    actually resolves are fingerprinted separately by content, so a plugin
+    that did shadow one would still change the receipt. Normalizing here keeps
+    one environment identity for one environment, instead of one per process
+    that computes it.
     """
     own = _own_command_directories()
     entries: list[str] = []
     seen: set[str] = set()
     for entry in str(value).split(os.pathsep):
         key = os.path.normcase(entry)
-        if key in own or key in seen:
+        if key in own or key in seen or _is_plugin_command_directory(key):
             continue
         seen.add(key)
         entries.append(entry)

--- a/tests/test_click_verification_bindings.py
+++ b/tests/test_click_verification_bindings.py
@@ -158,6 +158,29 @@ class VerificationBindingStageTests(unittest.TestCase):
             bindings.normalized_search_path(os.pathsep.join([*entries, "/opt/tools/bin"])),
         )
 
+    def test_other_installed_plugins_offered_by_the_host_do_not_split_the_identity(self):
+        # Claude Code appends every installed plugin's bin directory to the
+        # tool call's search path. The `plugins/cache/<marketplace>/<plugin>/
+        # <version>/bin` shape identifies them wherever Click itself was loaded
+        # from, so a sibling plugin cannot make each request rebind.
+        cache = Path("/home/user/.claude/plugins/cache")
+        sibling = cache / "agent-plugins-for-aws" / "deploy-on-aws" / "1.3.0" / "bin"
+        codex_sibling = Path("/home/user/.codex/plugins/cache/personal/agy-runner/0.2.0/bin")
+        entries = ["/usr/local/bin", "/usr/bin"]
+        hook = os.pathsep.join(entries)
+        runner = os.pathsep.join([*entries, str(sibling), str(codex_sibling)])
+        self.assertEqual(bindings.normalized_search_path(runner), bindings.normalized_search_path(hook))
+        # Only that exact shape is host-owned; anything else stays part of
+        # the identity, including deeper or shallower paths under a cache.
+        for kept in (str(cache / "other" / "bin"), str(cache / "a" / "b" / "c" / "lib"),
+                     str(cache / "a" / "b" / "c" / "bin" / "extra"), "/home/user/tools/v1/bin",
+                     "/opt/plugins/a/b/c/bin"):
+            with self.subTest(kept=kept):
+                self.assertNotEqual(
+                    bindings.normalized_search_path(os.pathsep.join([*entries, kept])),
+                    bindings.normalized_search_path(hook),
+                )
+
     def test_environment_fingerprint_is_an_allowlist_with_owner_extension(self):
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory).resolve()


### PR DESCRIPTION
## Problem

Claude Code appends every installed plugin's `bin` directory to the Bash tool's `PATH` (`~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/bin`). `normalized_search_path` dropped only Click's own directory, so with any second plugin installed the Hook-side fingerprint (no plugin dirs) and the runner-side fingerprint (all plugin dirs) differed on every request:

```
[Click] Verification runner environment changed after preparation; rebound to the current canonical environment.
```

and the second identical request re-ran the whole suite. On this machine `deploy-on-aws@agent-plugins-for-aws` was enough to reproduce it; the paired-session measurement in #135 had to disable that plugin in both arms to see any reuse at all. A user with two plugins never sees Click reuse on Claude Code.

## Fix

Treat every search-path entry of the shape `plugins/cache/<marketplace>/<plugin>/<version>/bin` as host-owned, identified by its shape rather than by Click's own install location (a first version derived the cache root from Click's location and failed to cover a development checkout loaded with `--plugin-dir` while the sibling plugin lived in the cache). Codex's cache has the same shape. The justification is unchanged from Click's own directory: a plugin directory holds only that plugin's commands, and the executables a check actually resolves are fingerprinted by content, so a plugin that shadowed one would still change the receipt.

Only that exact shape is dropped; `cache/other/bin`, `a/b/c/lib`, `a/b/c/bin/extra`, `/home/user/tools/v1/bin` and `/opt/plugins/a/b/c/bin` stay part of the identity (tested).

## Verification

- New test in `tests/test_click_verification_bindings.py` fails on `main` (the sibling entry survives normalization) and passes here; 17/17 in the module.
- End to end, headless Claude Code with `deploy-on-aws` **enabled** and the fixed plugin loaded via `--plugin-dir dist/claude`: zero environment-changed messages, first request executed four shards, identical second request → `Click reused 4 current unchanged-tree verification receipts`. Before the fix the same probe printed the message on both runs and re-executed all four shards.
- `validate_distribution.py`, repository policy, distribution and Claude adapter tests: 82 tests OK. `dist/antigravity` and `dist/claude` rebuilt, byte-identical to `hooks/`.
- `RELEASE_NOTES.md` opens a `## Unreleased v1.1 candidate` section with this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
