### PR TITLE
Support Claude Code on Windows through Git Bash

### DIFF
--- a/.click/evidence-shards.json
+++ b/.click/evidence-shards.json
@@ -179,6 +179,7 @@
               "unittest",
               "tests.test_antigravity_adapter",
               "tests.test_claude_adapter",
+              "tests.test_claude_launcher",
               "tests.test_click_authoritative_observer",
               "tests.test_click_authoritative_reuse",
               "tests.test_click_automatic_observation",
@@ -207,6 +208,7 @@
           "covers": [
             "tests/test_antigravity_adapter.py",
             "tests/test_claude_adapter.py",
+            "tests/test_claude_launcher.py",
             "tests/test_click_authoritative_observer.py",
             "tests/test_click_authoritative_reuse.py",
             "tests/test_click_automatic_observation.py",

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Claude Code runs the Hook launcher through sh (Git Bash on Windows); a
+# CRLF checkout under core.autocrlf would break it.
+*.sh text eol=lf

--- a/COMPATIBILITY_SURFACE.md
+++ b/COMPATIBILITY_SURFACE.md
@@ -22,9 +22,13 @@ The current host adapters still call a small, explicit set of gate symbols:
 - `hooks/claude_hook.py`: `main`
 - `hooks/antigravity_gate.py`: public `host_router`
 
-`hooks/click_windows.py` and the Antigravity launcher-path check use the formal
-`click_runner_transport` boundary. They no longer reach through private gate
-symbols to configure or decode runner commands.
+`hooks/click_windows.py`, `hooks/claude_hook.py` and the Antigravity
+launcher-path check use the formal `click_runner_transport` boundary. They no
+longer reach through private gate symbols to configure or decode runner
+commands. Windows runner renderers are registered per host id
+(`register_host_renderer`); the resident worker activates the renderer of the
+host that sent each event, so one runtime serves Codex (PowerShell or cmd.exe)
+and Claude Code (Git Bash).
 
 The named `click_host_router` and `click_runner_transport` interfaces now own
 adapter routing and runner transport. The remaining `click_gate.main` and

--- a/README.ko.md
+++ b/README.ko.md
@@ -86,8 +86,11 @@ claude plugin install click@click
 새 Claude Code 세션을 시작하면 설치된 Hook과 스킬이 로드됩니다. 모든
 `click-gate` 명령은 평범한 Bash 명령이며, 설치된 `PreToolUse` Hook이 Click
 러너로 다시 씁니다. Evidence 상태는 `~/.claude/plugins/data/click-click/`에
-저장됩니다. Linux와 macOS를 지원하며, 호스트별 제한은
-[Click for Claude Code](platforms/claude/README.md)를 참고하세요.
+저장됩니다. Linux·macOS·Windows를 지원합니다. Windows에서는 Claude Code의
+Bash 도구와 Hook이 Git for Windows에서 실행되며, Hook 실행기가 `py -3`,
+`python`, `python3` 순으로 인터프리터를 고릅니다. JS 조건부 재사용은 Linux
+전용입니다. 호스트별 제한은 [Click for Claude Code](platforms/claude/README.md)를
+참고하세요.
 
 업데이트 명령은 다음과 같습니다.
 
@@ -404,7 +407,7 @@ python3 --version
 
 이후 새 작업에서 작은 실제 검증을 실행하고 `click-gate status`를 확인합니다. 플러그인 활성화 표시만으로 Hook 실행까지 확인된 것은 아닙니다. Windows CI와 OS별 Observer 검증 범위는 [릴리스 노트](RELEASE_NOTES.md)에 있으며, 사용자에게 설치된 호스트와 설정도 별도로 확인해야 합니다.
 
-Claude Code에서는 `claude plugin list`로 설치된 플러그인을, `/hooks`에서 `[plugin:click]` Hook 정의를 확인합니다. 소스 빌드는 `claude plugin validate ./dist/claude --strict`로 검사할 수 있습니다. Hook 명령은 `python3`를 실행하므로 Claude Code가 사용하는 셸에서 `python3 --version`이 동작해야 합니다. Hook 출력과 오류는 대화 기록에 `click hook error` 줄로 표시됩니다.
+Claude Code에서는 `claude plugin list`로 설치된 플러그인을, `/hooks`에서 `[plugin:click]` Hook 정의를 확인합니다. 소스 빌드는 `claude plugin validate ./dist/claude --strict`로 검사할 수 있습니다. Hook 명령은 `sh "${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.sh"`이며 Claude Code가 Linux·macOS에서는 `sh -c`, Windows에서는 Git Bash로 실행합니다. 실행기는 Linux·macOS에서 `python3`를, Windows에서는 `py -3`, `python`, `python3` 순으로 실행하고, Python 설치만 권하는 Microsoft Store 별칭은 건너뜁니다. Windows에는 Git for Windows가 있어야 합니다. 없으면 Claude Code가 PowerShell 도구만 제공하는데, Click은 아직 그 도구를 다시 쓰지 않습니다. Hook 출력과 오류는 대화 기록에 `click hook error` 줄로 표시됩니다.
 
 ## Antigravity
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,11 @@ claude plugin install click@click
 Start a new Claude Code session so the installed Hooks and skill load. Every
 `click-gate` command is an ordinary Bash command that the installed `PreToolUse`
 Hook rewrites onto Click's runner; Evidence state lives under
-`~/.claude/plugins/data/click-click/`. Linux and macOS are supported; see
-[Click for Claude Code](platforms/claude/README.md) for the host limits.
+`~/.claude/plugins/data/click-click/`. Linux, macOS and Windows are supported;
+on Windows, Claude Code's Bash tool and its Hooks run in Git for Windows, and
+the Hook launcher picks `py -3`, `python` or `python3`. JS conditional reuse
+stays Linux-only. See [Click for Claude Code](platforms/claude/README.md) for
+the host limits.
 
 To update:
 
@@ -412,7 +415,7 @@ Restart Codex after an installation or update. In the CLI, use `/hooks` to revie
 
 Then start a new task, perform a small real verification, and inspect `click-gate status`. An enabled plugin alone does not demonstrate that its Hooks ran. Windows CI coverage and native Observer validation are described in the [release notes](RELEASE_NOTES.md); they do not replace checking the user's installed host and configuration.
 
-On Claude Code, `claude plugin list` shows the installed plugin and `/hooks` lists the `[plugin:click]` Hook definitions; `claude plugin validate ./dist/claude --strict` checks a source build. The Hook command runs `python3`, so confirm `python3 --version` works in the shell Claude Code uses. Hook output and errors appear in the transcript as `click hook error` lines.
+On Claude Code, `claude plugin list` shows the installed plugin and `/hooks` lists the `[plugin:click]` Hook definitions; `claude plugin validate ./dist/claude --strict` checks a source build. The Hook command is `sh "${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.sh"`, which Claude Code runs through `sh -c` on Linux and macOS and through Git Bash on Windows; the launcher runs `python3` (Linux and macOS) or `py -3`, `python`, `python3` in that order (Windows), skipping the Microsoft Store alias that only offers to install Python. On Windows, Git for Windows must be installed: without it Claude Code offers only its PowerShell tool, which Click does not rewrite yet. Hook output and errors appear in the transcript as `click hook error` lines.
 
 ## Antigravity
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -77,8 +77,10 @@ claude plugin install click@click
 
 新建 Claude Code 会话后，已安装的 Hook 和技能即会加载。所有 `click-gate`
 命令都是普通的 Bash 命令，由已安装的 `PreToolUse` Hook 改写到 Click 运行器；
-Evidence 状态保存在 `~/.claude/plugins/data/click-click/`。支持 Linux 与
-macOS；宿主限制详见 [Click for Claude Code](platforms/claude/README.md)。
+Evidence 状态保存在 `~/.claude/plugins/data/click-click/`。支持 Linux、macOS
+和 Windows：在 Windows 上，Claude Code 的 Bash 工具和 Hook 运行于 Git for
+Windows，Hook 启动器依次选择 `py -3`、`python`、`python3`。JS 条件复用仍仅限
+Linux。宿主限制详见 [Click for Claude Code](platforms/claude/README.md)。
 
 更新命令：
 
@@ -384,7 +386,7 @@ python3 --version
 
 然后新建任务，执行一个小型真实验证，并检查 `click-gate status`。仅看到插件已启用，并不能说明其 Hook 实际运行过。Windows CI 覆盖情况和原生 Observer 验证记录见[版本说明](RELEASE_NOTES.md)；它们不能替代对用户实际安装的宿主及配置的检查。
 
-在 Claude Code 中，用 `claude plugin list` 查看已安装插件，用 `/hooks` 查看 `[plugin:click]` 的 Hook 定义；源码构建可用 `claude plugin validate ./dist/claude --strict` 检查。Hook 命令运行 `python3`，请确认 Claude Code 使用的 shell 中 `python3 --version` 可用。Hook 的输出和错误会以 `click hook error` 行出现在对话记录中。
+在 Claude Code 中，用 `claude plugin list` 查看已安装插件，用 `/hooks` 查看 `[plugin:click]` 的 Hook 定义；源码构建可用 `claude plugin validate ./dist/claude --strict` 检查。Hook 命令为 `sh "${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.sh"`，Claude Code 在 Linux 和 macOS 上通过 `sh -c` 运行它，在 Windows 上通过 Git Bash 运行；启动器在 Linux 和 macOS 上运行 `python3`，在 Windows 上依次尝试 `py -3`、`python`、`python3`，并跳过只会提示安装 Python 的 Microsoft Store 别名。Windows 需要安装 Git for Windows：没有它，Claude Code 只提供 PowerShell 工具，而 Click 尚未改写该工具。Hook 的输出和错误会以 `click hook error` 行出现在对话记录中。
 
 ## Antigravity
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,11 +12,18 @@
   (forward-slash interpreter and script paths, bounded encoded transport),
   reads and writes the host's JSON as UTF-8, and the resident worker no longer
   requires the Codex Windows bridge: runner renderers are registered per host
-  and activated per event. `.gitattributes` keeps the launcher LF under
-  `core.autocrlf`. Windows CI drives the packaged hooks and rewritten commands
-  through Git Bash with a default-install PATH; interpreter selection is
-  covered on every OS with fake interpreters. Python checks are the Windows
-  scope; conditional JS reuse stays Linux-only.
+  and activated per event. The environment fingerprint spells Windows
+  search-path entries one way: every MSYS hop (Git Bash, then `sh`) re-spells
+  them for a native child (trailing separators, doubled separators, drive
+  letter case), and the Hook runs one hop deeper than the Bash tool, so the
+  same directories used to carry two identities and no receipt was reused.
+  The rebound notice now names the variables that differed (never their
+  values). `.gitattributes` keeps the launcher LF under `core.autocrlf`.
+  Windows CI drives the packaged hooks and rewritten commands through Git
+  Bash with a default-install PATH and proves the resubmitted check is
+  reused; interpreter selection is covered on every OS with fake
+  interpreters. Python checks are the Windows scope; conditional JS reuse
+  stays Linux-only.
 
 ## v1.1.1 — 2026-09-13 — English by default
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,23 @@
 # Release notes
 
+## Unreleased v1.2 candidate
+
+- Claude Code on Windows. The Claude Code package's Hook command is now
+  `sh "${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.sh"`, a POSIX launcher that
+  Claude Code runs through `sh -c` on Linux and macOS and through Git Bash on
+  Windows; it selects `py -3`, `python` or `python3` (skipping the Microsoft
+  Store alias stub and the py launcher's exit 103), runs the adapter in UTF-8
+  mode, and normalizes the backslash plugin root Claude Code substitutes. On
+  Windows the adapter renders rewritten `click-gate` commands for Git Bash
+  (forward-slash interpreter and script paths, bounded encoded transport),
+  reads and writes the host's JSON as UTF-8, and the resident worker no longer
+  requires the Codex Windows bridge: runner renderers are registered per host
+  and activated per event. `.gitattributes` keeps the launcher LF under
+  `core.autocrlf`. Windows CI drives the packaged hooks and rewritten commands
+  through Git Bash with a default-install PATH; interpreter selection is
+  covered on every OS with fake interpreters. Python checks are the Windows
+  scope; conditional JS reuse stays Linux-only.
+
 ## v1.1.1 — 2026-09-13 — English by default
 
 Patch release. Both marketplaces pin `v1.1.1`; updating v1.1.0 installs it.

--- a/dist/antigravity/hooks/click_runner_transport.py
+++ b/dist/antigravity/hooks/click_runner_transport.py
@@ -127,3 +127,24 @@ def install_runner_shell_renderer(
 
 def render_runner_shell_command(arguments: list[str]) -> str:
     return _runner_shell_renderer(arguments)
+
+
+# Hosts render the same runner argv for different tool shells: Codex on
+# Windows runs the rewritten command in PowerShell or cmd.exe, Claude Code in
+# Git Bash. Adapters register their renderer by host id and the resident
+# worker, which serves whichever host installed the package, activates the
+# right one for each event it dispatches.
+_host_renderers: dict[str, RunnerShellRenderer] = {}
+
+
+def register_host_renderer(host_id: str, renderer: RunnerShellRenderer) -> None:
+    if not isinstance(host_id, str) or not host_id or not callable(renderer):
+        raise TypeError("Click host renderers need a host id and a callable.")
+    _host_renderers[host_id] = renderer
+
+
+def activate_host_renderer(host_id: str) -> RunnerShellRenderer:
+    """Install the renderer registered for ``host_id`` (the default otherwise)."""
+    renderer = _host_renderers.get(host_id, default_runner_shell_command)
+    install_runner_shell_renderer(renderer)
+    return renderer

--- a/dist/antigravity/hooks/click_verification_bindings.py
+++ b/dist/antigravity/hooks/click_verification_bindings.py
@@ -395,7 +395,16 @@ def verification_environment_from_binding(
     binding: Any,
     runner_token: str,
     current_environment: dict[str, str],
+    *,
+    drift: dict[str, Any] | None = None,
 ) -> tuple[dict[str, str] | None, bool, str]:
+    """Project the runner's environment onto the prepared binding.
+
+    ``drift``, when given, receives ``{"changed": [names], "absent": count}``:
+    the fingerprinted variables whose value differs or that the Hook did not
+    bind, and how many bound variables the runner no longer sees (their names
+    exist only as keyed digests). Names only, never values.
+    """
     if not isinstance(binding, list) or not binding or len(binding) > 4096:
         return None, False, "Click verification runner environment binding was malformed."
     expected: dict[str, str] = {}
@@ -422,6 +431,7 @@ def verification_environment_from_binding(
     # fingerprinted value rebinds the receipt to what actually runs.
     matched: set[str] = set()
     drifted = False
+    changed: list[str] = []
     for key, value in environment_fingerprint(current_environment).items():
         normalized_key = verification_environment_key(str(key))
         key_digest = verification_environment_hmac(
@@ -430,15 +440,21 @@ def verification_environment_from_binding(
         expected_value = expected.get(key_digest)
         if expected_value is None:
             drifted = True
+            changed.append(normalized_key)
             continue
         current_value = verification_environment_hmac(
             runner_token, "value", f"{normalized_key}\0{value}"
         )
         if not secrets.compare_digest(expected_value, current_value):
             drifted = True
+            changed.append(normalized_key)
         matched.add(key_digest)
-    if matched != set(expected):
+    absent = len(set(expected) - matched)
+    if absent:
         drifted = True
+    if drift is not None:
+        drift["changed"] = sorted(changed)
+        drift["absent"] = absent
     return dict(current_environment), drifted, ""
 
 

--- a/dist/antigravity/hooks/click_verification_bindings.py
+++ b/dist/antigravity/hooks/click_verification_bindings.py
@@ -272,6 +272,13 @@ def normalized_search_path(value: str) -> str:
     entries: list[str] = []
     seen: set[str] = set()
     for entry in str(value).split(os.pathsep):
+        if os.name == "nt" and entry:
+            # Every MSYS hop (Git Bash, then sh) re-spells the Windows search
+            # path it hands to a native child: trailing separators dropped,
+            # doubled separators collapsed, the drive letter upper-cased. The
+            # Hook runs one hop deeper than the Bash tool, so the same
+            # directories would otherwise carry two identities.
+            entry = os.path.normcase(os.path.normpath(entry))
         key = os.path.normcase(entry)
         if key in own or key in seen or _is_plugin_command_directory(key):
             continue

--- a/dist/antigravity/hooks/click_verification_claims.py
+++ b/dist/antigravity/hooks/click_verification_claims.py
@@ -222,11 +222,13 @@ def _claim_verification_run(
     current_environment = _observer_environment(
         _verification_environment(cwd=Path.cwd()), verification
     )
+    environment_drift: dict[str, Any] = {}
     verification_environment, environment_rebound, binding_error = (
         _verification_environment_from_binding(
             running_environment_binding,
             runner_token,
             current_environment,
+            drift=environment_drift,
         )
     )
     if binding_error:
@@ -343,6 +345,7 @@ def _claim_verification_run(
     batch["_click_claim_binding"] = claim_binding
     batch["_click_verification_environment"] = verification_environment
     batch["_click_verification_environment_rebound"] = environment_rebound
+    batch["_click_verification_environment_drift"] = environment_drift
     batch["_click_command_plans"] = runtime_command_plans
     labels = verification.get("source_labels")
     batch["_click_source_labels"] = (

--- a/dist/antigravity/hooks/click_verification_runner.py
+++ b/dist/antigravity/hooks/click_verification_runner.py
@@ -220,6 +220,9 @@ def _run_verification_impl(
     environment_rebound = batch.pop(
         "_click_verification_environment_rebound", False
     )
+    environment_drift = batch.pop("_click_verification_environment_drift", {})
+    if not isinstance(environment_drift, dict):
+        environment_drift = {}
     claim_input_bindings = batch.pop("_click_explicit_input_bindings", None)
     if (
         not isinstance(claim_input_bindings, dict)
@@ -262,9 +265,22 @@ def _run_verification_impl(
         )
         active_authoritative_execute = click_authoritative_observer.run_command
     if environment_rebound:
+        # Name the variables (never their values) so a host that adds or
+        # rewrites one between the Hook and the tool call can be identified
+        # from the transcript instead of from a debugger.
+        changed = environment_drift.get("changed")
+        absent = environment_drift.get("absent")
+        details: list[str] = []
+        if isinstance(changed, list) and changed:
+            details.append("changed: " + ", ".join(str(name) for name in changed[:12]))
+            if len(changed) > 12:
+                details[-1] += f" and {len(changed) - 12} more"
+        if isinstance(absent, int) and absent > 0:
+            details.append(f"{absent} bound variable(s) absent")
         print(
-            "[Click] Verification runner environment changed after preparation; "
-            "rebound to the current canonical environment.",
+            "[Click] Verification runner environment changed after preparation"
+            + (f" ({'; '.join(details)})" if details else "")
+            + "; rebound to the current canonical environment.",
             flush=True,
         )
     before = git_workspace_snapshot(Path.cwd())

--- a/dist/claude/README.md
+++ b/dist/claude/README.md
@@ -78,9 +78,23 @@ receipts never cross hosts.
 - The `plugin://click@click` autocomplete mention is a Codex surface. On Claude
   Code, bypass and cancel use the plain first-line `@Click bypass` and
   `@Click cancel` forms.
-- The Hook command invokes `python3`; Linux and macOS are the supported hosts.
-  The Windows launcher bundled with the Codex plugin is not part of this
-  package.
+- The Hook command is `sh "${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.sh"`, a
+  shell-form hook on purpose: exec form has no shell and so no way to fall
+  back between interpreters. Claude Code runs it through `sh -c` on Linux and
+  macOS and through Git Bash on Windows. The POSIX launcher runs `python3`
+  (then `python`) on Linux and macOS and `py -3`, `python`, `python3` in that
+  order on Windows, skips the Microsoft Store alias that only offers to
+  install Python, and starts the adapter in UTF-8 mode so a Korean prompt or
+  the localized result-line label survives a legacy console code page.
+- Windows needs Git for Windows: Claude Code's Bash tool and its shell-form
+  Hooks run there. Rewritten `click-gate` commands are rendered for Git Bash
+  (forward-slash interpreter and script paths plus the bounded encoded
+  transport). Without Git Bash, Claude Code offers only its PowerShell tool,
+  which this package does not rewrite yet. The Codex Windows batch bridge is
+  not part of this package.
+- Python checks are the Windows scope: the resident worker, receipts, sharding
+  and the inbox ETW observer follow the shared runtime. Conditional JS reuse
+  (the Node observer) is Linux-only on every host.
 - Automatic input observation keeps its documented platform prerequisites; the
   host does not change which observer backends are available.
 

--- a/dist/claude/hooks/claude_hook.py
+++ b/dist/claude/hooks/claude_hook.py
@@ -23,6 +23,7 @@ import io
 import json
 import os
 from pathlib import Path
+import shlex
 import sys
 
 if __package__:
@@ -31,8 +32,10 @@ else:  # Executed directly from the bundled hooks directory.
     import click_import_bootstrap
 
 
-(click_hook_transport, click_host_coverage) = click_import_bootstrap.load_siblings(
-    __package__, "click_hook_transport", "click_host_coverage"
+(click_hook_transport, click_host_coverage, click_runner_transport) = (
+    click_import_bootstrap.load_siblings(
+        __package__, "click_hook_transport", "click_host_coverage", "click_runner_transport"
+    )
 )
 
 
@@ -41,6 +44,59 @@ CLAUDE_TOOL_MAP = click_host_coverage.CLAUDE_TOOL_MAP
 CLAUDE_MUTATION_TOOLS = click_host_coverage.CLAUDE_MUTATION_TOOL_NAMES
 CLAUDE_PLAN_TOOLS = click_host_coverage.CLAUDE_PLAN_TOOL_NAMES
 TOOL_EVENT_MODES = frozenset({"pre-tool", "post-tool"})
+
+
+def configure_streams() -> None:
+    """Read and write the host's JSON as UTF-8 whatever the console code page.
+
+    Claude Code sends and reads UTF-8. On Windows a pipe defaults to the
+    legacy code page, which can neither decode a Korean prompt nor encode the
+    result-line label in the Evidence context; the launcher passes ``-X utf8``
+    and this covers a direct ``python claude_hook.py`` call.
+    """
+    for stream in (sys.stdin, sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if callable(reconfigure):
+            try:
+                reconfigure(encoding="utf-8", errors="replace")
+            except (ValueError, OSError):
+                pass
+
+
+def runner_shell_command(arguments: list[str]) -> str:
+    """Render the rewritten runner for Claude Code's Bash tool.
+
+    The tool is Git Bash on Windows, so the command is POSIX-quoted there as on
+    every other host; the interpreter and script paths use forward slashes,
+    which Git Bash executes and Windows accepts, and everything after them
+    travels in the bounded encoded transport so no argument depends on the
+    MSYS path conversion or the console code page.
+    """
+    if os.name != "nt":
+        return click_runner_transport.default_runner_shell_command(arguments)
+    if len(arguments) < 3:
+        return "exit 2"
+    try:
+        interpreter = Path(arguments[0]).resolve(strict=True)
+        script_path = Path(arguments[1]).resolve(strict=True)
+    except (OSError, RuntimeError):
+        return "exit 2"
+    if not interpreter.is_file() or not script_path.is_file():
+        return "exit 2"
+    command = shlex.join(
+        [
+            str(interpreter).replace("\\", "/"),
+            str(script_path).replace("\\", "/"),
+            "--encoded-runner",
+            click_runner_transport.encode_runner_transport(arguments[2:]),
+        ]
+    )
+    if len(command) > click_runner_transport.WINDOWS_COMMAND_LINE_LIMIT:
+        return "exit 2"
+    return command
+
+
+click_runner_transport.register_host_renderer(HOST_ID, runner_shell_command)
 
 
 def configure_storage() -> None:
@@ -101,7 +157,10 @@ def merge_updated_input(
 
 
 def main() -> int:
+    configure_streams()
     configure_storage()
+    if os.name == "nt":
+        click_runner_transport.install_runner_shell_renderer(runner_shell_command)
     mode = sys.argv[1] if len(sys.argv) == 2 else ""
     if mode not in click_hook_transport.HOOK_MODES:
         (click_gate,) = click_import_bootstrap.load_siblings(__package__, "click_gate")

--- a/dist/claude/hooks/claude_hook.sh
+++ b/dist/claude/hooks/claude_hook.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Click Hook launcher for Claude Code.
+#
+# Claude Code runs a shell-form hook command through `sh -c` on macOS and
+# Linux and through Git Bash on Windows, so this file is POSIX sh. It selects a
+# Python 3 interpreter the way the Codex batch launcher does (`py -3`, then
+# `python`, then `python3` on Windows; `python3`, then `python` elsewhere),
+# skips the Microsoft Store alias stub that only offers to install Python, and
+# runs the adapter in UTF-8 mode so the host's JSON survives a legacy console
+# code page. Every argument is passed through to hooks/claude_hook.py.
+
+# Claude Code substitutes ${CLAUDE_PLUGIN_ROOT} with backslashes on Windows;
+# dirname only splits on "/", so normalize before locating the adapter.
+launcher=$(printf '%s\n' "$0" | tr '\\' '/')
+adapter=$(dirname "$launcher")/claude_hook.py
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*|Windows_NT)
+    windows=1
+    candidates="py python python3"
+    ;;
+  *)
+    windows=0
+    candidates="python3 python"
+    ;;
+esac
+
+for candidate in $candidates; do
+  resolved=$(command -v "$candidate" 2>/dev/null) || continue
+  [ -n "$resolved" ] || continue
+  if [ "$windows" = 1 ]; then
+    case "$resolved" in
+      *WindowsApps*|*windowsapps*)
+        # The App Execution Alias stub exits without running anything unless
+        # the Store build is installed; only a real interpreter passes this.
+        "$resolved" -c "import sys" </dev/null >/dev/null 2>&1 || continue
+        ;;
+    esac
+  fi
+  if [ "$candidate" = py ]; then
+    # The py launcher exits 103 without reading stdin when no Python 3 is
+    # registered with it; the next candidate then still sees the whole event.
+    "$resolved" -3 -X utf8 "$adapter" "$@"
+    status=$?
+    [ "$status" -eq 103 ] && continue
+    exit "$status"
+  fi
+  exec "$resolved" -X utf8 "$adapter" "$@"
+done
+
+echo "click hook error: Click requires Python 3; none of $candidates was found on PATH" >&2
+exit 127

--- a/dist/claude/hooks/click_hook_worker.py
+++ b/dist/claude/hooks/click_hook_worker.py
@@ -21,8 +21,10 @@ else:  # Executed directly from the bundled hooks directory.
     import click_import_bootstrap
 
 
-(click_hook_transport,) = click_import_bootstrap.load_siblings(
-    __package__, "click_hook_transport"
+(click_hook_transport, click_host_coverage, click_runner_transport) = (
+    click_import_bootstrap.load_siblings(
+        __package__, "click_hook_transport", "click_host_coverage", "click_runner_transport"
+    )
 )
 
 
@@ -48,15 +50,21 @@ class _BoundedText(io.StringIO):
         return len(value)
 
 
+# Host adapters register their Windows runner renderer when imported: Codex
+# rewrites into PowerShell or cmd.exe, Claude Code into Git Bash. Each package
+# bundles only its own adapter, so a missing sibling is expected; the renderer
+# for the host that sent each event is activated per request.
+_HOST_RENDERER_MODULES = ("click_windows", "claude_hook")
+
+
 def _load_gate() -> Any:
     (click_gate,) = click_import_bootstrap.load_siblings(__package__, "click_gate")
     if os.name == "nt":
-        (click_windows, click_runner_transport) = click_import_bootstrap.load_siblings(
-            __package__, "click_windows", "click_runner_transport"
-        )
-        click_runner_transport.install_runner_shell_renderer(
-            click_windows._runner_shell_command
-        )
+        for name in _HOST_RENDERER_MODULES:
+            try:
+                click_import_bootstrap.load_siblings(__package__, name)
+            except ImportError:
+                continue
     return click_gate
 
 
@@ -103,6 +111,10 @@ def _run_gate(click_gate: Any, request: dict[str, Any]) -> dict[str, Any]:
     if not target_cwd.is_dir():
         return _response(request_id, 1, "", "click hook error: invalid resident worker cwd\n")
 
+    if os.name == "nt":
+        click_runner_transport.activate_host_renderer(
+            click_host_coverage.host_id_from_event(event)
+        )
     input_text = json.dumps(event, ensure_ascii=False, separators=(",", ":"))
     output = _BoundedText()
     errors = _BoundedText()

--- a/dist/claude/hooks/click_runner_transport.py
+++ b/dist/claude/hooks/click_runner_transport.py
@@ -127,3 +127,24 @@ def install_runner_shell_renderer(
 
 def render_runner_shell_command(arguments: list[str]) -> str:
     return _runner_shell_renderer(arguments)
+
+
+# Hosts render the same runner argv for different tool shells: Codex on
+# Windows runs the rewritten command in PowerShell or cmd.exe, Claude Code in
+# Git Bash. Adapters register their renderer by host id and the resident
+# worker, which serves whichever host installed the package, activates the
+# right one for each event it dispatches.
+_host_renderers: dict[str, RunnerShellRenderer] = {}
+
+
+def register_host_renderer(host_id: str, renderer: RunnerShellRenderer) -> None:
+    if not isinstance(host_id, str) or not host_id or not callable(renderer):
+        raise TypeError("Click host renderers need a host id and a callable.")
+    _host_renderers[host_id] = renderer
+
+
+def activate_host_renderer(host_id: str) -> RunnerShellRenderer:
+    """Install the renderer registered for ``host_id`` (the default otherwise)."""
+    renderer = _host_renderers.get(host_id, default_runner_shell_command)
+    install_runner_shell_renderer(renderer)
+    return renderer

--- a/dist/claude/hooks/click_verification_bindings.py
+++ b/dist/claude/hooks/click_verification_bindings.py
@@ -395,7 +395,16 @@ def verification_environment_from_binding(
     binding: Any,
     runner_token: str,
     current_environment: dict[str, str],
+    *,
+    drift: dict[str, Any] | None = None,
 ) -> tuple[dict[str, str] | None, bool, str]:
+    """Project the runner's environment onto the prepared binding.
+
+    ``drift``, when given, receives ``{"changed": [names], "absent": count}``:
+    the fingerprinted variables whose value differs or that the Hook did not
+    bind, and how many bound variables the runner no longer sees (their names
+    exist only as keyed digests). Names only, never values.
+    """
     if not isinstance(binding, list) or not binding or len(binding) > 4096:
         return None, False, "Click verification runner environment binding was malformed."
     expected: dict[str, str] = {}
@@ -422,6 +431,7 @@ def verification_environment_from_binding(
     # fingerprinted value rebinds the receipt to what actually runs.
     matched: set[str] = set()
     drifted = False
+    changed: list[str] = []
     for key, value in environment_fingerprint(current_environment).items():
         normalized_key = verification_environment_key(str(key))
         key_digest = verification_environment_hmac(
@@ -430,15 +440,21 @@ def verification_environment_from_binding(
         expected_value = expected.get(key_digest)
         if expected_value is None:
             drifted = True
+            changed.append(normalized_key)
             continue
         current_value = verification_environment_hmac(
             runner_token, "value", f"{normalized_key}\0{value}"
         )
         if not secrets.compare_digest(expected_value, current_value):
             drifted = True
+            changed.append(normalized_key)
         matched.add(key_digest)
-    if matched != set(expected):
+    absent = len(set(expected) - matched)
+    if absent:
         drifted = True
+    if drift is not None:
+        drift["changed"] = sorted(changed)
+        drift["absent"] = absent
     return dict(current_environment), drifted, ""
 
 

--- a/dist/claude/hooks/click_verification_bindings.py
+++ b/dist/claude/hooks/click_verification_bindings.py
@@ -272,6 +272,13 @@ def normalized_search_path(value: str) -> str:
     entries: list[str] = []
     seen: set[str] = set()
     for entry in str(value).split(os.pathsep):
+        if os.name == "nt" and entry:
+            # Every MSYS hop (Git Bash, then sh) re-spells the Windows search
+            # path it hands to a native child: trailing separators dropped,
+            # doubled separators collapsed, the drive letter upper-cased. The
+            # Hook runs one hop deeper than the Bash tool, so the same
+            # directories would otherwise carry two identities.
+            entry = os.path.normcase(os.path.normpath(entry))
         key = os.path.normcase(entry)
         if key in own or key in seen or _is_plugin_command_directory(key):
             continue

--- a/dist/claude/hooks/click_verification_claims.py
+++ b/dist/claude/hooks/click_verification_claims.py
@@ -222,11 +222,13 @@ def _claim_verification_run(
     current_environment = _observer_environment(
         _verification_environment(cwd=Path.cwd()), verification
     )
+    environment_drift: dict[str, Any] = {}
     verification_environment, environment_rebound, binding_error = (
         _verification_environment_from_binding(
             running_environment_binding,
             runner_token,
             current_environment,
+            drift=environment_drift,
         )
     )
     if binding_error:
@@ -343,6 +345,7 @@ def _claim_verification_run(
     batch["_click_claim_binding"] = claim_binding
     batch["_click_verification_environment"] = verification_environment
     batch["_click_verification_environment_rebound"] = environment_rebound
+    batch["_click_verification_environment_drift"] = environment_drift
     batch["_click_command_plans"] = runtime_command_plans
     labels = verification.get("source_labels")
     batch["_click_source_labels"] = (

--- a/dist/claude/hooks/click_verification_runner.py
+++ b/dist/claude/hooks/click_verification_runner.py
@@ -220,6 +220,9 @@ def _run_verification_impl(
     environment_rebound = batch.pop(
         "_click_verification_environment_rebound", False
     )
+    environment_drift = batch.pop("_click_verification_environment_drift", {})
+    if not isinstance(environment_drift, dict):
+        environment_drift = {}
     claim_input_bindings = batch.pop("_click_explicit_input_bindings", None)
     if (
         not isinstance(claim_input_bindings, dict)
@@ -262,9 +265,22 @@ def _run_verification_impl(
         )
         active_authoritative_execute = click_authoritative_observer.run_command
     if environment_rebound:
+        # Name the variables (never their values) so a host that adds or
+        # rewrites one between the Hook and the tool call can be identified
+        # from the transcript instead of from a debugger.
+        changed = environment_drift.get("changed")
+        absent = environment_drift.get("absent")
+        details: list[str] = []
+        if isinstance(changed, list) and changed:
+            details.append("changed: " + ", ".join(str(name) for name in changed[:12]))
+            if len(changed) > 12:
+                details[-1] += f" and {len(changed) - 12} more"
+        if isinstance(absent, int) and absent > 0:
+            details.append(f"{absent} bound variable(s) absent")
         print(
-            "[Click] Verification runner environment changed after preparation; "
-            "rebound to the current canonical environment.",
+            "[Click] Verification runner environment changed after preparation"
+            + (f" ({'; '.join(details)})" if details else "")
+            + "; rebound to the current canonical environment.",
             flush=True,
         )
     before = git_workspace_snapshot(Path.cwd())

--- a/dist/claude/hooks/hooks.json
+++ b/dist/claude/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.py\" prompt-submit",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.sh\" prompt-submit",
             "timeout": 7
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.py\" pre-tool",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.sh\" pre-tool",
             "timeout": 7
           }
         ]
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.py\" post-tool",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.sh\" post-tool",
             "timeout": 7
           }
         ]
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.py\" session-end",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.sh\" session-end",
             "timeout": 3
           }
         ]

--- a/dist/claude/skills/click/references/claude-code.md
+++ b/dist/claude/skills/click/references/claude-code.md
@@ -6,7 +6,8 @@ Claude Code dispatches Click through the same Bash rewrite path as Codex:
 every `click-gate` action in the shared instructions is run as an ordinary
 `Bash` command, and the installed `PreToolUse` Hook rewrites it onto Click's
 trusted runner. Do not look for a `click-gate` executable on `PATH`, prefix it
-with `python3`, or reconstruct the runner path yourself.
+with `python3`, or reconstruct the runner path yourself. On Windows the Bash
+tool is Git Bash and the rewritten command is already shaped for it.
 
 ```text
 click-gate status

--- a/hooks/claude_hook.py
+++ b/hooks/claude_hook.py
@@ -23,6 +23,7 @@ import io
 import json
 import os
 from pathlib import Path
+import shlex
 import sys
 
 if __package__:
@@ -31,8 +32,10 @@ else:  # Executed directly from the bundled hooks directory.
     import click_import_bootstrap
 
 
-(click_hook_transport, click_host_coverage) = click_import_bootstrap.load_siblings(
-    __package__, "click_hook_transport", "click_host_coverage"
+(click_hook_transport, click_host_coverage, click_runner_transport) = (
+    click_import_bootstrap.load_siblings(
+        __package__, "click_hook_transport", "click_host_coverage", "click_runner_transport"
+    )
 )
 
 
@@ -41,6 +44,59 @@ CLAUDE_TOOL_MAP = click_host_coverage.CLAUDE_TOOL_MAP
 CLAUDE_MUTATION_TOOLS = click_host_coverage.CLAUDE_MUTATION_TOOL_NAMES
 CLAUDE_PLAN_TOOLS = click_host_coverage.CLAUDE_PLAN_TOOL_NAMES
 TOOL_EVENT_MODES = frozenset({"pre-tool", "post-tool"})
+
+
+def configure_streams() -> None:
+    """Read and write the host's JSON as UTF-8 whatever the console code page.
+
+    Claude Code sends and reads UTF-8. On Windows a pipe defaults to the
+    legacy code page, which can neither decode a Korean prompt nor encode the
+    result-line label in the Evidence context; the launcher passes ``-X utf8``
+    and this covers a direct ``python claude_hook.py`` call.
+    """
+    for stream in (sys.stdin, sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if callable(reconfigure):
+            try:
+                reconfigure(encoding="utf-8", errors="replace")
+            except (ValueError, OSError):
+                pass
+
+
+def runner_shell_command(arguments: list[str]) -> str:
+    """Render the rewritten runner for Claude Code's Bash tool.
+
+    The tool is Git Bash on Windows, so the command is POSIX-quoted there as on
+    every other host; the interpreter and script paths use forward slashes,
+    which Git Bash executes and Windows accepts, and everything after them
+    travels in the bounded encoded transport so no argument depends on the
+    MSYS path conversion or the console code page.
+    """
+    if os.name != "nt":
+        return click_runner_transport.default_runner_shell_command(arguments)
+    if len(arguments) < 3:
+        return "exit 2"
+    try:
+        interpreter = Path(arguments[0]).resolve(strict=True)
+        script_path = Path(arguments[1]).resolve(strict=True)
+    except (OSError, RuntimeError):
+        return "exit 2"
+    if not interpreter.is_file() or not script_path.is_file():
+        return "exit 2"
+    command = shlex.join(
+        [
+            str(interpreter).replace("\\", "/"),
+            str(script_path).replace("\\", "/"),
+            "--encoded-runner",
+            click_runner_transport.encode_runner_transport(arguments[2:]),
+        ]
+    )
+    if len(command) > click_runner_transport.WINDOWS_COMMAND_LINE_LIMIT:
+        return "exit 2"
+    return command
+
+
+click_runner_transport.register_host_renderer(HOST_ID, runner_shell_command)
 
 
 def configure_storage() -> None:
@@ -101,7 +157,10 @@ def merge_updated_input(
 
 
 def main() -> int:
+    configure_streams()
     configure_storage()
+    if os.name == "nt":
+        click_runner_transport.install_runner_shell_renderer(runner_shell_command)
     mode = sys.argv[1] if len(sys.argv) == 2 else ""
     if mode not in click_hook_transport.HOOK_MODES:
         (click_gate,) = click_import_bootstrap.load_siblings(__package__, "click_gate")

--- a/hooks/claude_hook.sh
+++ b/hooks/claude_hook.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Click Hook launcher for Claude Code.
+#
+# Claude Code runs a shell-form hook command through `sh -c` on macOS and
+# Linux and through Git Bash on Windows, so this file is POSIX sh. It selects a
+# Python 3 interpreter the way the Codex batch launcher does (`py -3`, then
+# `python`, then `python3` on Windows; `python3`, then `python` elsewhere),
+# skips the Microsoft Store alias stub that only offers to install Python, and
+# runs the adapter in UTF-8 mode so the host's JSON survives a legacy console
+# code page. Every argument is passed through to hooks/claude_hook.py.
+
+# Claude Code substitutes ${CLAUDE_PLUGIN_ROOT} with backslashes on Windows;
+# dirname only splits on "/", so normalize before locating the adapter.
+launcher=$(printf '%s\n' "$0" | tr '\\' '/')
+adapter=$(dirname "$launcher")/claude_hook.py
+
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*|Windows_NT)
+    windows=1
+    candidates="py python python3"
+    ;;
+  *)
+    windows=0
+    candidates="python3 python"
+    ;;
+esac
+
+for candidate in $candidates; do
+  resolved=$(command -v "$candidate" 2>/dev/null) || continue
+  [ -n "$resolved" ] || continue
+  if [ "$windows" = 1 ]; then
+    case "$resolved" in
+      *WindowsApps*|*windowsapps*)
+        # The App Execution Alias stub exits without running anything unless
+        # the Store build is installed; only a real interpreter passes this.
+        "$resolved" -c "import sys" </dev/null >/dev/null 2>&1 || continue
+        ;;
+    esac
+  fi
+  if [ "$candidate" = py ]; then
+    # The py launcher exits 103 without reading stdin when no Python 3 is
+    # registered with it; the next candidate then still sees the whole event.
+    "$resolved" -3 -X utf8 "$adapter" "$@"
+    status=$?
+    [ "$status" -eq 103 ] && continue
+    exit "$status"
+  fi
+  exec "$resolved" -X utf8 "$adapter" "$@"
+done
+
+echo "click hook error: Click requires Python 3; none of $candidates was found on PATH" >&2
+exit 127

--- a/hooks/click_hook_worker.py
+++ b/hooks/click_hook_worker.py
@@ -21,8 +21,10 @@ else:  # Executed directly from the bundled hooks directory.
     import click_import_bootstrap
 
 
-(click_hook_transport,) = click_import_bootstrap.load_siblings(
-    __package__, "click_hook_transport"
+(click_hook_transport, click_host_coverage, click_runner_transport) = (
+    click_import_bootstrap.load_siblings(
+        __package__, "click_hook_transport", "click_host_coverage", "click_runner_transport"
+    )
 )
 
 
@@ -48,15 +50,21 @@ class _BoundedText(io.StringIO):
         return len(value)
 
 
+# Host adapters register their Windows runner renderer when imported: Codex
+# rewrites into PowerShell or cmd.exe, Claude Code into Git Bash. Each package
+# bundles only its own adapter, so a missing sibling is expected; the renderer
+# for the host that sent each event is activated per request.
+_HOST_RENDERER_MODULES = ("click_windows", "claude_hook")
+
+
 def _load_gate() -> Any:
     (click_gate,) = click_import_bootstrap.load_siblings(__package__, "click_gate")
     if os.name == "nt":
-        (click_windows, click_runner_transport) = click_import_bootstrap.load_siblings(
-            __package__, "click_windows", "click_runner_transport"
-        )
-        click_runner_transport.install_runner_shell_renderer(
-            click_windows._runner_shell_command
-        )
+        for name in _HOST_RENDERER_MODULES:
+            try:
+                click_import_bootstrap.load_siblings(__package__, name)
+            except ImportError:
+                continue
     return click_gate
 
 
@@ -103,6 +111,10 @@ def _run_gate(click_gate: Any, request: dict[str, Any]) -> dict[str, Any]:
     if not target_cwd.is_dir():
         return _response(request_id, 1, "", "click hook error: invalid resident worker cwd\n")
 
+    if os.name == "nt":
+        click_runner_transport.activate_host_renderer(
+            click_host_coverage.host_id_from_event(event)
+        )
     input_text = json.dumps(event, ensure_ascii=False, separators=(",", ":"))
     output = _BoundedText()
     errors = _BoundedText()

--- a/hooks/click_runner_transport.py
+++ b/hooks/click_runner_transport.py
@@ -127,3 +127,24 @@ def install_runner_shell_renderer(
 
 def render_runner_shell_command(arguments: list[str]) -> str:
     return _runner_shell_renderer(arguments)
+
+
+# Hosts render the same runner argv for different tool shells: Codex on
+# Windows runs the rewritten command in PowerShell or cmd.exe, Claude Code in
+# Git Bash. Adapters register their renderer by host id and the resident
+# worker, which serves whichever host installed the package, activates the
+# right one for each event it dispatches.
+_host_renderers: dict[str, RunnerShellRenderer] = {}
+
+
+def register_host_renderer(host_id: str, renderer: RunnerShellRenderer) -> None:
+    if not isinstance(host_id, str) or not host_id or not callable(renderer):
+        raise TypeError("Click host renderers need a host id and a callable.")
+    _host_renderers[host_id] = renderer
+
+
+def activate_host_renderer(host_id: str) -> RunnerShellRenderer:
+    """Install the renderer registered for ``host_id`` (the default otherwise)."""
+    renderer = _host_renderers.get(host_id, default_runner_shell_command)
+    install_runner_shell_renderer(renderer)
+    return renderer

--- a/hooks/click_verification_bindings.py
+++ b/hooks/click_verification_bindings.py
@@ -395,7 +395,16 @@ def verification_environment_from_binding(
     binding: Any,
     runner_token: str,
     current_environment: dict[str, str],
+    *,
+    drift: dict[str, Any] | None = None,
 ) -> tuple[dict[str, str] | None, bool, str]:
+    """Project the runner's environment onto the prepared binding.
+
+    ``drift``, when given, receives ``{"changed": [names], "absent": count}``:
+    the fingerprinted variables whose value differs or that the Hook did not
+    bind, and how many bound variables the runner no longer sees (their names
+    exist only as keyed digests). Names only, never values.
+    """
     if not isinstance(binding, list) or not binding or len(binding) > 4096:
         return None, False, "Click verification runner environment binding was malformed."
     expected: dict[str, str] = {}
@@ -422,6 +431,7 @@ def verification_environment_from_binding(
     # fingerprinted value rebinds the receipt to what actually runs.
     matched: set[str] = set()
     drifted = False
+    changed: list[str] = []
     for key, value in environment_fingerprint(current_environment).items():
         normalized_key = verification_environment_key(str(key))
         key_digest = verification_environment_hmac(
@@ -430,15 +440,21 @@ def verification_environment_from_binding(
         expected_value = expected.get(key_digest)
         if expected_value is None:
             drifted = True
+            changed.append(normalized_key)
             continue
         current_value = verification_environment_hmac(
             runner_token, "value", f"{normalized_key}\0{value}"
         )
         if not secrets.compare_digest(expected_value, current_value):
             drifted = True
+            changed.append(normalized_key)
         matched.add(key_digest)
-    if matched != set(expected):
+    absent = len(set(expected) - matched)
+    if absent:
         drifted = True
+    if drift is not None:
+        drift["changed"] = sorted(changed)
+        drift["absent"] = absent
     return dict(current_environment), drifted, ""
 
 

--- a/hooks/click_verification_bindings.py
+++ b/hooks/click_verification_bindings.py
@@ -272,6 +272,13 @@ def normalized_search_path(value: str) -> str:
     entries: list[str] = []
     seen: set[str] = set()
     for entry in str(value).split(os.pathsep):
+        if os.name == "nt" and entry:
+            # Every MSYS hop (Git Bash, then sh) re-spells the Windows search
+            # path it hands to a native child: trailing separators dropped,
+            # doubled separators collapsed, the drive letter upper-cased. The
+            # Hook runs one hop deeper than the Bash tool, so the same
+            # directories would otherwise carry two identities.
+            entry = os.path.normcase(os.path.normpath(entry))
         key = os.path.normcase(entry)
         if key in own or key in seen or _is_plugin_command_directory(key):
             continue

--- a/hooks/click_verification_claims.py
+++ b/hooks/click_verification_claims.py
@@ -222,11 +222,13 @@ def _claim_verification_run(
     current_environment = _observer_environment(
         _verification_environment(cwd=Path.cwd()), verification
     )
+    environment_drift: dict[str, Any] = {}
     verification_environment, environment_rebound, binding_error = (
         _verification_environment_from_binding(
             running_environment_binding,
             runner_token,
             current_environment,
+            drift=environment_drift,
         )
     )
     if binding_error:
@@ -343,6 +345,7 @@ def _claim_verification_run(
     batch["_click_claim_binding"] = claim_binding
     batch["_click_verification_environment"] = verification_environment
     batch["_click_verification_environment_rebound"] = environment_rebound
+    batch["_click_verification_environment_drift"] = environment_drift
     batch["_click_command_plans"] = runtime_command_plans
     labels = verification.get("source_labels")
     batch["_click_source_labels"] = (

--- a/hooks/click_verification_runner.py
+++ b/hooks/click_verification_runner.py
@@ -220,6 +220,9 @@ def _run_verification_impl(
     environment_rebound = batch.pop(
         "_click_verification_environment_rebound", False
     )
+    environment_drift = batch.pop("_click_verification_environment_drift", {})
+    if not isinstance(environment_drift, dict):
+        environment_drift = {}
     claim_input_bindings = batch.pop("_click_explicit_input_bindings", None)
     if (
         not isinstance(claim_input_bindings, dict)
@@ -262,9 +265,22 @@ def _run_verification_impl(
         )
         active_authoritative_execute = click_authoritative_observer.run_command
     if environment_rebound:
+        # Name the variables (never their values) so a host that adds or
+        # rewrites one between the Hook and the tool call can be identified
+        # from the transcript instead of from a debugger.
+        changed = environment_drift.get("changed")
+        absent = environment_drift.get("absent")
+        details: list[str] = []
+        if isinstance(changed, list) and changed:
+            details.append("changed: " + ", ".join(str(name) for name in changed[:12]))
+            if len(changed) > 12:
+                details[-1] += f" and {len(changed) - 12} more"
+        if isinstance(absent, int) and absent > 0:
+            details.append(f"{absent} bound variable(s) absent")
         print(
-            "[Click] Verification runner environment changed after preparation; "
-            "rebound to the current canonical environment.",
+            "[Click] Verification runner environment changed after preparation"
+            + (f" ({'; '.join(details)})" if details else "")
+            + "; rebound to the current canonical environment.",
             flush=True,
         )
     before = git_workspace_snapshot(Path.cwd())

--- a/hooks/click_windows.py
+++ b/hooks/click_windows.py
@@ -63,6 +63,9 @@ def _runner_shell_command(arguments: list[str]) -> str:
     return command
 
 
+click_runner_transport.register_host_renderer("codex", _runner_shell_command)
+
+
 def main() -> int:
     if os.name == "nt":
         click_runner_transport.install_runner_shell_renderer(_runner_shell_command)

--- a/platforms/claude/README.md
+++ b/platforms/claude/README.md
@@ -78,9 +78,23 @@ receipts never cross hosts.
 - The `plugin://click@click` autocomplete mention is a Codex surface. On Claude
   Code, bypass and cancel use the plain first-line `@Click bypass` and
   `@Click cancel` forms.
-- The Hook command invokes `python3`; Linux and macOS are the supported hosts.
-  The Windows launcher bundled with the Codex plugin is not part of this
-  package.
+- The Hook command is `sh "${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.sh"`, a
+  shell-form hook on purpose: exec form has no shell and so no way to fall
+  back between interpreters. Claude Code runs it through `sh -c` on Linux and
+  macOS and through Git Bash on Windows. The POSIX launcher runs `python3`
+  (then `python`) on Linux and macOS and `py -3`, `python`, `python3` in that
+  order on Windows, skips the Microsoft Store alias that only offers to
+  install Python, and starts the adapter in UTF-8 mode so a Korean prompt or
+  the localized result-line label survives a legacy console code page.
+- Windows needs Git for Windows: Claude Code's Bash tool and its shell-form
+  Hooks run there. Rewritten `click-gate` commands are rendered for Git Bash
+  (forward-slash interpreter and script paths plus the bounded encoded
+  transport). Without Git Bash, Claude Code offers only its PowerShell tool,
+  which this package does not rewrite yet. The Codex Windows batch bridge is
+  not part of this package.
+- Python checks are the Windows scope: the resident worker, receipts, sharding
+  and the inbox ETW observer follow the shared runtime. Conditional JS reuse
+  (the Node observer) is Linux-only on every host.
 - Automatic input observation keeps its documented platform prerequisites; the
   host does not change which observer backends are available.
 

--- a/platforms/claude/hooks.json
+++ b/platforms/claude/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.py\" prompt-submit",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.sh\" prompt-submit",
             "timeout": 7
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.py\" pre-tool",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.sh\" pre-tool",
             "timeout": 7
           }
         ]
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.py\" post-tool",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.sh\" post-tool",
             "timeout": 7
           }
         ]
@@ -41,7 +41,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.py\" session-end",
+            "command": "sh \"${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.sh\" session-end",
             "timeout": 3
           }
         ]

--- a/scripts/build_claude_distribution.py
+++ b/scripts/build_claude_distribution.py
@@ -32,8 +32,9 @@ PLATFORM = ROOT / "platforms" / "claude"
 DESTINATION = ROOT / "dist" / "claude"
 
 # Claude Code keeps the resident Hook worker that Antigravity omits and drops
-# the Antigravity launcher plus the Windows batch bridge, which the Claude Code
-# Hook command does not invoke.
+# the Antigravity launcher plus the Codex Windows batch bridge: Claude Code
+# runs its Hook command through sh (Git Bash on Windows), so the package ships
+# the POSIX launcher `claude_hook.sh` instead.
 CLAUDE_HOOK_EXCLUDES = frozenset(
     {
         "antigravity_gate.py",
@@ -42,6 +43,7 @@ CLAUDE_HOOK_EXCLUDES = frozenset(
 )
 CLAUDE_ONLY_HOOK_FILES = (
     "claude_hook.py",
+    "claude_hook.sh",
     "click_hook.py",
     "click_hook_transport.py",
     "click_hook_worker.py",
@@ -51,7 +53,7 @@ HOOK_FILES = tuple(
         (set(SHARED_HOOK_FILES) - CLAUDE_HOOK_EXCLUDES) | set(CLAUDE_ONLY_HOOK_FILES)
     )
 )
-EXTRA_HOOK_SOURCES = ANTIGRAVITY_EXTRA_HOOK_SOURCES
+EXTRA_HOOK_SOURCES = ANTIGRAVITY_EXTRA_HOOK_SOURCES | {"claude_hook.sh"}
 CLICK_REFERENCE_FILES = tuple(
     name for name in SHARED_REFERENCE_FILES if name != "antigravity.md"
 ) + ("claude-code.md",)

--- a/scripts/validate_distribution.py
+++ b/scripts/validate_distribution.py
@@ -259,8 +259,11 @@ def _validate_claude(root: Path, errors: list[str], release_version: str) -> Non
             "PreToolUse, PostToolUse, and SessionEnd"
         )
     serialized = json.dumps(hook_config, sort_keys=True)
+    # Shell form on purpose: exec form cannot fall back between `py`, `python`
+    # and `python3`, and Claude Code runs shell-form hooks through Git Bash on
+    # Windows, where the POSIX launcher selects the interpreter.
     for marker in (
-        "${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.py",
+        'sh \\"${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.sh\\"',
         "MultiEdit",
         "NotebookEdit",
         "TodoWrite",
@@ -268,9 +271,20 @@ def _validate_claude(root: Path, errors: list[str], release_version: str) -> Non
     ):
         if marker not in serialized:
             errors.append(f"Claude Code hooks.json is missing `{marker}`")
-    for forbidden in ("commandWindows", "additionalContextLimit", "${PLUGIN_ROOT}"):
+    for forbidden in ("commandWindows", "additionalContextLimit", "${PLUGIN_ROOT}", '"args"', "claude_hook.py"):
         if forbidden in serialized:
             errors.append(f"Claude Code hooks.json must not use `{forbidden}`")
+    launcher = root / "hooks" / "claude_hook.sh"
+    if not launcher.is_file():
+        errors.append("Claude Code launcher hooks/claude_hook.sh is missing")
+    else:
+        launcher_text = launcher.read_text(encoding="utf-8")
+        if not launcher_text.startswith("#!/bin/sh\n"):
+            errors.append("Claude Code launcher must be POSIX sh")
+        if "\r" in launcher_text:
+            errors.append("Claude Code launcher must use LF line endings")
+        if "python3" not in launcher_text or "py" not in launcher_text:
+            errors.append("Claude Code launcher must try the py launcher and python3")
 
     marketplace = _json(root / ".claude-plugin" / "marketplace.json", errors, root)
     try:

--- a/skills/click/references/claude-code.md
+++ b/skills/click/references/claude-code.md
@@ -6,7 +6,8 @@ Claude Code dispatches Click through the same Bash rewrite path as Codex:
 every `click-gate` action in the shared instructions is run as an ordinary
 `Bash` command, and the installed `PreToolUse` Hook rewrites it onto Click's
 trusted runner. Do not look for a `click-gate` executable on `PATH`, prefix it
-with `python3`, or reconstruct the runner path yourself.
+with `python3`, or reconstruct the runner path yourself. On Windows the Bash
+tool is Git Bash and the rewritten command is already shaped for it.
 
 ```text
 click-gate status

--- a/tests/test_claude_adapter.py
+++ b/tests/test_claude_adapter.py
@@ -19,26 +19,28 @@ PROMPT_ID = "550e8400-e29b-41d4-a716-446655440000"
 LATER_PROMPT_ID = "550e8400-e29b-41d4-a716-446655440001"
 
 
-def _runner_tail(command: str) -> list[str]:
-    """Return the runner arguments after the interpreter on either host OS.
+def _runner_argv(command: str) -> list[str]:
+    """Return the rewritten runner's argv on either host OS.
 
-    POSIX renders ``<python> -c <script> <payload>``; Windows renders the bare
-    ``py -3`` launcher with an encoded transport for everything after it.
+    Claude Code's Bash tool is Git Bash on Windows, so the adapter renders a
+    POSIX-quoted command everywhere. POSIX keeps ``<python> -c <script>
+    <payload>`` inline; Windows renders forward-slash interpreter and script
+    paths with the bounded encoded transport for everything after them.
     """
+    argv = shlex.split(command)
     if os.name == "nt":
-        from hooks import antigravity_gate
-
-        argv = antigravity_gate._command_argv(command)
-        if argv[:2] != ["py", "-3"] or argv[3] != "--encoded-runner":
+        interpreter = str(Path(sys.executable).resolve()).replace("\\", "/")
+        if argv[0] != interpreter or "\\" in argv[0] + argv[1]:
             raise AssertionError(command)
-        decoded, error = click_runner_transport.decode_runner_transport(argv[4])
+        if argv[2] != "--encoded-runner" or len(argv) != 4:
+            raise AssertionError(command)
+        decoded, error = click_runner_transport.decode_runner_transport(argv[3])
         if error or decoded is None:
             raise AssertionError(error or command)
-        return [argv[2], *decoded]
-    argv = shlex.split(command)
+        return [sys.executable, argv[1], *decoded]
     if argv[0] != sys.executable:
         raise AssertionError(command)
-    return argv[1:]
+    return argv
 
 
 def _matcher_names(config: dict, event_name: str) -> set[str]:
@@ -212,7 +214,17 @@ class ClaudePlatformManifestTests(unittest.TestCase):
                 for hook in entry["hooks"]:
                     with self.subTest(event=event_name):
                         self.assertEqual(hook["type"], "command")
-                        self.assertIn('"${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.py"', hook["command"])
+                        # Shell form on purpose: Claude Code runs it through
+                        # `sh -c` on macOS and Linux and Git Bash on Windows,
+                        # where the POSIX launcher picks the interpreter. Exec
+                        # form (`args`) has no shell and so no fallback between
+                        # `py`, `python` and `python3`.
+                        self.assertRegex(
+                            hook["command"],
+                            r'^sh "\$\{CLAUDE_PLUGIN_ROOT\}/hooks/claude_hook\.sh" (prompt-submit|pre-tool|post-tool|session-end)$',
+                        )
+                        self.assertNotIn("args", hook)
+                        self.assertNotIn("shell", hook)
                         self.assertLessEqual(hook["timeout"], 7)
                         self.assertNotIn("commandWindows", hook)
 
@@ -286,6 +298,21 @@ class ClaudeHookProcessTests(unittest.TestCase):
         payload = json.loads(result.stdout) if result.stdout else {}
         return result.returncode, payload, result.stderr
 
+    def run_rewritten(self, command: str) -> str:
+        """Execute a rewritten Bash-tool command the way the host shell would."""
+        argv = _runner_argv(command)
+        result = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            env=self.environment,
+            cwd=str(self.workspace),
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return result.stdout
+
     def test_evidence_context_and_rewritten_commands_keep_claude_input_fields(self) -> None:
         code, payload, stderr = self.hook(
             "prompt-submit", self.event("UserPromptSubmit", prompt="Run the tests.")
@@ -319,9 +346,8 @@ class ClaudeHookProcessTests(unittest.TestCase):
         self.assertEqual(specific["updatedInput"]["description"], "Show Click status")
         self.assertEqual(specific["updatedInput"]["timeout"], 120000)
         self.assertNotEqual(specific["updatedInput"]["command"], "click-gate status --json")
-        tail = _runner_tail(specific["updatedInput"]["command"])
-        self.assertEqual(tail[0], "-c")
-        self.assertEqual(json.loads(tail[-1])["task"]["runtime_mode"], "evidence")
+        report = json.loads(self.run_rewritten(specific["updatedInput"]["command"]))
+        self.assertEqual(report["task"]["runtime_mode"], "evidence")
 
         # The default form is a short localized summary, not the JSON report.
         self.environment["CLICK_LANGUAGE"] = "en"
@@ -335,10 +361,9 @@ class ClaudeHookProcessTests(unittest.TestCase):
             ),
         )
         self.assertEqual((code, stderr), (0, ""))
-        summary = _runner_tail(payload["hookSpecificOutput"]["updatedInput"]["command"])
-        self.assertEqual(summary[0], "-c")
+        summary = self.run_rewritten(payload["hookSpecificOutput"]["updatedInput"]["command"])
         self.assertEqual(
-            summary[2:],
+            summary.splitlines(),
             [
                 "Executed 0 · Reused 0",
                 "Evidence mode · Revision 0 · No registered checks",
@@ -384,7 +409,7 @@ class ClaudeHookProcessTests(unittest.TestCase):
             self.event("PreToolUse", tool_name="Bash", tool_input={"command": "click-gate status --json"}, tool_use_id="s"),
         )
         self.assertEqual(code, 0)
-        status = json.loads(_runner_tail(payload["hookSpecificOutput"]["updatedInput"]["command"])[-1])
+        status = json.loads(self.run_rewritten(payload["hookSpecificOutput"]["updatedInput"]["command"]))
         self.assertEqual(status["task"]["mutation_revision"], 3)
         self.assertEqual(status["task"]["runtime_mode"], "evidence")
 

--- a/tests/test_claude_launcher.py
+++ b/tests/test_claude_launcher.py
@@ -404,28 +404,6 @@ class GitBashIntegrationTests(unittest.TestCase):
             except OSError:
                 time.sleep(0.25)
 
-    def test_git_bash_environment_diagnostics(self) -> None:
-        """Temporary: print the PATH each launch flow hands to Python."""
-        plugin_root = write_package(self.base / "diag")
-        environment = self.environment(plugin_root, self.base / "diag data", "0")
-        probe = "import json, os, sys; print(json.dumps({'PATH': os.environ.get('PATH'), 'executable': sys.executable, 'keys': sorted(os.environ)}))"
-        # The launcher chain itself, with the adapter replaced by the probe.
-        (plugin_root / "hooks" / "claude_hook.py").write_text(probe + "\n", encoding="utf-8")
-        flows = {
-            "bash-python": f"python -c \"{probe}\"",
-            "bash-sh-python": f"sh -c 'python -c \"{probe}\"'",
-            "bash-sh-py": f"sh -c 'py -3 -c \"{probe}\"'",
-            "bash-launcher": hook_command("pre-tool").replace("${CLAUDE_PLUGIN_ROOT}", str(plugin_root)),
-        }
-        results: dict[str, object] = {}
-        for name, command in flows.items():
-            result = self.bash_run(command, stdin="", cwd=self.base, environment=environment)
-            try:
-                results[name] = json.loads(result.stdout)
-            except json.JSONDecodeError:
-                results[name] = {"stdout": result.stdout[:2000], "stderr": result.stderr[:2000], "rc": result.returncode}
-        print("CLAUDE-GIT-BASH-DIAGNOSTICS " + json.dumps(results, ensure_ascii=True))
-
     def test_hooks_and_rewritten_commands_run_through_git_bash(self) -> None:
         for root_name, worker in (("click", "1"), ("Click Plugin Root With Spaces", "0")):
             with self.subTest(plugin_root=root_name, worker=worker):

--- a/tests/test_claude_launcher.py
+++ b/tests/test_claude_launcher.py
@@ -18,6 +18,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 
 from hooks import claude_hook, click_runner_transport
@@ -378,6 +379,53 @@ class GitBashIntegrationTests(unittest.TestCase):
             timeout=120,
         )
 
+    def stop_session(self, workspace: Path, environment: dict[str, str], spelled_root: str, root_name: str) -> None:
+        command = hook_command("session-end").replace("${CLAUDE_PLUGIN_ROOT}", spelled_root)
+        event = json.dumps(
+            {
+                "session_id": f"claude-windows-{root_name}".replace(" ", "-"),
+                "transcript_path": str(self.base / "transcript.jsonl"),
+                "cwd": str(workspace),
+                "permission_mode": "default",
+                "hook_event_name": "SessionEnd",
+                "prompt_id": PROMPT_ID,
+                "reason": "other",
+            }
+        )
+        try:
+            self.bash_run(command, stdin=event, cwd=workspace, environment=environment)
+        except (OSError, subprocess.SubprocessError):
+            pass
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            try:
+                shutil.rmtree(workspace)
+                return
+            except OSError:
+                time.sleep(0.25)
+
+    def test_git_bash_environment_diagnostics(self) -> None:
+        """Temporary: print the PATH each launch flow hands to Python."""
+        plugin_root = write_package(self.base / "diag")
+        environment = self.environment(plugin_root, self.base / "diag data", "0")
+        probe = "import json, os, sys; print(json.dumps({'PATH': os.environ.get('PATH'), 'executable': sys.executable, 'keys': sorted(os.environ)}))"
+        # The launcher chain itself, with the adapter replaced by the probe.
+        (plugin_root / "hooks" / "claude_hook.py").write_text(probe + "\n", encoding="utf-8")
+        flows = {
+            "bash-python": f"python -c \"{probe}\"",
+            "bash-sh-python": f"sh -c 'python -c \"{probe}\"'",
+            "bash-sh-py": f"sh -c 'py -3 -c \"{probe}\"'",
+            "bash-launcher": hook_command("pre-tool").replace("${CLAUDE_PLUGIN_ROOT}", str(plugin_root)),
+        }
+        results: dict[str, object] = {}
+        for name, command in flows.items():
+            result = self.bash_run(command, stdin="", cwd=self.base, environment=environment)
+            try:
+                results[name] = json.loads(result.stdout)
+            except json.JSONDecodeError:
+                results[name] = {"stdout": result.stdout[:2000], "stderr": result.stderr[:2000], "rc": result.returncode}
+        print("CLAUDE-GIT-BASH-DIAGNOSTICS " + json.dumps(results, ensure_ascii=True))
+
     def test_hooks_and_rewritten_commands_run_through_git_bash(self) -> None:
         for root_name, worker in (("click", "1"), ("Click Plugin Root With Spaces", "0")):
             with self.subTest(plugin_root=root_name, worker=worker):
@@ -400,6 +448,10 @@ class GitBashIntegrationTests(unittest.TestCase):
                 # (backslash) path before Git Bash sees the command.
                 spelled_root = str(plugin_root)
                 self.assertIn("\\", spelled_root)
+                # The resident worker keeps the workspace as its cwd until the
+                # session ends; stop it even when an assertion fails so the
+                # temporary directory can be removed.
+                self.addCleanup(self.stop_session, workspace, environment, spelled_root, root_name)
 
                 def hook(mode: str, event: dict[str, object]) -> dict[str, object]:
                     command = hook_command(mode).replace("${CLAUDE_PLUGIN_ROOT}", spelled_root)
@@ -449,8 +501,11 @@ class GitBashIntegrationTests(unittest.TestCase):
                 self.assertIn("--encoded-runner", rewritten)
                 executed = self.bash_run(rewritten, stdin="", cwd=workspace, environment=environment)
                 self.assertEqual(executed.returncode, 0, f"{executed.stderr}\n{executed.stdout}")
-                self.assertIn("Ran 1 test", executed.stdout + executed.stderr)
+                # Actionable reporting summarizes a passing check instead of
+                # relaying its output; the diagnostic line is the evidence.
                 self.assertIn("[Click verification 1/1:", executed.stdout + executed.stderr)
+                self.assertIn("passed.", executed.stdout)
+                self.assertNotIn("environment changed after preparation", executed.stdout)
                 hook("post-tool", event("PostToolUse", tool_name="Bash", tool_use_id="toolu_verify",
                                         tool_input={"command": f"click-gate verify -- {check}"},
                                         tool_response={"stdout": executed.stdout, "stderr": executed.stderr}))
@@ -478,8 +533,7 @@ class GitBashIntegrationTests(unittest.TestCase):
                 executed = self.bash_run(rewritten, stdin="", cwd=workspace, environment=environment)
                 self.assertEqual(executed.returncode, 0, f"{executed.stderr}\n{executed.stdout}")
                 self.assertIn("Click reused 1 current", executed.stdout, f"{executed.stderr}\n{executed.stdout}")
-                self.assertNotIn("Ran 1 test", executed.stdout + executed.stderr)
-                hook("session-end", event("SessionEnd", reason="other"))
+                self.assertNotIn("[Click verification 1/1:", executed.stdout + executed.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_claude_launcher.py
+++ b/tests/test_claude_launcher.py
@@ -1,0 +1,469 @@
+"""The Claude Code Hook launcher and the Windows (Git Bash) host path.
+
+Claude Code runs a shell-form hook command through ``sh -c`` on macOS and
+Linux and through Git Bash on Windows. ``hooks/claude_hook.sh`` selects the
+Python 3 interpreter there, and ``claude_hook.py`` renders rewritten commands
+for Git Bash on Windows. The interpreter selection is exercised on every OS
+with fake interpreters on a private PATH; the Git Bash end-to-end path runs
+only on Windows, where the CI runner ships Git for Windows.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from hooks import claude_hook, click_runner_transport
+from scripts import build_claude_distribution
+
+
+ROOT = Path(__file__).parents[1]
+LAUNCHER = ROOT / "hooks" / "claude_hook.sh"
+SH = shutil.which("sh") or "sh"
+HOOKS_JSON = ROOT / "platforms" / "claude" / "hooks.json"
+PROMPT_ID = "550e8400-e29b-41d4-a716-446655440000"
+COREUTILS = ("uname", "tr", "dirname", "cat")
+
+
+def hook_command(mode: str) -> str:
+    config = json.loads(HOOKS_JSON.read_text(encoding="utf-8"))
+    event_name = {
+        "prompt-submit": "UserPromptSubmit",
+        "pre-tool": "PreToolUse",
+        "post-tool": "PostToolUse",
+        "session-end": "SessionEnd",
+    }[mode]
+    return config["hooks"][event_name][0]["hooks"][0]["command"]
+
+
+def git_bash() -> str | None:
+    """Git for Windows' bash.exe, which Claude Code uses for shell-form hooks."""
+    if os.name != "nt":
+        return None
+    found = shutil.which("bash")
+    if found and "Git" in found:
+        return found
+    for variable in ("ProgramFiles", "ProgramW6432", "ProgramFiles(x86)"):
+        base = os.environ.get(variable)
+        if base:
+            candidate = Path(base) / "Git" / "bin" / "bash.exe"
+            if candidate.is_file():
+                return str(candidate)
+    return found
+
+
+def write_package(destination: Path) -> Path:
+    """Materialize the exact Claude Code package the marketplace installs."""
+    for relative, contents in build_claude_distribution.expected_files(ROOT).items():
+        path = destination / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(contents)
+    return destination
+
+
+class LauncherScriptTests(unittest.TestCase):
+    def test_launcher_is_posix_sh_with_lf_endings_and_ships_in_the_package(self) -> None:
+        raw = LAUNCHER.read_bytes()
+        self.assertTrue(raw.startswith(b"#!/bin/sh\n"))
+        self.assertNotIn(b"\r", raw)
+        text = raw.decode("utf-8")
+        for name in ("py", "python", "python3", "-X utf8", "WindowsApps", "103"):
+            self.assertIn(name, text)
+        self.assertIn("claude_hook.sh", build_claude_distribution.HOOK_FILES)
+        self.assertIn(
+            Path("hooks/claude_hook.sh"), build_claude_distribution.expected_files(ROOT)
+        )
+        attributes = (ROOT / ".gitattributes").read_text(encoding="utf-8")
+        self.assertIn("*.sh text eol=lf", attributes)
+        for mode in ("prompt-submit", "pre-tool", "post-tool", "session-end"):
+            self.assertEqual(
+                hook_command(mode), f'sh "${{CLAUDE_PLUGIN_ROOT}}/hooks/claude_hook.sh" {mode}'
+            )
+
+    @unittest.skipIf(os.name == "nt", "POSIX sh syntax check")
+    def test_launcher_parses_under_sh(self) -> None:
+        result = subprocess.run(["sh", "-n", str(LAUNCHER)], capture_output=True, text=True)
+        self.assertEqual((result.returncode, result.stderr), (0, ""))
+
+    @unittest.skipIf(os.name == "nt", "Claude Code runs shell-form hooks through sh -c here")
+    def test_shell_form_command_runs_the_packaged_adapter(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            plugin_root = write_package(base / "click plugin")
+            workspace = base / "workspace"
+            workspace.mkdir()
+            environment = {
+                key: value
+                for key, value in os.environ.items()
+                if key not in {"PLUGIN_DATA", "CLICK_CONFIG_HOME"}
+            }
+            environment.update(
+                {
+                    "CLAUDE_PLUGIN_ROOT": str(plugin_root),
+                    "CLAUDE_PLUGIN_DATA": str(base / "data"),
+                    "CLICK_HOOK_WORKER": "0",
+                    "CLICK_LANGUAGE": "en",
+                }
+            )
+            command = hook_command("prompt-submit").replace("${CLAUDE_PLUGIN_ROOT}", str(plugin_root))
+            event = {
+                "session_id": "claude-launcher",
+                "transcript_path": str(base / "transcript.jsonl"),
+                "cwd": str(workspace),
+                "permission_mode": "default",
+                "hook_event_name": "UserPromptSubmit",
+                "prompt_id": PROMPT_ID,
+                "prompt": "테스트를 실행해줘",
+            }
+            result = subprocess.run(
+                ["sh", "-c", command],
+                input=json.dumps(event, ensure_ascii=False),
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                cwd=str(workspace),
+                env=environment,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, f"{result.stderr}\n{result.stdout}")
+            payload = json.loads(result.stdout)
+            context = payload["hookSpecificOutput"]["additionalContext"]
+            self.assertIn("Click Evidence mode is enabled", context)
+            self.assertIn("`[Click result]`", context)
+
+
+@unittest.skipIf(os.name == "nt", "fake interpreters on a private PATH need POSIX sh")
+class LauncherInterpreterSelectionTests(unittest.TestCase):
+    """Drive the selection order with fake interpreters and a fake uname."""
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.base = Path(self.temporary.name)
+        self.tools = self.base / "tools"
+        self.tools.mkdir()
+        for name in COREUTILS:
+            real = shutil.which(name)
+            self.assertIsNotNone(real, name)
+            os.symlink(real, self.tools / name)
+        self.record = self.base / "record.txt"
+        self.plugin = self.base / "plugin root with spaces"
+        (self.plugin / "hooks").mkdir(parents=True)
+        shutil.copy(LAUNCHER, self.plugin / "hooks" / "claude_hook.sh")
+        (self.plugin / "hooks" / "claude_hook.py").write_text("", encoding="utf-8")
+
+    def fake(self, directory: Path, name: str, body: str) -> None:
+        directory.mkdir(parents=True, exist_ok=True)
+        path = directory / name
+        path.write_text("#!/bin/sh\n" + body, encoding="utf-8")
+        path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+    def recorder(self, label: str) -> str:
+        return f'printf \'%s\\n\' "{label}" "$@" > "{self.record}"\ncat > /dev/null\nexit 0\n'
+
+    def run_launcher(self, *directories: Path, uname: str | None = None) -> subprocess.CompletedProcess[str]:
+        path_entries = [str(directory) for directory in directories]
+        if uname is not None:
+            fake_uname = self.base / "uname-override"
+            self.fake(fake_uname, "uname", f"printf '%s\\n' '{uname}'\n")
+            path_entries.insert(0, str(fake_uname))
+        path_entries.append(str(self.tools))
+        return subprocess.run(
+            [SH, str(self.plugin / "hooks" / "claude_hook.sh"), "pre-tool"],
+            input='{"hook_event_name":"PreToolUse"}',
+            capture_output=True,
+            text=True,
+            env={"PATH": os.pathsep.join(path_entries), "LC_ALL": "C"},
+            check=False,
+        )
+
+    def recorded(self) -> list[str]:
+        return self.record.read_text(encoding="utf-8").splitlines()
+
+    def test_posix_prefers_python3_then_python_in_utf8_mode(self) -> None:
+        both = self.base / "both"
+        self.fake(both, "python3", self.recorder("python3"))
+        self.fake(both, "python", self.recorder("python"))
+        self.fake(both, "py", self.recorder("py"))
+        result = self.run_launcher(both)
+        self.assertEqual((result.returncode, result.stderr), (0, ""))
+        adapter = str(self.plugin / "hooks" / "claude_hook.py")
+        self.assertEqual(self.recorded(), ["python3", "-X", "utf8", adapter, "pre-tool"])
+
+        only_python = self.base / "only-python"
+        self.fake(only_python, "python", self.recorder("python"))
+        self.fake(only_python, "py", self.recorder("py"))
+        result = self.run_launcher(only_python)
+        self.assertEqual((result.returncode, result.stderr), (0, ""))
+        self.assertEqual(self.recorded()[0], "python")
+
+    def test_windows_prefers_the_py_launcher_and_skips_the_store_stub(self) -> None:
+        windows = self.base / "windows"
+        self.fake(windows, "py", self.recorder("py"))
+        self.fake(windows, "python", self.recorder("python"))
+        self.fake(windows, "python3", self.recorder("python3"))
+        result = self.run_launcher(windows, uname="MINGW64_NT-10.0-22631")
+        self.assertEqual((result.returncode, result.stderr), (0, ""))
+        adapter = str(self.plugin / "hooks" / "claude_hook.py")
+        self.assertEqual(self.recorded(), ["py", "-3", "-X", "utf8", adapter, "pre-tool"])
+
+        # The py launcher exits 103 when no Python 3 is registered with it and
+        # never reads stdin, so the next candidate still receives the event.
+        no_python3 = self.base / "py-without-python3"
+        self.fake(no_python3, "py", "exit 103\n")
+        self.fake(no_python3, "python", self.recorder("python"))
+        result = self.run_launcher(no_python3, uname="MSYS_NT-10.0")
+        self.assertEqual((result.returncode, result.stderr), (0, ""))
+        self.assertEqual(self.recorded()[0], "python")
+
+        # The Microsoft Store alias stub under WindowsApps only offers to
+        # install Python; a candidate there must prove it can run `import sys`.
+        store = self.base / "Microsoft" / "WindowsApps"
+        self.fake(store, "python", "echo 'Python was not found' >&2\nexit 9009\n")
+        self.fake(store, "python3", self.recorder("python3-store"))
+        result = self.run_launcher(store, uname="MINGW64_NT-10.0-22631")
+        self.assertEqual((result.returncode, result.stderr), (0, ""))
+        self.assertEqual(self.recorded()[0], "python3-store")
+
+    def test_missing_interpreter_is_reported_without_running_anything(self) -> None:
+        result = self.run_launcher(self.base / "empty")
+        self.assertEqual(result.returncode, 127)
+        self.assertIn("click hook error: Click requires Python 3", result.stderr)
+        self.assertEqual(result.stdout, "")
+        self.assertFalse(self.record.exists())
+
+    def test_launcher_normalizes_a_backslash_plugin_root(self) -> None:
+        # Claude Code substitutes ${CLAUDE_PLUGIN_ROOT} with backslashes on
+        # Windows, so $0 arrives as `C:\...\click/hooks/claude_hook.sh`. The
+        # launcher converts the separators before locating the adapter next to
+        # itself. A POSIX directory whose name contains a literal backslash
+        # reproduces that spelling without Windows.
+        both = self.base / "both"
+        self.fake(both, "python3", self.recorder("python3"))
+        spelled_hooks = self.base / "plugin\\hooks"
+        spelled_hooks.mkdir()
+        shutil.copy(LAUNCHER, spelled_hooks / "claude_hook.sh")
+        normalized_hooks = self.base / "plugin" / "hooks"
+        normalized_hooks.mkdir(parents=True)
+        (normalized_hooks / "claude_hook.py").write_text("", encoding="utf-8")
+        result = subprocess.run(
+            [SH, str(spelled_hooks / "claude_hook.sh"), "post-tool"],
+            input="{}",
+            capture_output=True,
+            text=True,
+            env={"PATH": os.pathsep.join([str(both), str(self.tools)]), "LC_ALL": "C"},
+            check=False,
+        )
+        self.assertEqual((result.returncode, result.stderr), (0, ""))
+        self.assertEqual(self.recorded()[3], str(normalized_hooks / "claude_hook.py"))
+
+
+class ClaudeRunnerRenderingTests(unittest.TestCase):
+    def test_claude_renderer_is_registered_and_activated_by_host_id(self) -> None:
+        previous = click_runner_transport.install_runner_shell_renderer(
+            click_runner_transport.default_runner_shell_command
+        )
+        try:
+            self.assertIs(
+                click_runner_transport.activate_host_renderer("claude"),
+                claude_hook.runner_shell_command,
+            )
+            self.assertIs(
+                click_runner_transport._runner_shell_renderer, claude_hook.runner_shell_command
+            )
+            self.assertIs(
+                click_runner_transport.activate_host_renderer("unknown-host"),
+                click_runner_transport.default_runner_shell_command,
+            )
+        finally:
+            click_runner_transport.install_runner_shell_renderer(previous)
+        with self.assertRaises(TypeError):
+            click_runner_transport.register_host_renderer("", claude_hook.runner_shell_command)
+
+    @unittest.skipIf(os.name == "nt", "POSIX rendering")
+    def test_posix_rendering_is_the_shared_default(self) -> None:
+        arguments = [sys.executable, "-c", "import sys; print(sys.argv)", "a b", "c'd"]
+        self.assertEqual(
+            claude_hook.runner_shell_command(arguments),
+            click_runner_transport.default_runner_shell_command(arguments),
+        )
+
+    @unittest.skipUnless(os.name == "nt", "Git Bash rendering")
+    def test_windows_rendering_targets_git_bash(self) -> None:
+        script = ROOT / "hooks" / "click_gate.py"
+        command = claude_hook.runner_shell_command(
+            [sys.executable, str(script), "run-json-report", "C:\\state root\\report.json", "summary"]
+        )
+        import shlex
+
+        argv = shlex.split(command)
+        self.assertEqual(len(argv), 4)
+        self.assertEqual(argv[0], str(Path(sys.executable).resolve()).replace("\\", "/"))
+        self.assertEqual(argv[1], str(script.resolve()).replace("\\", "/"))
+        self.assertNotIn("\\", argv[0] + argv[1])
+        self.assertEqual(argv[2], "--encoded-runner")
+        decoded, error = click_runner_transport.decode_runner_transport(argv[3])
+        self.assertEqual(error, "")
+        self.assertEqual(decoded, ["run-json-report", "C:\\state root\\report.json", "summary"])
+        # Inline `-c` payloads have no script file to resolve, so the report
+        # falls back to its bounded file form, as it does for Codex on Windows.
+        self.assertEqual(claude_hook.runner_shell_command([sys.executable, "-c", "print(1)"]), "exit 2")
+        self.assertEqual(claude_hook.runner_shell_command([sys.executable, str(script)]), "exit 2")
+        self.assertEqual(
+            claude_hook.runner_shell_command([sys.executable, str(script / "missing.py"), "x"]),
+            "exit 2",
+        )
+
+
+@unittest.skipUnless(os.name == "nt", "Claude Code on Windows runs hooks and the Bash tool in Git Bash")
+class GitBashIntegrationTests(unittest.TestCase):
+    """The installed package driven through Git Bash the way Claude Code does it."""
+
+    def setUp(self) -> None:
+        self.bash = git_bash()
+        self.assertIsNotNone(self.bash, "Git for Windows bash.exe is required on the Windows runner")
+        # The resident worker may still be exiting when the directory goes.
+        self.temporary = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        self.addCleanup(self.temporary.cleanup)
+        self.base = Path(self.temporary.name)
+
+    def environment(self, plugin_root: Path, plugin_data: Path, worker: str) -> dict[str, str]:
+        environment = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in {"PLUGIN_DATA", "CLICK_CONFIG_HOME", "CLAUDE_PLUGIN_DATA", "CLICK_LANGUAGE"}
+        }
+        # A default Git for Windows install puts only Git\cmd on the Windows
+        # PATH; `sh` must still resolve inside bash.exe from the MSYS runtime.
+        environment["PATH"] = os.pathsep.join(
+            entry
+            for entry in environment.get("PATH", "").split(os.pathsep)
+            if not (
+                "git" in entry.lower()
+                and any(entry.lower().rstrip("\\").endswith(tail) for tail in ("\\bin", "\\usr\\bin", "\\mingw64\\bin"))
+            )
+        )
+        environment.update(
+            {
+                "CLAUDE_PLUGIN_ROOT": str(plugin_root),
+                "CLAUDE_PLUGIN_DATA": str(plugin_data),
+                "CLICK_HOOK_WORKER": worker,
+                "CLICK_LANGUAGE": "en",
+                # Pin the py launcher to this interpreter's version so the
+                # hook, the runner and the check agree; a version the launcher
+                # does not know exits 103 and falls through to `python`.
+                "PY_PYTHON": f"{sys.version_info.major}.{sys.version_info.minor}",
+                "PY_PYTHON3": f"{sys.version_info.major}.{sys.version_info.minor}",
+            }
+        )
+        return environment
+
+    def bash_run(self, command: str, *, stdin: str, cwd: Path, environment: dict[str, str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [self.bash, "-c", command],
+            input=stdin,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=str(cwd),
+            env=environment,
+            check=False,
+            timeout=120,
+        )
+
+    def test_hooks_and_rewritten_commands_run_through_git_bash(self) -> None:
+        for root_name, worker in (("click", "1"), ("Click Plugin Root With Spaces", "0")):
+            with self.subTest(plugin_root=root_name, worker=worker):
+                plugin_root = write_package(self.base / root_name)
+                plugin_data = self.base / f"{root_name} data"
+                workspace = self.base / f"{root_name} workspace"
+                workspace.mkdir()
+                subprocess.run(["git", "init", "-q", str(workspace)], check=True)
+                (workspace / "calc.py").write_text("VALUE = 1\n", encoding="utf-8")
+                (workspace / "test_calc.py").write_text(
+                    "import unittest\nimport calc\n\n\nclass CalcTests(unittest.TestCase):\n"
+                    "    def test_value(self):\n        self.assertEqual(calc.VALUE, 1)\n",
+                    encoding="utf-8",
+                )
+                environment = self.environment(plugin_root, plugin_data, worker)
+                # Claude Code substitutes the placeholder with the native
+                # (backslash) path before Git Bash sees the command.
+                spelled_root = str(plugin_root)
+                self.assertIn("\\", spelled_root)
+
+                def hook(mode: str, event: dict[str, object]) -> dict[str, object]:
+                    command = hook_command(mode).replace("${CLAUDE_PLUGIN_ROOT}", spelled_root)
+                    result = self.bash_run(command, stdin=json.dumps(event), cwd=workspace, environment=environment)
+                    self.assertEqual(result.returncode, 0, f"{mode} hook failed:\n{result.stderr}\n{result.stdout}")
+                    self.assertNotIn("click hook error", result.stderr)
+                    return json.loads(result.stdout) if result.stdout.strip() else {}
+
+                def event(hook_event_name: str, **extra: object) -> dict[str, object]:
+                    return {
+                        "session_id": f"claude-windows-{root_name}".replace(" ", "-"),
+                        "transcript_path": str(self.base / "transcript.jsonl"),
+                        "cwd": str(workspace),
+                        "permission_mode": "default",
+                        "hook_event_name": hook_event_name,
+                        "prompt_id": PROMPT_ID,
+                        **extra,
+                    }
+
+                prompt = hook("prompt-submit", event("UserPromptSubmit", prompt="테스트를 실행해줘 (run the tests)"))
+                context = prompt["hookSpecificOutput"]["additionalContext"]
+                self.assertIn("Click Evidence mode is enabled", context)
+                self.assertIn("`[Click result]`", context)
+
+                status = hook(
+                    "pre-tool",
+                    event("PreToolUse", tool_name="Bash", tool_use_id="toolu_status",
+                          tool_input={"command": "click-gate status --json", "description": "status"}),
+                )
+                rewritten = status["hookSpecificOutput"]["updatedInput"]["command"]
+                self.assertEqual(status["hookSpecificOutput"]["permissionDecision"], "allow")
+                self.assertEqual(status["hookSpecificOutput"]["updatedInput"]["description"], "status")
+                self.assertNotIn("py -3", rewritten)
+                self.assertNotIn("powershell", rewritten.lower())
+                self.assertIn("--encoded-runner", rewritten)
+                executed = self.bash_run(rewritten, stdin="", cwd=workspace, environment=environment)
+                self.assertEqual(executed.returncode, 0, executed.stderr)
+                self.assertEqual(json.loads(executed.stdout)["task"]["runtime_mode"], "evidence")
+
+                check = "python -m unittest -q test_calc"
+                verify = hook(
+                    "pre-tool",
+                    event("PreToolUse", tool_name="Bash", tool_use_id="toolu_verify",
+                          tool_input={"command": f"click-gate verify -- {check}"}),
+                )
+                rewritten = verify["hookSpecificOutput"]["updatedInput"]["command"]
+                self.assertIn("--encoded-runner", rewritten)
+                executed = self.bash_run(rewritten, stdin="", cwd=workspace, environment=environment)
+                self.assertEqual(executed.returncode, 0, f"{executed.stderr}\n{executed.stdout}")
+                self.assertIn("Ran 1 test", executed.stdout + executed.stderr)
+                self.assertIn("[Click verification 1/1:", executed.stdout + executed.stderr)
+                hook("post-tool", event("PostToolUse", tool_name="Bash", tool_use_id="toolu_verify",
+                                        tool_input={"command": f"click-gate verify -- {check}"},
+                                        tool_response={"stdout": executed.stdout, "stderr": executed.stderr}))
+
+                summary = hook(
+                    "pre-tool",
+                    event("PreToolUse", tool_name="Bash", tool_use_id="toolu_summary",
+                          tool_input={"command": "click-gate status"}),
+                )
+                executed = self.bash_run(
+                    summary["hookSpecificOutput"]["updatedInput"]["command"], stdin="", cwd=workspace, environment=environment
+                )
+                self.assertEqual(executed.returncode, 0, executed.stderr)
+                self.assertTrue(executed.stdout.startswith("Executed 1 "), executed.stdout)
+                hook("session-end", event("SessionEnd", reason="other"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_claude_launcher.py
+++ b/tests/test_claude_launcher.py
@@ -386,6 +386,9 @@ class GitBashIntegrationTests(unittest.TestCase):
                 workspace = self.base / f"{root_name} workspace"
                 workspace.mkdir()
                 subprocess.run(["git", "init", "-q", str(workspace)], check=True)
+                # A real project ignores bytecode; Click reports any untracked
+                # path a check leaves behind, and unittest writes __pycache__.
+                (workspace / ".gitignore").write_text("__pycache__/\n", encoding="utf-8")
                 (workspace / "calc.py").write_text("VALUE = 1\n", encoding="utf-8")
                 (workspace / "test_calc.py").write_text(
                     "import unittest\nimport calc\n\n\nclass CalcTests(unittest.TestCase):\n"
@@ -462,6 +465,20 @@ class GitBashIntegrationTests(unittest.TestCase):
                 )
                 self.assertEqual(executed.returncode, 0, executed.stderr)
                 self.assertTrue(executed.stdout.startswith("Executed 1 "), executed.stdout)
+
+                # The same check resubmitted with nothing changed is reused:
+                # the Hook-side and runner-side environment fingerprints agree
+                # under Git Bash, so the receipt is current.
+                again = hook(
+                    "pre-tool",
+                    event("PreToolUse", tool_name="Bash", tool_use_id="toolu_verify_again",
+                          tool_input={"command": f"click-gate verify -- {check}"}),
+                )
+                rewritten = again["hookSpecificOutput"]["updatedInput"]["command"]
+                executed = self.bash_run(rewritten, stdin="", cwd=workspace, environment=environment)
+                self.assertEqual(executed.returncode, 0, f"{executed.stderr}\n{executed.stdout}")
+                self.assertIn("Click reused 1 current", executed.stdout, f"{executed.stderr}\n{executed.stdout}")
+                self.assertNotIn("Ran 1 test", executed.stdout + executed.stderr)
                 hook("session-end", event("SessionEnd", reason="other"))
 
 

--- a/tests/test_click_verification_bindings.py
+++ b/tests/test_click_verification_bindings.py
@@ -277,6 +277,18 @@ class VerificationBindingStageTests(unittest.TestCase):
         _, drifted, _ = bindings.verification_environment_from_binding(binding, "t" * 32, missing_bound)
         self.assertTrue(drifted)
 
+        # The drift report names what moved, never the values.
+        drift: dict[str, object] = {}
+        bindings.verification_environment_from_binding(binding, "t" * 32, changed_noise, drift=drift)
+        self.assertEqual(drift, {"changed": [], "absent": 0})
+        bindings.verification_environment_from_binding(
+            binding, "t" * 32, {**changed_bound, "LANG": "C.UTF-8"}, drift=drift
+        )
+        self.assertEqual(drift, {"changed": ["LANG", "TZ"], "absent": 0})
+        bindings.verification_environment_from_binding(binding, "t" * 32, missing_bound, drift=drift)
+        self.assertEqual(drift, {"changed": [], "absent": 1})
+        self.assertNotIn("Etc/GMT+7", repr(drift))
+
     def test_executable_payload_uses_content_instead_of_volatile_mtime(self):
         baseline = {
             "name": "npx.cmd",

--- a/tests/test_click_verification_bindings.py
+++ b/tests/test_click_verification_bindings.py
@@ -131,6 +131,14 @@ class VerificationBindingStageTests(unittest.TestCase):
         own = sorted(bindings._own_command_directories())[0]
         plugin_bin = str(Path(own))
         entries = ["/usr/local/bin", "/usr/bin", "/home/user/.local/bin"]
+
+        def spelled(*values: str) -> str:
+            # Windows entries are re-spelled to one canonical form (see
+            # test_windows_search_path_spellings_share_one_identity).
+            if os.name == "nt":
+                return os.pathsep.join(os.path.normcase(os.path.normpath(value)) for value in values)
+            return os.pathsep.join(values)
+
         # The Hook process sees a repeated entry; the tool call that runs the
         # verification sees Click's own command directory appended instead.
         hook = os.pathsep.join([*entries, "/usr/bin"])
@@ -139,18 +147,18 @@ class VerificationBindingStageTests(unittest.TestCase):
         self.assertEqual(
             bindings.normalized_search_path(hook), bindings.normalized_search_path(runner)
         )
-        self.assertEqual(bindings.normalized_search_path(hook), os.pathsep.join(entries))
+        self.assertEqual(bindings.normalized_search_path(hook), spelled(*entries))
         # Order and every distinct directory are preserved: a repeat can never
         # win over its first occurrence, so dropping it changes no resolution.
         self.assertEqual(
             bindings.normalized_search_path(os.pathsep.join(["/b", "/a", "/b"])),
-            os.pathsep.join(["/b", "/a"]),
+            spelled("/b", "/a"),
         )
         # Only the search path is normalized; other values stay verbatim.
         fingerprint = bindings.environment_fingerprint(
             {"PATH": hook, "TZ": "UTC" + os.pathsep + "UTC"}
         )
-        self.assertEqual(fingerprint["PATH"], os.pathsep.join(entries))
+        self.assertEqual(fingerprint["PATH"], spelled(*entries))
         self.assertEqual(fingerprint["TZ"], "UTC" + os.pathsep + "UTC")
         # A real directory difference still changes the identity.
         self.assertNotEqual(

--- a/tests/test_click_verification_bindings.py
+++ b/tests/test_click_verification_bindings.py
@@ -259,6 +259,35 @@ class VerificationBindingStageTests(unittest.TestCase):
                         malformed,
                     )
 
+    @unittest.skipUnless(os.name == "nt", "Windows search-path spelling")
+    def test_windows_search_path_spellings_share_one_identity(self):
+        # Git Bash hands `bash -c python` the raw Windows entries and
+        # `bash -c 'sh …'` the re-spelled ones; both name the same directories.
+        raw = ";".join(
+            [
+                "C:\\Program Files\\dotnet\\",
+                "C:\\\\ghcup\\bin",
+                "c:\\tools\\php",
+                "C:\\Windows\\System32\\OpenSSH\\",
+            ]
+        )
+        respelled = ";".join(
+            [
+                "C:\\Program Files\\dotnet",
+                "C:\\ghcup\\bin",
+                "C:\\tools\\php",
+                "C:\\Windows\\System32\\OpenSSH",
+            ]
+        )
+        self.assertEqual(
+            bindings.normalized_search_path(raw), bindings.normalized_search_path(respelled)
+        )
+        self.assertEqual(bindings.normalized_search_path(raw).count(";"), 3)
+        self.assertNotEqual(
+            bindings.normalized_search_path(raw),
+            bindings.normalized_search_path(raw + ";C:\\extra"),
+        )
+
     def test_environment_binding_covers_only_the_fingerprint_subset(self):
         execution = {"PATH": "/usr/bin", "PWD": "/work", "DATABASE_URL": "one", "TZ": "UTC"}
         binding = bindings.verification_environment_binding(execution, "t" * 32)


### PR DESCRIPTION
## Summary

Claude Code on Windows was excluded from the Claude Code package: the Hook command ran `python3`, which a python.org install does not provide, and on Windows the resident worker imported `click_windows.py`, which only the Codex package bundles, so it died on startup. This PR makes the Claude Code package work on Windows for Python checks (step 2 of the plan toward the plugin-directory submission; JS conditional reuse stays Linux-only).

**Facts the design rests on** (Claude Code docs: [hooks reference](https://code.claude.com/docs/en/hooks), [plugins reference](https://code.claude.com/docs/en/plugins-reference)):
- A shell-form hook (no `args`) runs through `sh -c` on macOS/Linux and **Git Bash on Windows** (PowerShell only when Git Bash is absent, in which case the Bash tool is not registered either).
- There is no per-OS hook field (nothing like Codex's `commandWindows`); exec form (`args`) spawns without a shell and therefore cannot fall back between `py`, `python` and `python3`.

**Changes**
- `hooks/claude_hook.sh` (new, POSIX sh): selects `py -3` → `python` → `python3` on Windows (skips the Microsoft Store alias stub under `WindowsApps`, treats the py launcher's exit 103 as "no Python 3 registered" and falls through without consuming stdin), `python3` → `python` elsewhere; runs the adapter with `-X utf8`; normalizes the backslash `${CLAUDE_PLUGIN_ROOT}` Claude Code substitutes.
- `platforms/claude/hooks.json`: all four hooks are `sh "${CLAUDE_PLUGIN_ROOT}/hooks/claude_hook.sh" <mode>` (shell form on purpose; validator forbids `args`, `shell`, `commandWindows`).
- `hooks/claude_hook.py`: reconfigures stdin/stdout/stderr to UTF-8 (a Korean prompt or the localized result-line label would otherwise fail on a cp1252/cp949 pipe); `runner_shell_command` renders rewritten commands for Git Bash on Windows (forward-slash interpreter and script paths + bounded encoded transport, `exit 2` → file-report fallback for inline `-c`, as Codex does); registered as the `claude` host renderer.
- `hooks/click_runner_transport.py`: `register_host_renderer` / `activate_host_renderer`. `hooks/click_windows.py` registers `codex`. `hooks/click_hook_worker.py` loads whichever adapter the package bundles and activates the renderer of the host that sent each event.
- Build/validate: `claude_hook.sh` ships in `dist/claude`; validator checks the launcher (POSIX sh, LF, py+python3 chain) and the hook command shape. `.gitattributes` pins `*.sh` to LF so a `core.autocrlf` checkout cannot break it.
- Docs: READMEs (en/ko/zh-CN), `platforms/claude/README.md`, `skills/click/references/claude-code.md`, `COMPATIBILITY_SURFACE.md`, `RELEASE_NOTES.md` (Unreleased v1.2 candidate).

## Tests

- `tests/test_claude_launcher.py` (new)
  - every OS: launcher is POSIX sh/LF and shipped; selection order, Store-stub skip, exit-103 fallback and backslash-root normalization with fake interpreters and a fake `uname` on a private PATH; the shell-form command runs the packaged adapter through `sh -c` (POSIX); renderer registry.
  - Windows only: the exact package (`expected_files`) driven through `bash.exe -c` with the native backslash plugin root and a default-install PATH (`Git\bin`, `Git\usr\bin`, `Git\mingw64\bin` removed): UserPromptSubmit context, `click-gate status --json` rewrite executed in Git Bash, `click-gate verify -- python -m unittest -q test_calc` executed in Git Bash, PostToolUse, `click-gate status` summary (`Executed 1 …`), SessionEnd; once with the resident worker and once one-shot, one root with spaces.
- `tests/test_claude_adapter.py`: hooks.json expectations updated; rewritten commands are now executed and their output checked (`_runner_argv` handles the Git Bash form on Windows).
- Local (Linux): affected suites pass (`test_claude_adapter`, `test_claude_launcher`, `test_windows_hook_commands`, `test_click_hook_worker`, `test_click_runner_transport`, `test_distribution_validation`, `test_repository_policy`); `validate_distribution.py` passes. The full local run is still in progress at PR time; Windows behaviour is only verified by the `windows-latest` CI jobs, which is the point of the new tests.

## Reviewer notes

- The `sh` inside Git Bash resolves from the MSYS runtime even when only `Git\cmd` is on the Windows PATH; the Windows test strips the other Git directories to prove that. If that assumption fails on CI, the fallback is `"${BASH:-sh}"`-style launching, which I avoided because Claude Code substitutes `${…}` placeholders textually.
- Not in scope: the PowerShell tool (`matcher: PowerShell`, Windows without Git Bash) and Windows/macOS JS observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
