### PR TITLE
Announce Node inspector endpoints with files instead of a FIFO

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,6 +11,14 @@
   not to use `click-gate` until a new session; tool hooks stay silent, so no
   tool call is blocked or littered with error lines. The Codex Windows batch
   launcher prints the same install instructions.
+- The JS runtime observer's endpoint transport is portable. Each observed Node
+  process announces its inspector endpoint in an `endpoint-<pid>.json` file
+  that the controller polls for, instead of writing into a FIFO the runner had
+  to `mkfifo` and hold open; the acknowledgement file and worker markers are
+  unchanged. The conditional projection treats the announcement as the
+  collector's own directory write it already ignored. Nothing else about the
+  Linux profile changes; this is the first step toward the same observer on
+  Windows.
 
 ## v1.2.0 — 2026-09-13 — Claude Code on Windows
 

--- a/dist/antigravity/hooks/click_conditional_observer.py
+++ b/dist/antigravity/hooks/click_conditional_observer.py
@@ -59,7 +59,6 @@ ordinary inputs. No application read is removed because it is later written.
         return None
     root = Path(project).resolve()
     ready = str(Path(directory) / f"ready-{next(iter(tree.process_ids))}")
-    pipe = str(Path(directory) / "endpoints.pipe")
     started, lines = False, []
     for line in tree.trace.decode("utf-8", errors="strict").splitlines():
         _, call_line = linux._strip_pid(line.strip())
@@ -76,8 +75,6 @@ ordinary inputs. No application read is removed because it is later written.
             if linux._return_integer(result) == 0:
                 started = True
             continue
-        if path == pipe and call == "openat" and "O_WRONLY" in arguments:
-            continue
         # libc probes kernel statx availability with a null pointer. EFAULT
         # supplies no filesystem value and is not a missing path dependency.
         if call == "statx" and arguments.startswith("0, NULL,") and result.startswith("-1 EFAULT"):
@@ -89,7 +86,7 @@ ordinary inputs. No application read is removed because it is later written.
             # fixed output transport. Stdin and arbitrary descriptors do not.
             continue
         if path and path.startswith(str(directory) + "/") and call in linux._OPEN_CALLS and "O_WRONLY" in arguments:
-            continue  # the collector's own transport files, written by the bootstrap
+            continue  # the collector's own transport files (endpoint announcement, worker markers), written by the bootstrap
         if (path == "/proc/self/cgroup" or (path and re.fullmatch(r"/proc/[0-9]+/cgroup", path))
                 or (path and path.startswith("/sys/fs/cgroup/") and path.endswith(("/memory.high", "/memory.max")))):
             # libuv and V8 read the process cgroup and memory limits when the

--- a/dist/antigravity/hooks/click_node_bootstrap.mjs
+++ b/dist/antigravity/hooks/click_node_bootstrap.mjs
@@ -18,10 +18,12 @@ if (directory && ownedOptions && isMainThread && !testRunner && !priorPreload) {
     if (!inspector.url()) {
       inspector.open(0, '127.0.0.1', false);
       owned = true;
-      const descriptor = fs.openSync(path.join(directory, 'endpoints.pipe'), 'w');
-      try {
-        fs.writeSync(descriptor, JSON.stringify({ pid: process.pid, url: inspector.url() }) + '\n');
-      } finally { fs.closeSync(descriptor); }
+      // One announcement file per process: a plain create-and-write that
+      // every host supports, which the collector polls for. A FIFO would
+      // need a POSIX-only mkfifo and a rename would be an extra file event
+      // for the projection to explain.
+      fs.writeFileSync(path.join(directory, `endpoint-${process.pid}.json`),
+        JSON.stringify({ pid: process.pid, url: inspector.url() }) + '\n', { mode: 0o600 });
       const acknowledgement = path.join(directory, `ready-${process.pid}`);
       const attached = await new Promise(resolve => {
         let attempts = 0;

--- a/dist/antigravity/hooks/click_node_controller.cjs
+++ b/dist/antigravity/hooks/click_node_controller.cjs
@@ -386,28 +386,42 @@ async function endpoint(value) {
   });
 }
 
+// Each target announces its inspector endpoint in `endpoint-<pid>.json`
+// (see click_node_bootstrap.mjs). Polling a directory needs no FIFO, socket
+// or pipe name, so the same transport serves every host. A file is consumed
+// once its single line is complete; a partial write is read again next tick.
+const ENDPOINT_FILE = /^endpoint-[0-9]+\.json$/;
+const consumed = new Set();
 let pendingInput = '';
-const input = fs.createReadStream(path.join(directory, 'endpoints.pipe'), { encoding: 'utf8' });
-input.on('data', chunk => {
-  pendingInput += chunk;
-  if (pendingInput.length > 65536) { failure('endpoint-limit'); pendingInput = ''; return; }
-  let newline;
-  while ((newline = pendingInput.indexOf('\n')) >= 0) {
-    const row = pendingInput.slice(0, newline); pendingInput = pendingInput.slice(newline + 1);
-    try { endpoint(JSON.parse(row)).catch(() => failure('session-setup-failed')); }
+function collectEndpoints() {
+  let names;
+  try { names = fs.readdirSync(directory); } catch { failure('endpoint-channel-failed'); return; }
+  for (const name of names) {
+    if (!ENDPOINT_FILE.test(name) || consumed.has(name)) continue;
+    const file = path.join(directory, name);
+    let row;
+    try { row = fs.readFileSync(file, 'utf8'); } catch { continue; }
+    if (row.length > 65536) { consumed.add(name); failure('endpoint-limit'); continue; }
+    const newline = row.indexOf('\n');
+    if (newline < 0) { pendingInput = row; continue; }
+    consumed.add(name);
+    pendingInput = '';
+    try { fs.unlinkSync(file); } catch {}
+    try { endpoint(JSON.parse(row.slice(0, newline))).catch(() => failure('session-setup-failed')); }
     catch { failure('invalid-endpoint'); }
   }
-});
-input.on('error', () => failure('endpoint-channel-failed'));
+}
+const input = setInterval(collectEndpoints, 10);
 process.stdin.resume();
 async function stop() {
   if (stopping) return;
   stopping = true;
+  clearInterval(input);
+  collectEndpoints();
   if (pendingInput.trim()) failure('endpoint-truncated');
   if (!sessions.size) failure('no-runtime-session');
   if ([...sessions].some(session => !session.finished)) failure('session-completion-unobserved');
   await Promise.allSettled([...sessions].map(session => session.release()));
-  input.destroy();
   sendLine({ kind: 'result', counts, sessions: sessions.size, contexts, installed, completed,
     workers: workerCount, process_ids: [...processIds].sort((a,b) => a-b), values: valueRecords,
     reasons: [...reasons].sort() });

--- a/dist/antigravity/hooks/click_node_observer.py
+++ b/dist/antigravity/hooks/click_node_observer.py
@@ -125,7 +125,6 @@ class Collector:
         self.record = empty("unsupported-runtime")
         self.child = None
         self.location = None
-        self.descriptor = None
         self.messages = queue.Queue(maxsize=8)
         self.process_ids = set()
         self.runtime_path = None
@@ -157,10 +156,9 @@ class Collector:
             self.location = tempfile.TemporaryDirectory(prefix="click-node-inputs-")
             directory = Path(self.location.name)
             os.chmod(directory, 0o700)
-            fifo = directory / "endpoints.pipe"
-            os.mkfifo(fifo, 0o600)
-            # Keep a reader and writer open across short-lived forked processes.
-            self.descriptor = os.open(fifo, os.O_RDWR | os.O_NONBLOCK | os.O_CLOEXEC)
+            # Targets announce their inspector endpoints as files in this
+            # directory and the controller polls for them: one transport for
+            # every host, with no FIFO, socket or pipe name to manage.
             child_environment = {key: value for key, value in environment.items()
                                  if key not in {"NODE_OPTIONS", "CLICK_NODE_OBSERVER_DIRECTORY"}}
             self.child = click_process.spawn_argv([str(node), str(Path(__file__).with_name("click_node_controller.cjs")), str(directory),
@@ -241,18 +239,6 @@ class Collector:
                 self.child.stdin.close()
             except OSError:
                 pass
-        # The controller reads the FIFO through a blocking pool thread, and
-        # its exit joins that pool. Unlink first so a late target cannot
-        # block opening a reader-less FIFO, then release the last writer so
-        # the pending read returns EOF instead of outliving a 5s wait.
-        if self.location is not None:
-            try:
-                (Path(self.location.name) / "endpoints.pipe").unlink()
-            except OSError:
-                pass
-        if self.descriptor is not None:
-            os.close(self.descriptor)
-            self.descriptor = None
         if self.child is not None:
             try:
                 if self.child.poll() is None:

--- a/dist/claude/hooks/click_conditional_observer.py
+++ b/dist/claude/hooks/click_conditional_observer.py
@@ -59,7 +59,6 @@ ordinary inputs. No application read is removed because it is later written.
         return None
     root = Path(project).resolve()
     ready = str(Path(directory) / f"ready-{next(iter(tree.process_ids))}")
-    pipe = str(Path(directory) / "endpoints.pipe")
     started, lines = False, []
     for line in tree.trace.decode("utf-8", errors="strict").splitlines():
         _, call_line = linux._strip_pid(line.strip())
@@ -76,8 +75,6 @@ ordinary inputs. No application read is removed because it is later written.
             if linux._return_integer(result) == 0:
                 started = True
             continue
-        if path == pipe and call == "openat" and "O_WRONLY" in arguments:
-            continue
         # libc probes kernel statx availability with a null pointer. EFAULT
         # supplies no filesystem value and is not a missing path dependency.
         if call == "statx" and arguments.startswith("0, NULL,") and result.startswith("-1 EFAULT"):
@@ -89,7 +86,7 @@ ordinary inputs. No application read is removed because it is later written.
             # fixed output transport. Stdin and arbitrary descriptors do not.
             continue
         if path and path.startswith(str(directory) + "/") and call in linux._OPEN_CALLS and "O_WRONLY" in arguments:
-            continue  # the collector's own transport files, written by the bootstrap
+            continue  # the collector's own transport files (endpoint announcement, worker markers), written by the bootstrap
         if (path == "/proc/self/cgroup" or (path and re.fullmatch(r"/proc/[0-9]+/cgroup", path))
                 or (path and path.startswith("/sys/fs/cgroup/") and path.endswith(("/memory.high", "/memory.max")))):
             # libuv and V8 read the process cgroup and memory limits when the

--- a/dist/claude/hooks/click_node_bootstrap.mjs
+++ b/dist/claude/hooks/click_node_bootstrap.mjs
@@ -18,10 +18,12 @@ if (directory && ownedOptions && isMainThread && !testRunner && !priorPreload) {
     if (!inspector.url()) {
       inspector.open(0, '127.0.0.1', false);
       owned = true;
-      const descriptor = fs.openSync(path.join(directory, 'endpoints.pipe'), 'w');
-      try {
-        fs.writeSync(descriptor, JSON.stringify({ pid: process.pid, url: inspector.url() }) + '\n');
-      } finally { fs.closeSync(descriptor); }
+      // One announcement file per process: a plain create-and-write that
+      // every host supports, which the collector polls for. A FIFO would
+      // need a POSIX-only mkfifo and a rename would be an extra file event
+      // for the projection to explain.
+      fs.writeFileSync(path.join(directory, `endpoint-${process.pid}.json`),
+        JSON.stringify({ pid: process.pid, url: inspector.url() }) + '\n', { mode: 0o600 });
       const acknowledgement = path.join(directory, `ready-${process.pid}`);
       const attached = await new Promise(resolve => {
         let attempts = 0;

--- a/dist/claude/hooks/click_node_controller.cjs
+++ b/dist/claude/hooks/click_node_controller.cjs
@@ -386,28 +386,42 @@ async function endpoint(value) {
   });
 }
 
+// Each target announces its inspector endpoint in `endpoint-<pid>.json`
+// (see click_node_bootstrap.mjs). Polling a directory needs no FIFO, socket
+// or pipe name, so the same transport serves every host. A file is consumed
+// once its single line is complete; a partial write is read again next tick.
+const ENDPOINT_FILE = /^endpoint-[0-9]+\.json$/;
+const consumed = new Set();
 let pendingInput = '';
-const input = fs.createReadStream(path.join(directory, 'endpoints.pipe'), { encoding: 'utf8' });
-input.on('data', chunk => {
-  pendingInput += chunk;
-  if (pendingInput.length > 65536) { failure('endpoint-limit'); pendingInput = ''; return; }
-  let newline;
-  while ((newline = pendingInput.indexOf('\n')) >= 0) {
-    const row = pendingInput.slice(0, newline); pendingInput = pendingInput.slice(newline + 1);
-    try { endpoint(JSON.parse(row)).catch(() => failure('session-setup-failed')); }
+function collectEndpoints() {
+  let names;
+  try { names = fs.readdirSync(directory); } catch { failure('endpoint-channel-failed'); return; }
+  for (const name of names) {
+    if (!ENDPOINT_FILE.test(name) || consumed.has(name)) continue;
+    const file = path.join(directory, name);
+    let row;
+    try { row = fs.readFileSync(file, 'utf8'); } catch { continue; }
+    if (row.length > 65536) { consumed.add(name); failure('endpoint-limit'); continue; }
+    const newline = row.indexOf('\n');
+    if (newline < 0) { pendingInput = row; continue; }
+    consumed.add(name);
+    pendingInput = '';
+    try { fs.unlinkSync(file); } catch {}
+    try { endpoint(JSON.parse(row.slice(0, newline))).catch(() => failure('session-setup-failed')); }
     catch { failure('invalid-endpoint'); }
   }
-});
-input.on('error', () => failure('endpoint-channel-failed'));
+}
+const input = setInterval(collectEndpoints, 10);
 process.stdin.resume();
 async function stop() {
   if (stopping) return;
   stopping = true;
+  clearInterval(input);
+  collectEndpoints();
   if (pendingInput.trim()) failure('endpoint-truncated');
   if (!sessions.size) failure('no-runtime-session');
   if ([...sessions].some(session => !session.finished)) failure('session-completion-unobserved');
   await Promise.allSettled([...sessions].map(session => session.release()));
-  input.destroy();
   sendLine({ kind: 'result', counts, sessions: sessions.size, contexts, installed, completed,
     workers: workerCount, process_ids: [...processIds].sort((a,b) => a-b), values: valueRecords,
     reasons: [...reasons].sort() });

--- a/dist/claude/hooks/click_node_observer.py
+++ b/dist/claude/hooks/click_node_observer.py
@@ -125,7 +125,6 @@ class Collector:
         self.record = empty("unsupported-runtime")
         self.child = None
         self.location = None
-        self.descriptor = None
         self.messages = queue.Queue(maxsize=8)
         self.process_ids = set()
         self.runtime_path = None
@@ -157,10 +156,9 @@ class Collector:
             self.location = tempfile.TemporaryDirectory(prefix="click-node-inputs-")
             directory = Path(self.location.name)
             os.chmod(directory, 0o700)
-            fifo = directory / "endpoints.pipe"
-            os.mkfifo(fifo, 0o600)
-            # Keep a reader and writer open across short-lived forked processes.
-            self.descriptor = os.open(fifo, os.O_RDWR | os.O_NONBLOCK | os.O_CLOEXEC)
+            # Targets announce their inspector endpoints as files in this
+            # directory and the controller polls for them: one transport for
+            # every host, with no FIFO, socket or pipe name to manage.
             child_environment = {key: value for key, value in environment.items()
                                  if key not in {"NODE_OPTIONS", "CLICK_NODE_OBSERVER_DIRECTORY"}}
             self.child = click_process.spawn_argv([str(node), str(Path(__file__).with_name("click_node_controller.cjs")), str(directory),
@@ -241,18 +239,6 @@ class Collector:
                 self.child.stdin.close()
             except OSError:
                 pass
-        # The controller reads the FIFO through a blocking pool thread, and
-        # its exit joins that pool. Unlink first so a late target cannot
-        # block opening a reader-less FIFO, then release the last writer so
-        # the pending read returns EOF instead of outliving a 5s wait.
-        if self.location is not None:
-            try:
-                (Path(self.location.name) / "endpoints.pipe").unlink()
-            except OSError:
-                pass
-        if self.descriptor is not None:
-            os.close(self.descriptor)
-            self.descriptor = None
         if self.child is not None:
             try:
                 if self.child.poll() is None:

--- a/hooks/click_conditional_observer.py
+++ b/hooks/click_conditional_observer.py
@@ -59,7 +59,6 @@ ordinary inputs. No application read is removed because it is later written.
         return None
     root = Path(project).resolve()
     ready = str(Path(directory) / f"ready-{next(iter(tree.process_ids))}")
-    pipe = str(Path(directory) / "endpoints.pipe")
     started, lines = False, []
     for line in tree.trace.decode("utf-8", errors="strict").splitlines():
         _, call_line = linux._strip_pid(line.strip())
@@ -76,8 +75,6 @@ ordinary inputs. No application read is removed because it is later written.
             if linux._return_integer(result) == 0:
                 started = True
             continue
-        if path == pipe and call == "openat" and "O_WRONLY" in arguments:
-            continue
         # libc probes kernel statx availability with a null pointer. EFAULT
         # supplies no filesystem value and is not a missing path dependency.
         if call == "statx" and arguments.startswith("0, NULL,") and result.startswith("-1 EFAULT"):
@@ -89,7 +86,7 @@ ordinary inputs. No application read is removed because it is later written.
             # fixed output transport. Stdin and arbitrary descriptors do not.
             continue
         if path and path.startswith(str(directory) + "/") and call in linux._OPEN_CALLS and "O_WRONLY" in arguments:
-            continue  # the collector's own transport files, written by the bootstrap
+            continue  # the collector's own transport files (endpoint announcement, worker markers), written by the bootstrap
         if (path == "/proc/self/cgroup" or (path and re.fullmatch(r"/proc/[0-9]+/cgroup", path))
                 or (path and path.startswith("/sys/fs/cgroup/") and path.endswith(("/memory.high", "/memory.max")))):
             # libuv and V8 read the process cgroup and memory limits when the

--- a/hooks/click_node_bootstrap.mjs
+++ b/hooks/click_node_bootstrap.mjs
@@ -18,10 +18,12 @@ if (directory && ownedOptions && isMainThread && !testRunner && !priorPreload) {
     if (!inspector.url()) {
       inspector.open(0, '127.0.0.1', false);
       owned = true;
-      const descriptor = fs.openSync(path.join(directory, 'endpoints.pipe'), 'w');
-      try {
-        fs.writeSync(descriptor, JSON.stringify({ pid: process.pid, url: inspector.url() }) + '\n');
-      } finally { fs.closeSync(descriptor); }
+      // One announcement file per process: a plain create-and-write that
+      // every host supports, which the collector polls for. A FIFO would
+      // need a POSIX-only mkfifo and a rename would be an extra file event
+      // for the projection to explain.
+      fs.writeFileSync(path.join(directory, `endpoint-${process.pid}.json`),
+        JSON.stringify({ pid: process.pid, url: inspector.url() }) + '\n', { mode: 0o600 });
       const acknowledgement = path.join(directory, `ready-${process.pid}`);
       const attached = await new Promise(resolve => {
         let attempts = 0;

--- a/hooks/click_node_controller.cjs
+++ b/hooks/click_node_controller.cjs
@@ -386,28 +386,42 @@ async function endpoint(value) {
   });
 }
 
+// Each target announces its inspector endpoint in `endpoint-<pid>.json`
+// (see click_node_bootstrap.mjs). Polling a directory needs no FIFO, socket
+// or pipe name, so the same transport serves every host. A file is consumed
+// once its single line is complete; a partial write is read again next tick.
+const ENDPOINT_FILE = /^endpoint-[0-9]+\.json$/;
+const consumed = new Set();
 let pendingInput = '';
-const input = fs.createReadStream(path.join(directory, 'endpoints.pipe'), { encoding: 'utf8' });
-input.on('data', chunk => {
-  pendingInput += chunk;
-  if (pendingInput.length > 65536) { failure('endpoint-limit'); pendingInput = ''; return; }
-  let newline;
-  while ((newline = pendingInput.indexOf('\n')) >= 0) {
-    const row = pendingInput.slice(0, newline); pendingInput = pendingInput.slice(newline + 1);
-    try { endpoint(JSON.parse(row)).catch(() => failure('session-setup-failed')); }
+function collectEndpoints() {
+  let names;
+  try { names = fs.readdirSync(directory); } catch { failure('endpoint-channel-failed'); return; }
+  for (const name of names) {
+    if (!ENDPOINT_FILE.test(name) || consumed.has(name)) continue;
+    const file = path.join(directory, name);
+    let row;
+    try { row = fs.readFileSync(file, 'utf8'); } catch { continue; }
+    if (row.length > 65536) { consumed.add(name); failure('endpoint-limit'); continue; }
+    const newline = row.indexOf('\n');
+    if (newline < 0) { pendingInput = row; continue; }
+    consumed.add(name);
+    pendingInput = '';
+    try { fs.unlinkSync(file); } catch {}
+    try { endpoint(JSON.parse(row.slice(0, newline))).catch(() => failure('session-setup-failed')); }
     catch { failure('invalid-endpoint'); }
   }
-});
-input.on('error', () => failure('endpoint-channel-failed'));
+}
+const input = setInterval(collectEndpoints, 10);
 process.stdin.resume();
 async function stop() {
   if (stopping) return;
   stopping = true;
+  clearInterval(input);
+  collectEndpoints();
   if (pendingInput.trim()) failure('endpoint-truncated');
   if (!sessions.size) failure('no-runtime-session');
   if ([...sessions].some(session => !session.finished)) failure('session-completion-unobserved');
   await Promise.allSettled([...sessions].map(session => session.release()));
-  input.destroy();
   sendLine({ kind: 'result', counts, sessions: sessions.size, contexts, installed, completed,
     workers: workerCount, process_ids: [...processIds].sort((a,b) => a-b), values: valueRecords,
     reasons: [...reasons].sort() });

--- a/hooks/click_node_observer.py
+++ b/hooks/click_node_observer.py
@@ -125,7 +125,6 @@ class Collector:
         self.record = empty("unsupported-runtime")
         self.child = None
         self.location = None
-        self.descriptor = None
         self.messages = queue.Queue(maxsize=8)
         self.process_ids = set()
         self.runtime_path = None
@@ -157,10 +156,9 @@ class Collector:
             self.location = tempfile.TemporaryDirectory(prefix="click-node-inputs-")
             directory = Path(self.location.name)
             os.chmod(directory, 0o700)
-            fifo = directory / "endpoints.pipe"
-            os.mkfifo(fifo, 0o600)
-            # Keep a reader and writer open across short-lived forked processes.
-            self.descriptor = os.open(fifo, os.O_RDWR | os.O_NONBLOCK | os.O_CLOEXEC)
+            # Targets announce their inspector endpoints as files in this
+            # directory and the controller polls for them: one transport for
+            # every host, with no FIFO, socket or pipe name to manage.
             child_environment = {key: value for key, value in environment.items()
                                  if key not in {"NODE_OPTIONS", "CLICK_NODE_OBSERVER_DIRECTORY"}}
             self.child = click_process.spawn_argv([str(node), str(Path(__file__).with_name("click_node_controller.cjs")), str(directory),
@@ -241,18 +239,6 @@ class Collector:
                 self.child.stdin.close()
             except OSError:
                 pass
-        # The controller reads the FIFO through a blocking pool thread, and
-        # its exit joins that pool. Unlink first so a late target cannot
-        # block opening a reader-less FIFO, then release the last writer so
-        # the pending read returns EOF instead of outliving a 5s wait.
-        if self.location is not None:
-            try:
-                (Path(self.location.name) / "endpoints.pipe").unlink()
-            except OSError:
-                pass
-        if self.descriptor is not None:
-            os.close(self.descriptor)
-            self.descriptor = None
         if self.child is not None:
             try:
                 if self.child.poll() is None:

--- a/tests/test_click_node_observer.py
+++ b/tests/test_click_node_observer.py
@@ -73,8 +73,8 @@ class RealNodeObservationTests(unittest.TestCase):
         self.assertFalse(self.record["reuse_authorized"])
         self.assertIn("engine-input-coverage-incomplete", self.record["reasons"])
         self.assertIsNotNone(controller.poll(), "observer process was stranded")
-        # The controller exits by itself once its FIFO writer is released;
-        # a terminated controller would report a signal exit instead.
+        # The controller exits by itself once it has reported; a terminated
+        # controller would report a signal exit instead.
         self.assertEqual(controller.returncode, 0, "observer process did not exit after reporting")
         self.assertFalse(Path(directory).exists(), "transient observer directory was retained")
         self.assertNotIn("ws://", json.dumps(self.record))


### PR DESCRIPTION
## Summary

Stage 1 of JS conditional reuse on Windows: make the runtime observer's endpoint transport portable without changing what is observed.

- `hooks/click_node_bootstrap.mjs`: the target writes `endpoint-<pid>.json` (one `writeFileSync`, no rename) into the collector directory instead of opening the FIFO; the `ready-<pid>` acknowledgement wait and the worker markers are unchanged.
- `hooks/click_node_controller.cjs`: polls the directory every 10 ms for complete announcement files (a partial write is read again next tick, and reported as `endpoint-truncated` only if still incomplete at stop), consumes each once, and keeps the same session handling.
- `hooks/click_node_observer.py`: no `mkfifo`, no held-open descriptor, no FIFO unlink dance in `close()`.
- `hooks/click_conditional_observer.py`: drops the FIFO-specific `openat(O_WRONLY)` filter; the announcement is covered by the existing rule for the collector's own directory writes.
- `RELEASE_NOTES.md`: Unreleased v1.3 candidate entry.

The source digest of the observer changes with these files, as designed (older conditional receipts are re-learned).

## Tests

Local, Linux, Node 22.23.2, strace 6.8: `test_click_node_observer` (19), `test_click_conditional_observation` (16, all real), `test_click_framework_observation`, `test_click_framework_candidates`, `test_click_automatic_observation`, `test_click_dependency_trace`, distribution and policy checks all pass. CI `framework-observation` covers the same on ubuntu with both pytest versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
