### PR TITLE
Update the community drafts for v1.1.0

### DIFF
--- a/COMMUNITY_POSTS.md
+++ b/COMMUNITY_POSTS.md
@@ -1,6 +1,6 @@
 # Click community drafts
 
-Local drafts, not published posts. Written for v1.0.1. Every number below comes
+Local drafts, not published posts. Written for v1.1.0. Every number below comes
 from [`docs/history/agent-ab-2026-09-12/`](docs/history/agent-ab-2026-09-12/README.md)
 (eight paired Opus 5 sessions) or from `RELEASE_NOTES.md` fixture measurements;
 cite the record when a number is challenged. Never replace a measured value with
@@ -12,7 +12,10 @@ Allowed, with the condition attached:
 
 - "Same task, Opus 5, 8 sessions: 381 s → 123 s (−68%) with Click; test
   executions 20 → 10; cost +6–11%." — 40 s four-module `unittest` fixture,
-  three seeded bugs fixed one at a time, one machine, Linux.
+  three seeded bugs fixed one at a time, one machine, Linux, v1.0.0.
+- "With v1.1.0's plain `click-gate verify -- <command>` form, Click-on cost
+  came down to the Click-off level ($0.57 vs $0.60)" — two sessions only;
+  always say n=2 and "direction", never "measured saving".
 - "The same test never runs twice, its output is never read twice, and nothing
   is skipped by guess." — README hero line; the code enforces it.
 - "Every skip has a receipt: an exact receipt, a signed input observation, or a
@@ -24,7 +27,9 @@ Allowed, with the condition attached:
 
 Not allowed:
 
-- Any token or cost *saving*. Tokens went up (+19–37%), cost +6–11%.
+- Any token or cost *saving*. In the eight-session record tokens went up
+  (+19–37%) and cost +6–11%; the v1.1.0 plain form brought cost level with
+  Click off in two sessions, which is parity, not a saving.
 - Any percentage for "real projects" or "production". The record is a fixture.
 - Attributing the wall-time gain to reuse alone: on equal shards it is mostly
   concurrent shard execution; reuse shows as executions 20 → 10 and one fully
@@ -72,7 +77,7 @@ AI 에이전트 테스트 재사용 플러그인 만들었는데, 추측으로 �
 
 코딩 에이전트 쓰면 다들 겪는 거. 함수 하나 고치고 "테스트 돌려봐" 하면 전체
 스위트 다시 돌고, 로그 다시 읽고, 다음 수정에서 또 반복. 그거 없애는 플러그인을
-만들어서 v1.0.1 냈다. Claude Code랑 Codex CLI 둘 다 붙는다. MIT.
+만들어서 v1.1.0 냈다. Claude Code랑 Codex CLI 둘 다 붙는다. MIT.
 
 원칙은 한 줄: **같은 테스트는 두 번 안 돌리고, 같은 로그는 두 번 안 읽고, 추측으로는
 아무것도 안 건너뛴다.** 건너뛸 때는 반드시 영수증이 있어야 한다 — 같은 상태의 정확한
@@ -85,7 +90,10 @@ AI 에이전트 테스트 재사용 플러그인 만들었는데, 추측으로 �
 - 세션 시간: 381초 → 123초 (−68%). 끈 쪽은 전부 6분대, 켠 쪽은 전부 2분대.
 - 테스트 모듈 실행: 20회 → 10회. 켠 쪽은 매번 4 → 3 → 2 → 1 → 0으로 줄고 마지막
   확인 실행은 아예 안 돌았다 ("4개 전부 재사용").
-- 비용: +6~11%. 토큰은 오히려 늘었다. 턴이 1~2개 더 돌고 명령이 길어져서.
+- 비용: +6~11%. 토큰은 오히려 늘었다. 턴이 1~2개 더 돌고, 매번 타이핑하는 JSON
+  명령이 길어서. 그래서 v1.1.0에서 `click-gate verify -- <명령>` 축약형을 넣었고,
+  추가 2세션에서는 비용이 Click 꺼진 쪽과 같아졌다 ($0.57 vs $0.60). 2세션이라
+  방향만 본 거고, 절감이 아니라 동등이다.
 - 8세션 전부 버그 3개 다 고쳤고 테스트 파일은 안 건드렸다.
 
 솔직히 써야 할 것. 첫째, 시간 줄어든 건 재사용보다 **샤드 병렬 실행** 덕이 크다.
@@ -123,7 +131,8 @@ codex plugin marketplace add grapefruit0205/click && codex plugin add click@clic
 - "깨진 테스트를 통과로 둔갑하면?" → 재사용은 영수증 없으면 안 됨. 입력 파일 하나만
   바뀌어도 그 샤드는 돈다. 위 실험에서 실행 횟수 반으로 줄이고도 결과가 같았던 게
   그 증거고, 계측 코드가 거부당한 게 반대 방향 증거.
-- "토큰은?" → 늘었다. +6~11% 비용. 시간 −68%와 같은 줄에 써놨다.
+- "토큰은?" → 8세션 기록에선 늘었다(+6~11% 비용). v1.1.0 축약형으로 2세션 재측정하니
+  Click 꺼진 쪽과 같은 비용. 절감 주장은 안 한다.
 - "내 프로젝트도 빨라지나?" → 편집→테스트 반복이 많고, 테스트가 파일 단위로 독립적이고,
   스위트가 관리 비용(1초 미만)을 묻을 만큼 길면. 아니면 그냥 원래대로 돈다.
 
@@ -134,11 +143,11 @@ codex plugin marketplace add grapefruit0205/click && codex plugin add click@clic
 
 ### 标题 A（痛点 → 数字）
 
-给 Claude Code / Codex 做了个插件：同一个测试不跑两次，同一份日志不读两次。8 个 Opus 5 会话实测 6 分钟 → 2 分钟（v1.0.1 发布）
+给 Claude Code / Codex 做了个插件：同一个测试不跑两次，同一份日志不读两次。8 个 Opus 5 会话实测 6 分钟 → 2 分钟（v1.1.0 发布）
 
 ### 标题 B（先讲安全）
 
-编码代理的测试复用插件，但绝不凭猜测跳过任何检查 —— Click v1.0.1
+编码代理的测试复用插件，但绝不凭猜测跳过任何检查 —— Click v1.1.0
 
 ### 正文（A/B 共用）
 
@@ -157,7 +166,7 @@ codex plugin marketplace add grapefruit0205/click && codex plugin add click@clic
 |---|---|---|---|
 | 会话耗时 | 381 s | 123 s | **−68%** |
 | 测试模块执行次数 | 20 | 10 | **−50%** |
-| 费用 | $0.60 | $0.66 | **+6~11%** |
+| 费用 | $0.60 | $0.66 | **+6~11%**（v1.1.0 简写形式下另测 2 个会话：$0.57，与关闭时持平） |
 
 开启侧的 4 个会话轨迹完全一致：每轮执行 4 → 3 → 2 → 1 → 0 个分片，最后一次确认
 "4 个凭据全部复用"，一个都没跑。8 个会话全部修好了 3 个 bug，没有动 `tests/`。
@@ -165,7 +174,9 @@ codex plugin marketplace add grapefruit0205/click && codex plugin add click@clic
 必须说清楚的三点。第一，耗时下降主要来自**分片并发执行**而不是复用：4 个分片长度相同，
 只要有一个要跑，这一轮就是约 15 秒；复用体现在执行次数减半和最后一轮 0 秒。第二，
 **Token 和费用是上升的**（Token +19~37%，费用 +6~11%），多出来的是 1~2 个回合的缓存读取和
-更长的命令，不是 Click 的输出更长。第三，这是 40 秒套件的结果；2 秒的套件会因为管理成本
+模型每轮敲的那段约 200 字符的 JSON 命令，不是 Click 的输出更长。v1.1.0 为此加了简写形式
+`click-gate verify -- <命令>`，另测的 2 个会话里费用降到与关闭 Click 持平（$0.57 vs $0.60）；
+样本只有 2 个，是方向，不是节省。第三，这是 40 秒套件的结果；2 秒的套件会因为管理成本
 反而更慢（也实测并留在仓库里：0.7 s → 13.3 s）。JS 条件复用只支持 Linux + Node 22.23.2，
 Python 签名完整观测支持 CPython 3.12.3~3.12.14。
 
@@ -193,7 +204,8 @@ codex plugin marketplace add grapefruit0205/click && codex plugin add click@clic
 
 - "会不会把坏掉的测试当成通过？" → 没有凭据就不复用；任何一个输入文件变了，对应分片就重跑。
   上面的实验执行次数减半而结果不变是正向证据，计数代码被拒绝是反向证据。
-- "Token 呢？" → 上升了，费用 +6~11%，和 −68% 写在同一行。
+- "Token 呢？" → 8 会话记录里是上升的（费用 +6~11%）；v1.1.0 简写形式另测 2 个会话，费用与关闭时持平。
+  不主张节省。
 - "我的项目会更快吗？" → 前提是编辑→测试循环多、测试按文件独立、套件长到能摊掉不到 1 秒的
   管理成本。不满足就照常执行，没有损失以外的损失。
 
@@ -216,6 +228,8 @@ Measured: the same three-bug fix task, Opus 5, eight headless sessions, four
 with the plugin off and four on, alternated, on a four-module 40 s `unittest`
 fixture. Session time 381 s → 123 s (−68%); test module executions 20 → 10;
 cost +6–11%, tokens +19–37%. All eight fixed every bug without touching tests.
+v1.1.0's plain `click-gate verify -- <command>` form brought Click-on cost level
+with Click off in two further sessions (n=2, a direction).
 The gain is mostly concurrent shard execution on equal-length shards; reuse is
 the halved executions and a final request that ran nothing. A two-second suite
 is slower with Click (measured). JS conditional reuse: Linux + Node 22.23.2;


### PR DESCRIPTION
Drafts now reference v1.1.0 and carry the plain-form result the way the record states it: in two further sessions the `click-gate verify -- <command>` form brought Click-on cost level with Click off ($0.57 vs $0.60 median) — n=2, a direction, parity rather than a saving. The eight-session line (−68% time, executions 20 → 10, cost +6–11%) stays as the primary claim. Korean, Chinese and English bodies, the prepared replies and the claims checklist are updated consistently. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)